### PR TITLE
fix(pr-meta): convert pr_number to number for reusable workflow

### DIFF
--- a/.github/workflows/agents-pr-meta.yml
+++ b/.github/workflows/agents-pr-meta.yml
@@ -72,7 +72,7 @@ jobs:
     if: github.event_name == 'issue_comment' && github.event.issue.pull_request
     uses: stranske/Workflows/.github/workflows/reusable-20-pr-meta.yml@main
     with:
-      pr_number: ${{ needs.resolve_pr.outputs.pr_number }}
+      pr_number: ${{ fromJSON(needs.resolve_pr.outputs.pr_number) }}
       comment_id: ${{ needs.resolve_pr.outputs.comment_id }}
       comment_body: ${{ needs.resolve_pr.outputs.comment_body }}
       event_name: 'issue_comment'


### PR DESCRIPTION
The reusable-20-pr-meta.yml expects pr_number as `type: number` but job outputs are always strings. Use `fromJSON()` to convert.

This fix is required for the `pr_meta_comment` job to run - without it the job silently fails to start due to type mismatch. This is why keepalive detection isn't working.

**Root Cause:**
The `resolve_pr` job sets `pr_number` as a string output. When passed to the reusable workflow which expects `type: number`, GitHub Actions silently skips creating the job rather than running it with type coercion.

**Fix:**
Use `${{ fromJSON(needs.resolve_pr.outputs.pr_number) }}` to explicitly convert the string to a number.