### PR TITLE
fix(workflow): remove duplicate secrets inherit line

### DIFF
--- a/.github/workflows/agents-pr-meta.yml
+++ b/.github/workflows/agents-pr-meta.yml
@@ -150,4 +150,3 @@ jobs:
       allowed_keepalive_logins: ${{ vars.ALLOWED_KEEPALIVE_LOGINS || 'stranske' }}
       allow_replay: true
     secrets: inherit
-    secrets: inherit


### PR DESCRIPTION
## Problem
The agents-pr-meta.yml workflow has a YAML syntax error with duplicate `secrets: inherit` lines at the end of the file.

This causes all workflow runs to fail immediately with no jobs executing.

## Fix
Remove the duplicate line.

**This is blocking all keepalive functionality.**