### PR TITLE
feat(keepalive): trigger on Gate completion for automatic continuation

### DIFF
--- a/.github/workflows/agents-pr-meta.yml
+++ b/.github/workflows/agents-pr-meta.yml
@@ -19,6 +19,11 @@ on:
     types: [created]
   pull_request:
     types: [opened, synchronize, reopened, edited]
+  # Re-evaluate keepalive when Gate completes - handles race condition where
+  # human comment arrives before Gate finishes
+  workflow_run:
+    workflows: ["Gate"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -88,4 +93,61 @@ jobs:
       pr_number: ${{ github.event.pull_request.number }}
       event_name: 'pull_request'
       event_action: ${{ github.event.action }}
+    secrets: inherit
+
+  # Resolve PR from Gate workflow_run event
+  resolve_gate_pr:
+    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.resolve.outputs.pr_number }}
+      should_process: ${{ steps.resolve.outputs.should_process }}
+    steps:
+      - name: Resolve PR from Gate run
+        id: resolve
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+            const prs = run.pull_requests || [];
+            
+            if (prs.length === 0) {
+              core.info('No PRs associated with Gate run');
+              core.setOutput('should_process', 'false');
+              return;
+            }
+            
+            // Use the first PR (Gate typically runs on a single PR)
+            const prNumber = prs[0].number;
+            core.info(`Gate completed for PR #${prNumber}`);
+            
+            // Check if PR has keepalive label
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber
+            });
+            
+            const hasKeepalive = pr.labels.some(l => l.name === 'agents:keepalive');
+            if (!hasKeepalive) {
+              core.info(`PR #${prNumber} does not have agents:keepalive label`);
+              core.setOutput('should_process', 'false');
+              return;
+            }
+            
+            core.setOutput('pr_number', prNumber);
+            core.setOutput('should_process', 'true');
+
+  # Re-evaluate keepalive when Gate completes successfully
+  pr_meta_gate:
+    needs: resolve_gate_pr
+    if: github.event_name == 'workflow_run' && needs.resolve_gate_pr.outputs.should_process == 'true'
+    uses: stranske/Workflows/.github/workflows/reusable-20-pr-meta.yml@main
+    with:
+      pr_number: ${{ fromJSON(needs.resolve_gate_pr.outputs.pr_number) }}
+      event_name: 'workflow_run'
+      event_action: 'completed'
+      allowed_keepalive_logins: ${{ vars.ALLOWED_KEEPALIVE_LOGINS || 'stranske' }}
+      allow_replay: true
+    secrets: inherit
     secrets: inherit


### PR DESCRIPTION
Add `workflow_run` trigger for Gate workflow to handle the race condition where human comment arrives before Gate finishes. When Gate completes, pr-meta now re-evaluates keepalive conditions with `allow_replay=true`.

**Problem:**
When a human posts `@codex` on a new PR, Gate is often still running. Keepalive correctly defers with `gate-not-concluded`. But when Gate completes, only bot comments trigger pr-meta, which get skipped as `automation-comment`.

**Solution:**
- Add `workflow_run` trigger for Gate workflow
- Re-evaluate keepalive when Gate completes successfully  
- Use `allow_replay=true` to process the existing human activation

**This ensures keepalive continues automatically after:**
1. Human posts `@codex` comment (human activation)
2. Gate workflow completes successfully
3. Agent run initiated by the human has finished

No more need for manual orchestrator trigger or waiting for 30-min schedule.

**Dependencies:**
- Requires stranske/Workflows#67 to be merged first (adds `allow_replay` input to reusable-20-pr-meta.yml)