### PR TITLE
Add itinerary field mappings and guidance

### DIFF
--- a/config/excel_mappings.yaml
+++ b/config/excel_mappings.yaml
@@ -1,0 +1,87 @@
+templates:
+  - template_id: ITIN-2025.1
+    file_name: Travel_Itinerary_Form_2025.xlsx
+    sheet_name: Itinerary
+    version_reviewed: 2025-09-06
+    fields:
+      - canonical_field: traveler_name
+        cell: B4
+        note: Primary traveler full name
+      - canonical_field: business_purpose
+        cell: B5
+        note: Business purpose / event title
+      - canonical_field: cost_center
+        cell: D5
+        note: Chartfield or cost center string
+      - canonical_field: destination_zip
+        cell: F7
+        note: Destination ZIP code for per-diem
+      - canonical_field: city_state
+        cell: B7
+        note: City and state
+      - canonical_field: depart_date
+        cell: B9
+      - canonical_field: return_date
+        cell: D9
+      - canonical_field: event_registration_cost
+        cell: F11
+      - canonical_field: flight_pref_outbound.carrier_flight
+        cell: B12
+      - canonical_field: flight_pref_outbound.depart_time
+        cell: C12
+      - canonical_field: flight_pref_outbound.arrive_time
+        cell: D12
+      - canonical_field: flight_pref_outbound.roundtrip_cost
+        cell: F12
+      - canonical_field: flight_pref_return.carrier_flight
+        cell: B13
+      - canonical_field: flight_pref_return.depart_time
+        cell: C13
+      - canonical_field: flight_pref_return.arrive_time
+        cell: D13
+      - canonical_field: lowest_cost_roundtrip
+        cell: F13
+        note: Documented lowest available fare
+      - canonical_field: parking_estimate
+        cell: F15
+      - canonical_field: hotel.name
+        cell: B17
+      - canonical_field: hotel.address
+        cell: B18
+      - canonical_field: hotel.city_state
+        cell: E18
+      - canonical_field: hotel.nightly_rate
+        cell: F17
+      - canonical_field: hotel.nights
+        cell: G17
+      - canonical_field: hotel.price_compare_notes
+        cell: B20
+        note: Price comparison or exception notes
+      - canonical_field: comparable_hotels[0].name
+        cell: B22
+      - canonical_field: comparable_hotels[0].nightly_rate
+        cell: F22
+      - canonical_field: comparable_hotels[1].name
+        cell: B23
+      - canonical_field: comparable_hotels[1].nightly_rate
+        cell: F23
+      - canonical_field: notes
+        cell: B27
+    checkbox_fields:
+      - canonical_field: hotel.conference_hotel
+        cell: E17
+        checked_value: Yes
+        unchecked_value: No
+        note: Mark if hotel is conference hotel
+    dropdown_fields:
+      - canonical_field: ground_transport_pref
+        cell: B25
+        allowed_values:
+          - Rideshare/Taxi
+          - Rental Car
+          - Public Transit
+          - Personal Vehicle
+    calculated_fields:
+      - cell: F28
+        description: Meal per-diem total (formula-driven on template)
+        formula_driven: true

--- a/docs/field-mapping.md
+++ b/docs/field-mapping.md
@@ -3,6 +3,59 @@
 We maintain a canonical JSON for trips and expenses. A small mapping file
 translates canonical fields to each spreadsheet cell.
 
+## Itinerary template mappings (ITIN-2025.1)
+
+The canonical trip fields for **Travel_Itinerary_Form_2025.xlsx** (Template ID:
+ITIN-2025.1) are enumerated in `config/excel_mappings.yaml` with the following
+cell targets on the **Itinerary** sheet:
+
+- traveler_name → **B4**
+- business_purpose → **B5**
+- cost_center → **D5**
+- destination_zip → **F7**
+- city_state → **B7**
+- depart_date → **B9**
+- return_date → **D9**
+- event_registration_cost → **F11**
+- flight_pref_outbound.{carrier_flight, depart_time, arrive_time, roundtrip_cost}
+  → **B12**, **C12**, **D12**, **F12**
+- flight_pref_return.{carrier_flight, depart_time, arrive_time}
+  → **B13**, **C13**, **D13**
+- lowest_cost_roundtrip → **F13**
+- parking_estimate → **F15**
+- hotel.{name, address, city_state, nightly_rate, nights, price_compare_notes}
+  → **B17**, **B18**, **E18**, **F17**, **G17**, **B20**
+- comparable_hotels[0|1].{name, nightly_rate} → **B22/F22**, **B23/F23**
+- ground_transport_pref (dropdown) → **B25**
+- notes → **B27**
+
+### Checkbox and dropdown formats
+
+- **hotel.conference_hotel** checkbox at **E17** uses `Yes` / `No` values.
+- **ground_transport_pref** dropdown at **B25** expects one of:
+  `Rideshare/Taxi`, `Rental Car`, `Public Transit`, or `Personal Vehicle`.
+
+### Formula-driven fields
+
+- Meal per-diem total at **F28** is formula-driven in the template and should
+  not be overwritten by the agent. Mapping is marked `formula_driven: true` for
+  version **ITIN-2025.1**.
+
+## Minimal Q&A coverage (draft)
+
+To reach field completeness within ten questions for typical trips, start with:
+
+1. Traveler name and role.
+2. Trip purpose / event name.
+3. Destination city/state and ZIP.
+4. Travel dates (depart / return).
+5. Cost center or chartfield.
+6. Registration cost (if applicable).
+7. Outbound flight preference (carrier + times) and lowest available fare.
+8. Return flight preference (carrier + times).
+9. Hotel choice (conference hotel Y/N), nightly rate, nights, comparable options.
+10. Ground transport preference and parking estimate.
+
 ## Canonical Trip fields (initial)
 
 - traveler_name


### PR DESCRIPTION
# Summary
- add ITIN-2025.1 spreadsheet cell mappings to config/excel_mappings.yaml
- document mapping details, dropdown/checkbox values, and per-diem formula treatment in docs/field-mapping.md
- outline a minimal 10-question intake flow for itinerary completeness

## Testing
- python -m compileall src

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a102a0f30833182fc008a84094811)