### PR TITLE
chore(codex): bootstrap PR for issue #54

### DIFF
--- a/agents/codex-54.md
+++ b/agents/codex-54.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #54 -->

--- a/config/policy.yaml
+++ b/config/policy.yaml
@@ -1,0 +1,32 @@
+rules:
+  advance_booking:
+    days_required: 14
+    severity: advisory
+  fare_comparison:
+    max_over_lowest: 200
+    severity: blocking
+  cabin_class:
+    long_haul_hours: 5
+    allowed_classes:
+      - economy
+    severity: blocking
+  fare_evidence:
+    severity: blocking
+  driving_vs_flying:
+    severity: advisory
+  hotel_comparison:
+    minimum_alternatives: 2
+    severity: advisory
+  local_overnight:
+    min_distance_miles: 50
+    severity: advisory
+  meal_per_diem:
+    severity: advisory
+  non_reimbursable:
+    blocked_keywords:
+      - liquor
+      - alcohol
+      - personal
+    severity: blocking
+  third_party_paid:
+    severity: blocking

--- a/docs/validation-rules.md
+++ b/docs/validation-rules.md
@@ -1,61 +1,18 @@
-# Validation rule reference
+# Validation rules (policy-lite)
 
-The policy-lite validator is configured through `config/policy.yaml`. Each rule can be tuned or disabled by editing the values under `rules:` and then reloading the `PolicyEngine` (for example via `PolicyEngine.from_file()` or `PolicyEngine.from_yaml()`). Thresholds and severities shown below reflect the repository defaults.
+These rules are configured via `config/policy.yaml` and loaded by `PolicyEngine.from_file()` or `PolicyEngine.from_yaml()`. Each rule produces a structured result with `rule_id`, `severity` (`blocking` or `advisory`), `passed`, and `message`. The descriptions below reflect the default configuration shipped with the repo.
 
-## Rule catalog
-
-| Rule ID | Default severity | Configuration keys | Behavior summary |
+| Rule ID | Default severity | Configuration keys | Behavior |
 | --- | --- | --- | --- |
-| `advance_booking` | `advisory` | `days_required` (int) | Warns when the trip is booked fewer than the required days before departure. |
-| `fare_comparison` | `blocking` | `max_over_lowest` (decimal) | Blocks when the selected fare exceeds the lowest available by more than the threshold. |
-| `cabin_class` | `blocking` | `long_haul_hours` (float), `allowed_classes` (list of strings) | Blocks when a sub-threshold flight duration uses a cabin class outside the allowed list. |
-| `fare_evidence` | `blocking` | — | Blocks when fare evidence (e.g., screenshot) is missing. |
-| `driving_vs_flying` | `advisory` | — | Warns when driving costs more than the equivalent flight. |
-| `hotel_comparison` | `advisory` | `minimum_alternatives` (int) | Warns when fewer than the required number of alternative hotel quotes are provided. |
-| `local_overnight` | `advisory` | `min_distance_miles` (float) | Warns when an overnight stay is requested within the local distance threshold. |
-| `meal_per_diem` | `advisory` | — | Warns when a per diem is requested while meals are provided by a conference/event. |
-| `non_reimbursable` | `blocking` | `blocked_keywords` (list of strings) | Blocks expenses that match non-reimbursable keywords (e.g., liquor, personal). |
-| `third_party_paid` | `blocking` | — | Blocks when third-party paid items are not itemized and excluded from reimbursement. |
+| `advance_booking` | `advisory` | `days_required` | Require bookings be made at least the configured days before departure (default 14). |
+| `fare_comparison` | `blocking` | `max_over_lowest` | Selected fare cannot exceed the lowest comparable fare by more than the configured amount (default $200). |
+| `cabin_class` | `blocking` | `long_haul_hours`, `allowed_classes` | Flights at or under the long-haul threshold must use one of the allowed cabin classes (default ≤5 hours must be economy). |
+| `fare_evidence` | `blocking` | — | A screenshot or other fare evidence must be attached. |
+| `driving_vs_flying` | `advisory` | — | Reimbursement is limited to the lesser cost between driving and flying when both estimates are provided. |
+| `hotel_comparison` | `advisory` | `minimum_alternatives` | Require at least the configured number of comparable hotel quotes (default 2). |
+| `local_overnight` | `advisory` | `min_distance_miles` | Overnight stays within the configured distance from the office need a waiver (default 50 miles). |
+| `meal_per_diem` | `advisory` | — | Exclude conference-provided meals from per diem claims. |
+| `non_reimbursable` | `blocking` | `blocked_keywords` | Expenses containing the configured keywords are not reimbursable (defaults: liquor, alcohol, personal). |
+| `third_party_paid` | `blocking` | — | Third-party paid items must be itemized and excluded from reimbursement. |
 
-## Default configuration
-
-```yaml
-rules:
-  advance_booking:
-    days_required: 14
-    severity: advisory
-  fare_comparison:
-    max_over_lowest: 200
-    severity: blocking
-  cabin_class:
-    long_haul_hours: 5
-    allowed_classes:
-      - economy
-    severity: blocking
-  fare_evidence:
-    severity: blocking
-  driving_vs_flying:
-    severity: advisory
-  hotel_comparison:
-    minimum_alternatives: 2
-    severity: advisory
-  local_overnight:
-    min_distance_miles: 50
-    severity: advisory
-  meal_per_diem:
-    severity: advisory
-  non_reimbursable:
-    blocked_keywords:
-      - liquor
-      - alcohol
-      - personal
-    severity: blocking
-  third_party_paid:
-    severity: blocking
-```
-
-### Notes
-
-- To change severity, set `severity` to `blocking` or `advisory`. Blocking results will prevent submission when the rule fails; advisory results allow submission but are surfaced as warnings.
-- All rules are loaded automatically by `PolicyEngine.from_file()`; callers can provide inline YAML with `from_yaml()` for scenario-specific testing.
-- Messages returned by each rule include the configured threshold values so downstream UIs can present actionable guidance without duplicating configuration.
+Update `config/policy.yaml` to adjust thresholds or severities for your deployment. Rules are evaluated in the order shown above, and `PolicyEngine.blocking_results()` returns only failed blocking rules for submission gating.

