### PR TITLE
feat: add provider registry validation

### DIFF
--- a/config/providers.yaml
+++ b/config/providers.yaml
@@ -1,0 +1,46 @@
+version: "2024.09"
+updated_at: 2024-09-01
+approver: "Travel Operations Manager"
+change_log:
+  - version: "2024.09"
+    date: 2024-09-01
+    description: "Initial approved provider list"
+    approver: "Travel Operations Manager"
+
+providers:
+  - name: "Blue Skies Airlines"
+    type: airline
+    contract_id: "AIR-2024-001"
+    valid_from: 2024-01-01
+    valid_to: 2024-12-31
+    destinations:
+      - "new york"
+      - "san francisco"
+      - "london"
+    rate_notes: "Includes contracted fare caps for transatlantic routes."
+
+  - name: "Downtown Suites"
+    type: hotel
+    contract_id: "HOT-2024-010"
+    valid_from: 2024-02-01
+    valid_to: 2024-12-31
+    destinations:
+      - "new york"
+    rate_notes: "Breakfast and wifi included."
+
+  - name: "Citywide Rides"
+    type: ground_transport
+    contract_id: "GRT-2024-003"
+    valid_from: 2024-01-15
+    valid_to: 2024-10-31
+    destinations: []
+    rate_notes: "Nationwide coverage with fixed airport transfer rates."
+
+  - name: "Harbor Hotels"
+    type: hotel
+    contract_id: "HOT-2023-007"
+    valid_from: 2023-01-01
+    valid_to: 2023-12-31
+    destinations:
+      - "seattle"
+    rate_notes: "Expired sample to test validity filtering."

--- a/config/validation.yaml
+++ b/config/validation.yaml
@@ -26,3 +26,10 @@ rules:
     severity: warning
     blocking: false
     max_consecutive_days: 14
+
+  - type: provider_approval
+    name: approved_provider_warning
+    code: PROV-001
+    severity: warning
+    blocking: false
+    providers_path: config/providers.yaml

--- a/docs/provider-governance.md
+++ b/docs/provider-governance.md
@@ -1,0 +1,25 @@
+# Provider governance
+
+This package manages approved travel providers (airlines, hotels, and ground transport) through a
+versioned registry stored at `config/providers.yaml`.
+
+## Data model
+
+- **Provider**: `name`, `type` (`airline`, `hotel`, `ground_transport`), `contract_id`,
+  `valid_from`, `valid_to`, `destinations`, `rate_notes`.
+- **Metadata**: `version`, `updated_at`, `approver`, and a `change_log` with
+  `version`, `date`, `description`, and `approver` entries to make updates auditable.
+
+Contracts must include both start and end dates so that lookups can filter to active providers.
+
+## Workflow for updates
+
+1. Propose the change (add/remove/update) in a PR and bump the `version` in `config/providers.yaml`.
+2. Add a `change_log` entry with the new version, date, description, and the designated
+   approver’s name or role.
+3. Obtain approval from the designated approver recorded in the metadata before merging.
+4. Run provider-related tests (`python -m pytest tests/python/test_providers.py`) to verify lookups.
+5. Merge after approval so the audit trail reflects who authorized the change.
+
+This workflow ensures the provider list is auditable, versioned, and controlled by a designated
+approver.

--- a/src/travel_plan_permission/__init__.py
+++ b/src/travel_plan_permission/__init__.py
@@ -39,6 +39,7 @@ from .prompt_flow import (
     generate_questions,
     required_field_gaps,
 )
