### PR TITLE
fix: correct labeler config and Policy–Lite hyphenation

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,7 +13,7 @@ type:mapping:
 type:workflow:
   - .github/workflows/**
 
-"risk:major":
+risk:major:
   - schemas/**
   - policy/**
   - mapping/**

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -11,7 +11,7 @@ perfection.
 - **Stage 0 — Repo scaffolding**: docs, schemas, labels, CODEOWNERS,
   branch rules.
 - **Stage 1 — Excel Agent Bridge**: agent completes existing Itinerary and
-  Expense spreadsheets; Policy‑Lite checks; no new UI.
+  Expense spreadsheets; Policy–Lite checks; no new UI.
 - **Stage 2 — Workflow Lite**: lightweight portal for submit/approve,
   minimal receipts; exports for accounting.
 - **Stage 3 — Agentic Verify**: pre‑approved providers, snapshot options,
@@ -28,5 +28,5 @@ scope and guardrails.
 
 - Minutes saved per itinerary vs baseline
 - Back‑and‑forth count before approval
-- First-pass Policy‑Lite pass rate
+- First-pass Policy–Lite pass rate
 - % of trips processed without manual spreadsheet edits


### PR DESCRIPTION
## Summary
- fix labeler YAML key quoting to satisfy labeler workflow
- use en dash for "Policy–Lite" in plan document

## Testing
- `npx markdownlint-cli '**/*.md'`


------
https://chatgpt.com/codex/tasks/task_e_68bd26ca52b4833192ea66b0298a6005