--- a/docs/validation-rules.md
+++ b/docs/validation-rules.md
@@ -1,0 +1,61 @@
+# Validation rule reference
+
+The policy-lite validator is configured through `config/policy.yaml`. Each rule can be tuned or disabled by editing the values under `rules:` and then reloading the `PolicyEngine` (for example via `PolicyEngine.from_file()` or `PolicyEngine.from_yaml()`). Thresholds and severities shown below reflect the repository defaults.
+
+## Rule catalog
+
+| Rule ID | Default severity | Configuration keys | Behavior summary |
+| --- | --- | --- | --- |
+| `advance_booking` | `advisory` | `days_required` (int) | Warns when the trip is booked fewer than the required days before departure. |
+| `fare_comparison` | `blocking` | `max_over_lowest` (decimal) | Blocks when the selected fare exceeds the lowest available by more than the threshold. |
+| `cabin_class` | `blocking` | `long_haul_hours` (float), `allowed_classes` (list of strings) | Blocks when a sub-threshold flight duration uses a cabin class outside the allowed list. |
+| `fare_evidence` | `blocking` | — | Blocks when fare evidence (e.g., screenshot) is missing. |
+| `driving_vs_flying` | `advisory` | — | Warns when driving costs more than the equivalent flight. |
+| `hotel_comparison` | `advisory` | `minimum_alternatives` (int) | Warns when fewer than the required number of alternative hotel quotes are provided. |
+| `local_overnight` | `advisory` | `min_distance_miles` (float) | Warns when an overnight stay is requested within the local distance threshold. |
+| `meal_per_diem` | `advisory` | — | Warns when a per diem is requested while meals are provided by a conference/event. |
+| `non_reimbursable` | `blocking` | `blocked_keywords` (list of strings) | Blocks expenses that match non-reimbursable keywords (e.g., liquor, personal). |
+| `third_party_paid` | `blocking` | — | Blocks when third-party paid items are not itemized and excluded from reimbursement. |
+
+## Default configuration
+
+```yaml
+rules:
+  advance_booking:
+    days_required: 14
+    severity: advisory
+  fare_comparison:
+    max_over_lowest: 200
+    severity: blocking
+  cabin_class:
+    long_haul_hours: 5
+    allowed_classes:
+      - economy
+    severity: blocking
+  fare_evidence:
+    severity: blocking
+  driving_vs_flying:
+    severity: advisory
+  hotel_comparison:
+    minimum_alternatives: 2
+    severity: advisory
+  local_overnight:
+    min_distance_miles: 50
+    severity: advisory
+  meal_per_diem:
+    severity: advisory
+  non_reimbursable:
+    blocked_keywords:
+      - liquor
+      - alcohol
+      - personal
+    severity: blocking
+  third_party_paid:
+    severity: blocking
+```
+
+### Notes
+
+- To change severity, set `severity` to `blocking` or `advisory`. Blocking results will prevent submission when the rule fails; advisory results allow submission but are surfaced as warnings.
+- All rules are loaded automatically by `PolicyEngine.from_file()`; callers can provide inline YAML with `from_yaml()` for scenario-specific testing.
+- Messages returned by each rule include the configured threshold values so downstream UIs can present actionable guidance without duplicating configuration.

--- a/src/travel_plan_permission/__init__.py
+++ b/src/travel_plan_permission/__init__.py
@@ -13,6 +13,23 @@ from .models import (
     TripPlan,
     TripStatus,
 )
+from .policy import (
+    AdvanceBookingRule,
+    CabinClassRule,
+    DrivingVsFlyingRule,
+    FareComparisonRule,
+    FareEvidenceRule,
+    HotelComparisonRule,
+    LocalOvernightRule,
+    MealPerDiemRule,
+    NonReimbursableRule,
+    PolicyContext,
+    PolicyEngine,
+    PolicyResult,
+    PolicyRule,
+    Severity,
+    ThirdPartyPaidRule,
+)
 
 __all__ = [
     "ApprovalAction",
@@ -26,6 +43,21 @@ __all__ = [
     "ExportService",
     "TripPlan",
     "TripStatus",
+    "AdvanceBookingRule",
+    "CabinClassRule",
+    "DrivingVsFlyingRule",
+    "FareComparisonRule",
+    "FareEvidenceRule",
+    "HotelComparisonRule",
+    "LocalOvernightRule",
+    "MealPerDiemRule",
+    "NonReimbursableRule",
+    "PolicyContext",
+    "PolicyEngine",
+    "PolicyResult",
+    "PolicyRule",
+    "Severity",
+    "ThirdPartyPaidRule",
     "__version__",
 ]
 __version__ = "0.1.0"

--- a/src/travel_plan_permission/policy.py
+++ b/src/travel_plan_permission/policy.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from datetime import date
 from decimal import Decimal
 from pathlib import Path
+from typing import Any, cast
 
 import yaml
 
@@ -353,10 +354,10 @@ class ThirdPartyPaidRule(PolicyRule):
 
 
 def _load_rule_config(
-    config: dict[str, object], key: str, default: dict[str, object]
-) -> dict[str, object]:
-    rules_cfg = config.get("rules", {}) or {}
-    rule_cfg = rules_cfg.get(key, {}) or {}
+    config: dict[str, Any], key: str, default: dict[str, Any]
+) -> dict[str, Any]:
+    rules_cfg: dict[str, Any] = config.get("rules", {}) or {}
+    rule_cfg: dict[str, Any] = rules_cfg.get(key, {}) or {}
     merged = default.copy()
     merged.update(rule_cfg)
     return merged

--- a/src/travel_plan_permission/policy.py
+++ b/src/travel_plan_permission/policy.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from datetime import date
 from decimal import Decimal
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 import yaml
 

--- a/src/travel_plan_permission/policy.py
+++ b/src/travel_plan_permission/policy.py
@@ -9,11 +9,11 @@ message that includes the relevant threshold or policy text.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import date
 from decimal import Decimal
 from pathlib import Path