+from .providers import Provider, ProviderRegistry, ProviderType
 from .receipts import (
     ALLOWED_RECEIPT_TYPES,
     MAX_RECEIPT_SIZE_BYTES,
@@ -52,6 +53,7 @@ from .validation import (
 from .validation import (
     BudgetLimitRule,
     DurationLimitRule,
+    ProviderApprovalRule as ValidationProviderApprovalRule,
     PolicyValidator,
     ValidationResult,
     ValidationRule,
@@ -90,6 +92,9 @@ __all__ = [
     "PolicyResult",
     "PolicyRule",
     "PolicyValidator",
+    "Provider",
+    "ProviderRegistry",
+    "ProviderType",
     "ReceiptExtractionResult",
     "ReceiptProcessor",
     "Question",
@@ -102,6 +107,7 @@ __all__ = [
     "TripPlan",
     "TripStatus",
     "ValidationAdvanceBookingRule",
+    "ValidationProviderApprovalRule",
     "ValidationResult",
     "ValidationRule",
     "ValidationSeverity",

--- a/src/travel_plan_permission/models.py
+++ b/src/travel_plan_permission/models.py
@@ -121,6 +121,12 @@ class TripPlan(BaseModel):
         default_factory=dict,
         description="Optional planned spend by category",
     )
+    selected_providers: dict[ExpenseCategory, str] = Field(
+        default_factory=dict,
+        description=(
+            "Traveler-selected providers keyed by expense category; used for approved provider checks"
+        ),
+    )
     validation_results: list[ValidationResult] = Field(
         default_factory=list,
         description="Results from policy validation",

--- a/src/travel_plan_permission/providers.py
+++ b/src/travel_plan_permission/providers.py
@@ -1,0 +1,201 @@
+"""Provider registry and lookup utilities for approved travel vendors."""
+
+from __future__ import annotations
+
+from datetime import date
+from enum import Enum
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class ProviderType(str, Enum):
+    """Categories of supported travel providers."""
+
+    AIRLINE = "airline"
+    HOTEL = "hotel"
+    GROUND_TRANSPORT = "ground_transport"
+
+
+def provider_type_for_category(category: str) -> ProviderType | None:
+    """Map an expense category string to a provider type when applicable."""
+
+    normalized = category.lower()
+    if normalized == "airfare":
+        return ProviderType.AIRLINE
+    if normalized == "lodging":
+        return ProviderType.HOTEL
+    if normalized == "ground_transport":
+        return ProviderType.GROUND_TRANSPORT
+    return None
+
+
+class Provider(BaseModel):
+    """An approved travel provider record."""
+
+    name: str = Field(..., description="Display name of the provider")
+    type: ProviderType = Field(..., description="Category of provider")
+    contract_id: str = Field(..., description="Internal contract identifier")
+    valid_from: date = Field(..., description="Contract start date")
+    valid_to: date | None = Field(
+        default=None, description="Contract end date; None when open-ended"
+    )
+    destinations: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Destination keywords (case-insensitive substring) where the provider applies; "
+            "empty means globally applicable"
+        ),
+    )
+    rate_notes: str | None = Field(
+        default=None, description="Optional notes about negotiated rates"
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def _validate_dates(self) -> Provider:
+        if self.valid_to and self.valid_to < self.valid_from:
+            msg = "valid_to must be on or after valid_from"
+            raise ValueError(msg)
+        return self
+
+    def is_active(self, reference_date: date | None = None) -> bool:
+        """Return True when the provider contract is active for the reference date."""
+
+        check_date = reference_date or date.today()
+        if check_date < self.valid_from:
+            return False
+        if self.valid_to and check_date > self.valid_to:
+            return False
+        return True
+
+    def matches_destination(self, destination: str) -> bool:
+        """Return True when the provider applies to the requested destination."""
+
+        if not self.destinations:
+            return True
+        destination_lower = destination.lower()
+        return any(keyword.lower() in destination_lower for keyword in self.destinations)
+
+
+class ProviderChange(BaseModel):
+    """Audit entry for changes to the provider list."""
+
+    version: str = Field(..., description="Version identifier for the change")
+    change_date: date = Field(
+        ..., alias="date", description="Date the change was approved"
+    )
+    description: str = Field(..., description="Summary of the change")
+    approver: str = Field(..., description="Person or role who approved the change")
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+
+class ProviderRegistry(BaseModel):
+    """Registry of approved providers with lookup helpers."""
+
+    version: str = Field(..., description="Version tag for the provider list")
+    approver: str = Field(..., description="Designated approver for list updates")
+    updated_at: date = Field(..., description="Last updated timestamp for the registry")
+    change_log: list[ProviderChange] = Field(
+        default_factory=list, description="Audit trail of provider list updates"
+    )
+    providers: list[Provider] = Field(
+        default_factory=list, description="Collection of approved providers"
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+    @classmethod
+    def from_yaml(cls, content: str) -> ProviderRegistry:
+        """Instantiate a registry from YAML content."""
+
+        data = yaml.safe_load(content) or {}
+        providers = data.get("providers")
+        if not providers:
+            raise ValueError("Provider configuration must include a 'providers' list")
+        return cls.model_validate(data)
+
+    @classmethod
+    def from_file(cls, path: str | Path | None = None) -> ProviderRegistry:
+        """Load provider configuration from a file, falling back to the default path."""
+
+        target_path = cls._resolve_path(path)
+        return cls.from_yaml(target_path.read_text(encoding="utf-8"))
+
+    @staticmethod
+    def _default_path() -> Path | None:
+        for parent in Path(__file__).resolve().parents:
+            candidate = parent / "config" / "providers.yaml"
+            if candidate.exists():
+                return candidate
+        return None
+
+    @classmethod
+    def _resolve_path(cls, path: str | Path | None) -> Path:
+        if path is None:
+            default_path = cls._default_path()
+            if default_path is None:
+                raise FileNotFoundError("No providers.yaml file found")
+            return default_path
+
+        candidate = Path(path)
+        if candidate.is_absolute() and candidate.exists():
+            return candidate
+
+        for parent in Path(__file__).resolve().parents:
+            relative_candidate = parent / candidate
+            if relative_candidate.exists():
+                return relative_candidate
+        return candidate
+
+    def lookup(
+        self,
+        provider_type: ProviderType,
+        destination: str,
+        *,
+        reference_date: date | None = None,
+    ) -> list[Provider]:
+        """Return approved providers for the type and destination."""
+
+        return sorted(
+            [
+                provider
+                for provider in self.providers
+                if provider.type == provider_type
+                and provider.is_active(reference_date)
+                and provider.matches_destination(destination)
+            ],
+            key=lambda provider: provider.name.lower(),
+        )
+
+    def is_approved(
+        self,
+        provider_name: str,
+        provider_type: ProviderType,
+        destination: str,
+        *,
+        reference_date: date | None = None,
+    ) -> bool:
+        """Return True when the provider name is approved for the destination."""
+
+        approved_names = {
+            provider.name
+            for provider in self.lookup(
+                provider_type, destination, reference_date=reference_date
+            )
+        }
+        return provider_name in approved_names
+
+    def active_providers(
+        self, *, reference_date: date | None = None
+    ) -> list[Provider]:
+        """Return all providers with an active contract for the given date."""
+
+        return [
+            provider
+            for provider in self.providers
+            if provider.is_active(reference_date=reference_date)
+        ]

--- a/tests/python/test_providers.py
+++ b/tests/python/test_providers.py
@@ -1,0 +1,29 @@
+"""Tests for provider registry loading and lookup."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from travel_plan_permission.providers import ProviderRegistry, ProviderType
+
+
+def test_lookup_filters_by_destination_and_validity() -> None:
+    registry = ProviderRegistry.from_file("config/providers.yaml")
+
+    london_airlines = registry.lookup(
+        ProviderType.AIRLINE, "London, UK", reference_date=date(2024, 6, 1)
+    )
+    assert [provider.name for provider in london_airlines] == ["Blue Skies Airlines"]
+
+    expired_hotels = registry.lookup(
+        ProviderType.HOTEL, "Seattle, WA", reference_date=date(2024, 3, 1)
+    )
+    assert expired_hotels == []
+
+
+def test_registry_metadata_requires_approver_and_version() -> None:
+    registry = ProviderRegistry.from_file("config/providers.yaml")
+
+    assert registry.version == "2024.09"
+    assert registry.approver == "Travel Operations Manager"
+    assert registry.change_log, "Change log should capture provider list updates"


### PR DESCRIPTION
## Summary
- add a versioned providers.yaml registry with approver metadata and sample airlines, hotels, and ground transport providers
- introduce a ProviderRegistry/ProviderApprovalRule with TripPlan provider selections and warnings for non-approved vendors
- document provider governance workflow and add coverage for registry lookups and provider validation

## Testing
- python -m pytest tests/python/test_providers.py tests/python/test_validation.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a19aae7988331a02ae96209117988)