### PR TITLE
feat: add Agents Verifier workflow for post-merge verification

### DIFF
--- a/.github/workflows/agents-verifier.yml
+++ b/.github/workflows/agents-verifier.yml
@@ -1,0 +1,27 @@
+# Thin caller for Agents Verifier - delegates to Workflows repo reusable workflow
+# Runs post-merge to verify acceptance criteria were met and opens follow-up issues
+#
+# Triggers:
+# - PR merged (pull_request closed with merged=true)
+name: Agents Verifier
+
+on:
+  pull_request:
+    types:
+      - closed
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+  actions: read
+
+jobs:
+  verifier:
+    # Only run on merged PRs
+    if: github.event.pull_request.merged == true
+    uses: stranske/Workflows/.github/workflows/reusable-agents-verifier.yml@main
+    with:
+      # CI workflows to wait for before running verifier
+      ci_workflows: '["ci.yml", "pr-00-gate.yml"]'
+    secrets: inherit


### PR DESCRIPTION
Adds workflow that runs after PRs are merged to verify acceptance criteria were met. Uses secrets: inherit for cleaner secret passing.

# Summary

One sentence.

## Checklist

- [ ] Does NOT touch protected paths (schemas, policy, mapping,
  workflow docs, CI)
- [ ] If schema changed: examples updated and CI is green
- [ ] If policy-lite changed: rule IDs/messages updated
- [ ] If mapping changed: cell refs updated in docs

## Labels

Add `stage:*`, `type:*`, and size (`XS/S/M/L`).

Add `stage:*`, `type:*`, and size (`XS/S/M/L`).