-from typing import Iterable
 
 import yaml
 
@@ -104,7 +104,9 @@ class AdvanceBookingRule(PolicyRule):
 
     def evaluate(self, context: PolicyContext) -> PolicyResult:
         if context.booking_date is None or context.departure_date is None:
-            return self._result(True, "Advance booking check skipped due to missing dates")
+            return self._result(
+                True, "Advance booking check skipped due to missing dates"
+            )
 
         days_notice = (context.departure_date - context.booking_date).days
         if days_notice < self.days_required:
@@ -112,7 +114,10 @@ class AdvanceBookingRule(PolicyRule):
                 False,
                 f"Bookings should be made at least {self.days_required} days in advance; only {days_notice} days provided.",
             )
-        return self._result(True, f"Booked {days_notice} days in advance (minimum {self.days_required}).")
+        return self._result(
+            True,
+            f"Booked {days_notice} days in advance (minimum {self.days_required}).",
+        )
 
     def message(self) -> str:  # pragma: no cover - static template
         return f"Bookings must be made {self.days_required} days before departure."
@@ -127,7 +132,9 @@ class FareComparisonRule(PolicyRule):
 
     def evaluate(self, context: PolicyContext) -> PolicyResult:
         if context.selected_fare is None or context.lowest_fare is None:
-            return self._result(True, "Fare comparison skipped due to missing fare data")
+            return self._result(
+                True, "Fare comparison skipped due to missing fare data"
+            )
 
         overage = context.selected_fare - context.lowest_fare
         if overage > self.max_over_lowest:
@@ -138,7 +145,9 @@ class FareComparisonRule(PolicyRule):
                     " allowable threshold."
                 ),
             )
-        return self._result(True, f"Fare within {self.max_over_lowest} of lowest available.")
+        return self._result(
+            True, f"Fare within {self.max_over_lowest} of lowest available."
+        )
 
     def message(self) -> str:  # pragma: no cover - static template
         return f"Selected fare must be within {self.max_over_lowest} of the lowest available option."
@@ -147,14 +156,18 @@ class FareComparisonRule(PolicyRule):
 class CabinClassRule(PolicyRule):
     rule_id = "cabin_class"
 
-    def __init__(self, long_haul_hours: float, allowed_classes: Iterable[str], severity: str) -> None:
+    def __init__(
+        self, long_haul_hours: float, allowed_classes: Iterable[str], severity: str
+    ) -> None:
         super().__init__(severity)
         self.long_haul_hours = float(long_haul_hours)
         self.allowed_classes = {c.lower() for c in allowed_classes}
 
     def evaluate(self, context: PolicyContext) -> PolicyResult:
         if context.cabin_class is None or context.flight_duration_hours is None:
-            return self._result(True, "Cabin class check skipped due to missing flight details")
+            return self._result(
+                True, "Cabin class check skipped due to missing flight details"
+            )
 
         cabin = context.cabin_class.lower()
         duration = context.flight_duration_hours
@@ -166,7 +179,10 @@ class CabinClassRule(PolicyRule):
                     f" requested '{context.cabin_class}'."
                 ),
             )
-        return self._result(True, f"Cabin '{context.cabin_class}' acceptable for {duration} hour flight.")
+        return self._result(
+            True,
+            f"Cabin '{context.cabin_class}' acceptable for {duration} hour flight.",
+        )
 
     def message(self) -> str:  # pragma: no cover - static template
         return (
@@ -184,7 +200,9 @@ class FareEvidenceRule(PolicyRule):
     def evaluate(self, context: PolicyContext) -> PolicyResult:
         if context.fare_evidence_attached:
             return self._result(True, "Fare evidence attached")
-        return self._result(False, "Screenshot or fare evidence must be attached to the request.")
+        return self._result(
+            False, "Screenshot or fare evidence must be attached to the request."
+        )
 
     def message(self) -> str:  # pragma: no cover - static template
         return "Fare evidence (e.g., screenshot) is required."
@@ -198,7 +216,9 @@ class DrivingVsFlyingRule(PolicyRule):
 
     def evaluate(self, context: PolicyContext) -> PolicyResult:
         if context.driving_cost is None or context.flight_cost is None:
-            return self._result(True, "Driving vs flying comparison skipped due to missing estimates")
+            return self._result(
+                True, "Driving vs flying comparison skipped due to missing estimates"
+            )
 
         if context.driving_cost > context.flight_cost:
             return self._result(
@@ -228,7 +248,10 @@ class HotelComparisonRule(PolicyRule):
                 False,
                 f"Provide at least {self.minimum_alternatives} comparable hotel rates; {len(alternatives)} supplied.",
             )
-        return self._result(True, f"{len(alternatives)} comparable hotels provided (minimum {self.minimum_alternatives}).")
+        return self._result(
+            True,
+            f"{len(alternatives)} comparable hotels provided (minimum {self.minimum_alternatives}).",
+        )
 
     def message(self) -> str:  # pragma: no cover - static template
         return f"At least {self.minimum_alternatives} comparable hotel options are required."
@@ -245,16 +268,23 @@ class LocalOvernightRule(PolicyRule):
         if not context.overnight_stay:
             return self._result(True, "No overnight stay requested")
         if context.distance_from_office_miles is None:
-            return self._result(True, "Local overnight check skipped due to missing distance data")
+            return self._result(
+                True, "Local overnight check skipped due to missing distance data"
+            )
         if context.distance_from_office_miles < self.min_distance_miles:
             return self._result(
                 False,
                 f"Overnight stays within {self.min_distance_miles} miles require waiver; distance is {context.distance_from_office_miles} miles.",
             )
-        return self._result(True, f"Overnight stay is {context.distance_from_office_miles} miles from office (minimum {self.min_distance_miles}).")
+        return self._result(
+            True,
+            f"Overnight stay is {context.distance_from_office_miles} miles from office (minimum {self.min_distance_miles}).",
+        )
 
     def message(self) -> str:  # pragma: no cover - static template
-        return f"Overnight stays under {self.min_distance_miles} miles require a waiver."
+        return (
+            f"Overnight stays under {self.min_distance_miles} miles require a waiver."
+        )
 
 
 class MealPerDiemRule(PolicyRule):
@@ -314,13 +344,17 @@ class ThirdPartyPaidRule(PolicyRule):
                     False,
                     f"Third-party payment '{description}' must be itemized and excluded from reimbursement.",
                 )
-        return self._result(True, "Third-party payments are properly itemized or none provided.")
+        return self._result(
+            True, "Third-party payments are properly itemized or none provided."
+        )
 
     def message(self) -> str:  # pragma: no cover - static template
         return "Third-party paid expenses must be itemized and excluded."
 
 
-def _load_rule_config(config: dict[str, object], key: str, default: dict[str, object]) -> dict[str, object]:
+def _load_rule_config(
+    config: dict[str, object], key: str, default: dict[str, object]
+) -> dict[str, object]:
     rules_cfg = config.get("rules", {}) or {}
     rule_cfg = rules_cfg.get(key, {}) or {}
     merged = default.copy()
@@ -347,15 +381,23 @@ class PolicyEngine:
         config = yaml.safe_load(content) or {}
 
         advance_cfg = _load_rule_config(
-            config, "advance_booking", {"days_required": 14, "severity": Severity.ADVISORY}
+            config,
+            "advance_booking",
+            {"days_required": 14, "severity": Severity.ADVISORY},
         )
         fare_comparison_cfg = _load_rule_config(
-            config, "fare_comparison", {"max_over_lowest": Decimal("200"), "severity": Severity.BLOCKING}
+            config,
+            "fare_comparison",
+            {"max_over_lowest": Decimal("200"), "severity": Severity.BLOCKING},
         )
         cabin_class_cfg = _load_rule_config(
             config,
             "cabin_class",
-            {"long_haul_hours": 5, "allowed_classes": ["economy"], "severity": Severity.BLOCKING},
+            {
+                "long_haul_hours": 5,
+                "allowed_classes": ["economy"],
+                "severity": Severity.BLOCKING,
+            },
         )
         fare_evidence_cfg = _load_rule_config(
             config, "fare_evidence", {"severity": Severity.BLOCKING}
@@ -364,10 +406,14 @@ class PolicyEngine:
             config, "driving_vs_flying", {"severity": Severity.ADVISORY}
         )
         hotel_comparison_cfg = _load_rule_config(
-            config, "hotel_comparison", {"minimum_alternatives": 2, "severity": Severity.ADVISORY}
+            config,
+            "hotel_comparison",
+            {"minimum_alternatives": 2, "severity": Severity.ADVISORY},
         )
         local_overnight_cfg = _load_rule_config(
-            config, "local_overnight", {"min_distance_miles": 50, "severity": Severity.ADVISORY}
+            config,
+            "local_overnight",
+            {"min_distance_miles": 50, "severity": Severity.ADVISORY},
         )
         meal_per_diem_cfg = _load_rule_config(
             config, "meal_per_diem", {"severity": Severity.ADVISORY}
@@ -375,7 +421,10 @@ class PolicyEngine:
         non_reimbursable_cfg = _load_rule_config(
             config,
             "non_reimbursable",
-            {"blocked_keywords": ["liquor", "alcohol", "personal"], "severity": Severity.BLOCKING},
+            {
+                "blocked_keywords": ["liquor", "alcohol", "personal"],
+                "severity": Severity.BLOCKING,
+            },
         )
         third_party_paid_cfg = _load_rule_config(
             config, "third_party_paid", {"severity": Severity.BLOCKING}
@@ -383,7 +432,8 @@ class PolicyEngine:
 
         rules: list[PolicyRule] = [
             AdvanceBookingRule(
-                days_required=int(advance_cfg["days_required"]), severity=str(advance_cfg["severity"])
+                days_required=int(advance_cfg["days_required"]),
+                severity=str(advance_cfg["severity"]),
             ),
             FareComparisonRule(
                 max_over_lowest=Decimal(fare_comparison_cfg["max_over_lowest"]),
@@ -426,5 +476,8 @@ class PolicyEngine:
         return [rule.evaluate(context) for rule in self.rules]
 
     def blocking_results(self, context: PolicyContext) -> list[PolicyResult]:
-        return [result for result in self.validate(context) if result.severity == Severity.BLOCKING and not result.passed]
-
+        return [
+            result
+            for result in self.validate(context)
+            if result.severity == Severity.BLOCKING and not result.passed
+        ]

--- a/src/travel_plan_permission/policy.py
+++ b/src/travel_plan_permission/policy.py
@@ -1,0 +1,430 @@
+"""Policy-lite validation rules for trip plans and expenses.
+
+This module implements a configurable policy engine that evaluates a trip plan
+context against a set of rules. Each rule returns a structured result that
+captures whether the rule passed, the severity (blocking vs advisory), and a
+message that includes the relevant threshold or policy text.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+from typing import Iterable
+
+import yaml
+
+from .models import ExpenseItem
+
+
+class Severity(str):
+    """Severity of a policy result."""
+
+    BLOCKING = "blocking"
+    ADVISORY = "advisory"
+    INFO = "info"
+
+
+@dataclass
+class PolicyResult:
+    """Result of evaluating a single policy rule."""
+
+    rule_id: str
+    severity: str
+    passed: bool
+    message: str
+
+
+@dataclass
+class PolicyContext:
+    """Input data used by the policy engine.
+
+    The context intentionally stays lightweight and only includes the fields
+    needed by the policy-lite rules. All attributes are optional so callers can
+    gradually adopt the rules without breaking existing flows.
+    """
+
+    booking_date: date | None = None
+    departure_date: date | None = None
+    return_date: date | None = None
+    selected_fare: Decimal | None = None
+    lowest_fare: Decimal | None = None
+    cabin_class: str | None = None
+    flight_duration_hours: float | None = None
+    fare_evidence_attached: bool | None = None
+    driving_cost: Decimal | None = None
+    flight_cost: Decimal | None = None
+    comparable_hotels: list[Decimal] | None = None
+    distance_from_office_miles: float | None = None
+    overnight_stay: bool | None = None
+    meals_provided: bool | None = None
+    meal_per_diem_requested: bool | None = None
+    expenses: list[ExpenseItem] | None = None
+
+    # Third-party paid entries should be itemized to exclude them from
+    # reimbursement.
+    third_party_payments: list[dict[str, object]] | None = None
+
+
+class PolicyRule(ABC):
+    """Base class for all policy-lite rules."""
+
+    rule_id: str
+    severity: str
+
+    def __init__(self, severity: str) -> None:
+        self.severity = severity
+
+    @abstractmethod
+    def evaluate(self, context: PolicyContext) -> PolicyResult:
+        """Evaluate the rule and return a structured result."""
+
+    @abstractmethod
+    def message(self) -> str:
+        """Return the policy message associated with the rule."""
+
+    def _result(self, passed: bool, message: str | None = None) -> PolicyResult:
+        return PolicyResult(
+            rule_id=self.rule_id,
+            severity=self.severity if not passed else Severity.INFO,
+            passed=passed,
+            message=message or self.message(),
+        )
+
+
+class AdvanceBookingRule(PolicyRule):
+    rule_id = "advance_booking"
+
+    def __init__(self, days_required: int, severity: str) -> None:
+        super().__init__(severity)
+        self.days_required = days_required
+
+    def evaluate(self, context: PolicyContext) -> PolicyResult:
+        if context.booking_date is None or context.departure_date is None:
+            return self._result(True, "Advance booking check skipped due to missing dates")
+
+        days_notice = (context.departure_date - context.booking_date).days
+        if days_notice < self.days_required:
+            return self._result(
+                False,
+                f"Bookings should be made at least {self.days_required} days in advance; only {days_notice} days provided.",
+            )
+        return self._result(True, f"Booked {days_notice} days in advance (minimum {self.days_required}).")
+
+    def message(self) -> str:  # pragma: no cover - static template
+        return f"Bookings must be made {self.days_required} days before departure."
+
+
+class FareComparisonRule(PolicyRule):
+    rule_id = "fare_comparison"
+
+    def __init__(self, max_over_lowest: Decimal, severity: str) -> None:
+        super().__init__(severity)
+        self.max_over_lowest = Decimal(max_over_lowest)
+
+    def evaluate(self, context: PolicyContext) -> PolicyResult:
+        if context.selected_fare is None or context.lowest_fare is None:
+            return self._result(True, "Fare comparison skipped due to missing fare data")
+
+        overage = context.selected_fare - context.lowest_fare
+        if overage > self.max_over_lowest:
+            return self._result(
+                False,
+                (
+                    f"Selected fare exceeds lowest available by {overage} which is above the {self.max_over_lowest}"
+                    " allowable threshold."
+                ),
+            )
+        return self._result(True, f"Fare within {self.max_over_lowest} of lowest available.")
+
+    def message(self) -> str:  # pragma: no cover - static template
+        return f"Selected fare must be within {self.max_over_lowest} of the lowest available option."
+
+
+class CabinClassRule(PolicyRule):
+    rule_id = "cabin_class"
+
+    def __init__(self, long_haul_hours: float, allowed_classes: Iterable[str], severity: str) -> None:
+        super().__init__(severity)
+        self.long_haul_hours = float(long_haul_hours)
+        self.allowed_classes = {c.lower() for c in allowed_classes}
+
+    def evaluate(self, context: PolicyContext) -> PolicyResult:
+        if context.cabin_class is None or context.flight_duration_hours is None:
+            return self._result(True, "Cabin class check skipped due to missing flight details")
+
+        cabin = context.cabin_class.lower()
+        duration = context.flight_duration_hours
+        if duration <= self.long_haul_hours and cabin not in self.allowed_classes:
+            return self._result(
+                False,
+                (
+                    f"Flights under {self.long_haul_hours} hours must use allowed cabins {sorted(self.allowed_classes)};"
+                    f" requested '{context.cabin_class}'."
+                ),
+            )
+        return self._result(True, f"Cabin '{context.cabin_class}' acceptable for {duration} hour flight.")
+
+    def message(self) -> str:  # pragma: no cover - static template
+        return (
+            f"Economy (or allowed cabins {sorted(self.allowed_classes)}) required unless flight exceeds"
+            f" {self.long_haul_hours} hours."
+        )
+
+
+class FareEvidenceRule(PolicyRule):
+    rule_id = "fare_evidence"
+
+    def __init__(self, severity: str) -> None:
+        super().__init__(severity)
+
+    def evaluate(self, context: PolicyContext) -> PolicyResult:
+        if context.fare_evidence_attached:
+            return self._result(True, "Fare evidence attached")
+        return self._result(False, "Screenshot or fare evidence must be attached to the request.")
+
+    def message(self) -> str:  # pragma: no cover - static template
+        return "Fare evidence (e.g., screenshot) is required."
+
+
+class DrivingVsFlyingRule(PolicyRule):
+    rule_id = "driving_vs_flying"
+
+    def __init__(self, severity: str) -> None:
+        super().__init__(severity)
+
+    def evaluate(self, context: PolicyContext) -> PolicyResult:
+        if context.driving_cost is None or context.flight_cost is None:
+            return self._result(True, "Driving vs flying comparison skipped due to missing estimates")
+
+        if context.driving_cost > context.flight_cost:
+            return self._result(
+                False,
+                (
+                    f"Driving estimate {context.driving_cost} exceeds flight estimate {context.flight_cost};"
+                    " reimbursement will be limited to the lesser cost."
+                ),
+            )
+        return self._result(True, "Driving is lower or equal cost compared to flying.")
+
+    def message(self) -> str:  # pragma: no cover - static template
+        return "Reimbursement is limited to the lesser of driving vs flying costs."
+
+
+class HotelComparisonRule(PolicyRule):
+    rule_id = "hotel_comparison"
+
+    def __init__(self, minimum_alternatives: int, severity: str) -> None:
+        super().__init__(severity)
+        self.minimum_alternatives = minimum_alternatives
+
+    def evaluate(self, context: PolicyContext) -> PolicyResult:
+        alternatives = context.comparable_hotels or []
+        if len(alternatives) < self.minimum_alternatives:
+            return self._result(
+                False,
+                f"Provide at least {self.minimum_alternatives} comparable hotel rates; {len(alternatives)} supplied.",
+            )
+        return self._result(True, f"{len(alternatives)} comparable hotels provided (minimum {self.minimum_alternatives}).")
+
+    def message(self) -> str:  # pragma: no cover - static template
+        return f"At least {self.minimum_alternatives} comparable hotel options are required."
+
+
+class LocalOvernightRule(PolicyRule):
+    rule_id = "local_overnight"
+
+    def __init__(self, min_distance_miles: float, severity: str) -> None:
+        super().__init__(severity)
+        self.min_distance_miles = float(min_distance_miles)
+
+    def evaluate(self, context: PolicyContext) -> PolicyResult:
+        if not context.overnight_stay:
+            return self._result(True, "No overnight stay requested")
+        if context.distance_from_office_miles is None:
+            return self._result(True, "Local overnight check skipped due to missing distance data")
+        if context.distance_from_office_miles < self.min_distance_miles:
+            return self._result(
+                False,
+                f"Overnight stays within {self.min_distance_miles} miles require waiver; distance is {context.distance_from_office_miles} miles.",
+            )
+        return self._result(True, f"Overnight stay is {context.distance_from_office_miles} miles from office (minimum {self.min_distance_miles}).")
+
+    def message(self) -> str:  # pragma: no cover - static template
+        return f"Overnight stays under {self.min_distance_miles} miles require a waiver."
+
+
+class MealPerDiemRule(PolicyRule):
+    rule_id = "meal_per_diem"
+
+    def __init__(self, severity: str) -> None:
+        super().__init__(severity)
+
+    def evaluate(self, context: PolicyContext) -> PolicyResult:
+        if context.meals_provided and context.meal_per_diem_requested:
+            return self._result(
+                False,
+                "Meal per diem should exclude conference-provided meals; adjust the request accordingly.",
+            )
+        return self._result(True, "Meal per diem request aligns with provided meals.")
+
+    def message(self) -> str:  # pragma: no cover - static template
+        return "Conference-provided meals must be excluded from per diem claims."
+
+
+class NonReimbursableRule(PolicyRule):
+    rule_id = "non_reimbursable"
+
+    def __init__(self, blocked_keywords: Iterable[str], severity: str) -> None:
+        super().__init__(severity)
+        self.blocked_keywords = {kw.lower() for kw in blocked_keywords}
+
+    def evaluate(self, context: PolicyContext) -> PolicyResult:
+        expenses = context.expenses or []
+        for expense in expenses:
+            description = expense.description.lower()
+            if any(keyword in description for keyword in self.blocked_keywords):
+                return self._result(
+                    False,
+                    f"Expense '{expense.description}' includes non-reimbursable items ({', '.join(sorted(self.blocked_keywords))}).",
+                )
+        return self._result(True, "No non-reimbursable items detected.")
+
+    def message(self) -> str:  # pragma: no cover - static template
+        keywords = ", ".join(sorted(self.blocked_keywords))
+        return f"Expenses cannot include non-reimbursable items such as {keywords}."
+
+
+class ThirdPartyPaidRule(PolicyRule):
+    rule_id = "third_party_paid"
+
+    def __init__(self, severity: str) -> None:
+        super().__init__(severity)
+
+    def evaluate(self, context: PolicyContext) -> PolicyResult:
+        payments = context.third_party_payments or []
+        for payment in payments:
+            itemized = bool(payment.get("itemized"))
+            description = str(payment.get("description", "third-party payment"))
+            if not itemized:
+                return self._result(
+                    False,
+                    f"Third-party payment '{description}' must be itemized and excluded from reimbursement.",
+                )
+        return self._result(True, "Third-party payments are properly itemized or none provided.")
+
+    def message(self) -> str:  # pragma: no cover - static template
+        return "Third-party paid expenses must be itemized and excluded."
+
+
+def _load_rule_config(config: dict[str, object], key: str, default: dict[str, object]) -> dict[str, object]:
+    rules_cfg = config.get("rules", {}) or {}
+    rule_cfg = rules_cfg.get(key, {}) or {}
+    merged = default.copy()
+    merged.update(rule_cfg)
+    return merged
+
+
+def _default_policy_path() -> Path | None:
+    for parent in Path(__file__).resolve().parents:
+        candidate = parent / "config" / "policy.yaml"
+        if candidate.exists():
+            return candidate
+    return None
+
+
+class PolicyEngine:
+    """Execute all policy-lite rules and aggregate their results."""
+
+    def __init__(self, rules: Iterable[PolicyRule]):
+        self.rules = list(rules)
+
+    @classmethod
+    def from_yaml(cls, content: str) -> PolicyEngine:
+        config = yaml.safe_load(content) or {}
+
+        advance_cfg = _load_rule_config(
+            config, "advance_booking", {"days_required": 14, "severity": Severity.ADVISORY}
+        )
+        fare_comparison_cfg = _load_rule_config(
+            config, "fare_comparison", {"max_over_lowest": Decimal("200"), "severity": Severity.BLOCKING}
+        )
+        cabin_class_cfg = _load_rule_config(
+            config,
+            "cabin_class",
+            {"long_haul_hours": 5, "allowed_classes": ["economy"], "severity": Severity.BLOCKING},
+        )
+        fare_evidence_cfg = _load_rule_config(
+            config, "fare_evidence", {"severity": Severity.BLOCKING}
+        )
+        driving_vs_flying_cfg = _load_rule_config(
+            config, "driving_vs_flying", {"severity": Severity.ADVISORY}
+        )
+        hotel_comparison_cfg = _load_rule_config(
+            config, "hotel_comparison", {"minimum_alternatives": 2, "severity": Severity.ADVISORY}
+        )
+        local_overnight_cfg = _load_rule_config(
+            config, "local_overnight", {"min_distance_miles": 50, "severity": Severity.ADVISORY}
+        )
+        meal_per_diem_cfg = _load_rule_config(
+            config, "meal_per_diem", {"severity": Severity.ADVISORY}
+        )
+        non_reimbursable_cfg = _load_rule_config(
+            config,
+            "non_reimbursable",
+            {"blocked_keywords": ["liquor", "alcohol", "personal"], "severity": Severity.BLOCKING},
+        )
+        third_party_paid_cfg = _load_rule_config(
+            config, "third_party_paid", {"severity": Severity.BLOCKING}
+        )
+
+        rules: list[PolicyRule] = [
+            AdvanceBookingRule(
+                days_required=int(advance_cfg["days_required"]), severity=str(advance_cfg["severity"])
+            ),
+            FareComparisonRule(
+                max_over_lowest=Decimal(fare_comparison_cfg["max_over_lowest"]),
+                severity=str(fare_comparison_cfg["severity"]),
+            ),
+            CabinClassRule(
+                long_haul_hours=float(cabin_class_cfg["long_haul_hours"]),
+                allowed_classes=cabin_class_cfg["allowed_classes"],
+                severity=str(cabin_class_cfg["severity"]),
+            ),
+            FareEvidenceRule(severity=str(fare_evidence_cfg["severity"])),
+            DrivingVsFlyingRule(severity=str(driving_vs_flying_cfg["severity"])),
+            HotelComparisonRule(
+                minimum_alternatives=int(hotel_comparison_cfg["minimum_alternatives"]),
+                severity=str(hotel_comparison_cfg["severity"]),
+            ),
+            LocalOvernightRule(
+                min_distance_miles=float(local_overnight_cfg["min_distance_miles"]),
+                severity=str(local_overnight_cfg["severity"]),
+            ),
+            MealPerDiemRule(severity=str(meal_per_diem_cfg["severity"])),
+            NonReimbursableRule(
+                blocked_keywords=non_reimbursable_cfg["blocked_keywords"],
+                severity=str(non_reimbursable_cfg["severity"]),
+            ),
+            ThirdPartyPaidRule(severity=str(third_party_paid_cfg["severity"])),
+        ]
+
+        return cls(rules)
+
+    @classmethod
+    def from_file(cls, path: str | Path | None = None) -> PolicyEngine:
+        target_path = Path(path) if path is not None else _default_policy_path()
+        if target_path is None:
+            raise FileNotFoundError("No policy.yaml configuration file found")
+        content = target_path.read_text(encoding="utf-8")
+        return cls.from_yaml(content)
+
+    def validate(self, context: PolicyContext) -> list[PolicyResult]:
+        return [rule.evaluate(context) for rule in self.rules]
+
+    def blocking_results(self, context: PolicyContext) -> list[PolicyResult]:
+        return [result for result in self.validate(context) if result.severity == Severity.BLOCKING and not result.passed]
+

--- a/src/travel_plan_permission/policy.py
+++ b/src/travel_plan_permission/policy.py
@@ -104,6 +104,7 @@ class PolicyRule(ABC):
             "description": self.message(),
         }
 
+
 class AdvanceBookingRule(PolicyRule):
     rule_id = "advance_booking"
 

--- a/src/travel_plan_permission/policy.py
+++ b/src/travel_plan_permission/policy.py
@@ -95,6 +95,14 @@ class PolicyRule(ABC):
             message=message or self.message(),
         )
 
+    def metadata(self) -> dict[str, object]:
+        """Return static metadata about the rule for documentation surfaces."""
+
+        return {
+            "rule_id": self.rule_id,
+            "severity": self.severity,
+            "description": self.message(),
+        }
 
 class AdvanceBookingRule(PolicyRule):
     rule_id = "advance_booking"
@@ -482,3 +490,8 @@ class PolicyEngine:
             for result in self.validate(context)
             if result.severity == Severity.BLOCKING and not result.passed
         ]
+
+    def describe_rules(self) -> list[dict[str, object]]:
+        """Expose structured rule metadata for documentation and UIs."""
+
+        return [rule.metadata() for rule in self.rules]

--- a/tests/python/test_policy_engine.py
+++ b/tests/python/test_policy_engine.py
@@ -1,0 +1,118 @@
+from datetime import date
+from decimal import Decimal
+
+from travel_plan_permission import (
+    ExpenseCategory,
+    ExpenseItem,
+    PolicyContext,
+    PolicyEngine,
+    Severity,
+)
+
+
+def test_policy_engine_evaluates_all_rules():
+    yaml_content = """
+rules:
+  advance_booking:
+    days_required: 10
+  fare_comparison:
+    max_over_lowest: 150
+"""
+    engine = PolicyEngine.from_yaml(yaml_content)
+    context = PolicyContext(
+        booking_date=date(2025, 1, 1),
+        departure_date=date(2025, 1, 5),
+        return_date=date(2025, 1, 7),
+        selected_fare=Decimal("600"),
+        lowest_fare=Decimal("400"),
+        cabin_class="Business",
+        flight_duration_hours=2.0,
+        fare_evidence_attached=False,
+        driving_cost=Decimal("500"),
+        flight_cost=Decimal("300"),
+        comparable_hotels=[Decimal("150")],
+        distance_from_office_miles=10,
+        overnight_stay=True,
+        meals_provided=True,
+        meal_per_diem_requested=True,
+        expenses=[
+            ExpenseItem(
+                category=ExpenseCategory.MEALS,
+                description="Liquor with client dinner",
+                amount=Decimal("50"),
+                expense_date=date(2025, 1, 6),
+            )
+        ],
+        third_party_payments=[{"description": "Sponsor pays hotel", "itemized": False}],
+    )
+
+    results = {result.rule_id: result for result in engine.validate(context)}
+    assert set(results.keys()) == {
+        "advance_booking",
+        "fare_comparison",
+        "cabin_class",
+        "fare_evidence",
+        "driving_vs_flying",
+        "hotel_comparison",
+        "local_overnight",
+        "meal_per_diem",
+        "non_reimbursable",
+        "third_party_paid",
+    }
+
+    assert not results["advance_booking"].passed
+    assert not results["fare_comparison"].passed
+    assert not results["cabin_class"].passed
+    assert not results["fare_evidence"].passed
+    assert not results["driving_vs_flying"].passed
+    assert not results["hotel_comparison"].passed
+    assert not results["local_overnight"].passed
+    assert not results["meal_per_diem"].passed
+    assert not results["non_reimbursable"].passed
+    assert not results["third_party_paid"].passed
+
+    blocking = engine.blocking_results(context)
+    blocking_ids = {result.rule_id for result in blocking}
+    assert blocking_ids == {
+        "fare_comparison",
+        "cabin_class",
+        "fare_evidence",
+        "non_reimbursable",
+        "third_party_paid",
+    }
+    assert all(result.severity == Severity.BLOCKING for result in blocking)
+
+
+def test_policy_engine_from_file_defaults():
+    engine = PolicyEngine.from_file()
+    context = PolicyContext(
+        booking_date=date(2025, 1, 1),
+        departure_date=date(2025, 1, 20),
+        return_date=date(2025, 1, 22),
+        selected_fare=Decimal("300"),
+        lowest_fare=Decimal("200"),
+        cabin_class="Economy",
+        flight_duration_hours=4.0,
+        fare_evidence_attached=True,
+        driving_cost=Decimal("100"),
+        flight_cost=Decimal("300"),
+        comparable_hotels=[Decimal("120"), Decimal("130")],
+        distance_from_office_miles=60,
+        overnight_stay=False,
+        meals_provided=False,
+        meal_per_diem_requested=True,
+        expenses=[
+            ExpenseItem(
+                category=ExpenseCategory.OTHER,
+                description="Office supplies for trip",
+                amount=Decimal("25"),
+                expense_date=date(2025, 1, 3),
+            )
+        ],
+        third_party_payments=[{"description": "Conference lodging", "itemized": True}],
+    )
+
+    results = engine.validate(context)
+    assert len(results) == 10
+    assert all(result.passed for result in results)
+    assert engine.blocking_results(context) == []

--- a/tests/python/test_policy_metadata.py
+++ b/tests/python/test_policy_metadata.py
@@ -1,0 +1,30 @@
+from travel_plan_permission import PolicyEngine
+
+
+def test_describe_rules_reflects_configuration():
+    yaml_content = """
+rules:
+  advance_booking:
+    days_required: 21
+    severity: blocking
+  fare_comparison:
+    max_over_lowest: 150
+  cabin_class:
+    long_haul_hours: 6
+    allowed_classes:
+      - economy
+      - premium economy
+    severity: advisory
+  non_reimbursable:
+    blocked_keywords:
+      - gift
+"""
+    engine = PolicyEngine.from_yaml(yaml_content)
+    metadata = {item["rule_id"]: item for item in engine.describe_rules()}
+
+    assert metadata["advance_booking"]["severity"] == "blocking"
+    assert "21 days" in metadata["advance_booking"]["description"]
+    assert "150" in metadata["fare_comparison"]["description"]
+    assert metadata["cabin_class"]["severity"] == "advisory"
+    assert "premium economy" in metadata["cabin_class"]["description"].lower()
+    assert "gift" in metadata["non_reimbursable"]["description"]


### PR DESCRIPTION
# Summary

One sentence.

## Checklist

- [ ] Does NOT touch protected paths (schemas, policy, mapping,
  workflow docs, CI)
- [ ] If schema changed: examples updated and CI is green
- [ ] If policy-lite changed: rule IDs/messages updated
- [ ] If mapping changed: cell refs updated in docs

## Labels

Add `stage:*`, `type:*`, and size (`XS/S/M/L`).

Add `stage:*`, `type:*`, and size (`XS/S/M/L`).

<!-- pr-preamble:start -->
<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
- [x] The Policy-Lite checklist (docs/policy-lite-checklist.md) defines 10 rules that must be evaluated against trip plans and expenses. Currently these are checked manually. Automating them reduces approval delays and ensures consistent enforcement.

#### Tasks
- [x] [ ] Create PolicyRule base class with evaluate() and message() methods
- [x] [ ] Implement AdvanceBookingRule (14 days, advisory)
- [x] [ ] Implement FareComparisonRule ($200 threshold, blocking)
- [x] [ ] Implement CabinClassRule (economy unless >5hr flight, advisory/blocking)
- [x] [ ] Implement FareEvidenceRule (screenshot required, blocking)
- [x] [ ] Implement DrivingVsFlyingRule (lesser cost reimbursement, advisory)
- [x] [ ] Implement HotelComparisonRule (2 alternatives required, advisory)
- [x] [ ] Implement LocalOvernightRule (50 mile waiver, advisory)
- [x] [ ] Implement MealPerDiemRule (exclude conference-provided, advisory)
- [x] [ ] Implement NonReimbursableRule (liquor/personal items, blocking)
- [x] [ ] Implement ThirdPartyPaidRule (itemize and exclude, blocking)
- [x] [ ] Create PolicyEngine that runs all rules and aggregates results
- [x] [ ] Write unit tests for each rule with edge cases
- [x] [ ] Document rule configurations in docs/validation-rules.md

#### Acceptance criteria
- [x] - All 10 Policy-Lite rules implemented and individually testable
- [x] - Blocking rules return errors that prevent submission
- [x] - Advisory rules return warnings that allow submission with flag
- [x] - Each rule message includes the specific threshold or policy text
- [x] - PolicyEngine.validate() returns structured results with rule ID, severity, message
- [x] - Rule thresholds configurable via policy.yaml

**Head SHA:** 20efddaac8a14b133a0acb58d75d8d66154a3383
**Latest Runs:** ⏳ pending — Gate
**Required:** gate: ⏳ pending

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/20450617488) |
| Autofix | ⏳ pending | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/20450617507) |
| CI | ❔ in progress | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/20450617490) |
| Gate | ⏳ pending | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/20450617489) |
<!-- auto-status-summary:end -->