### PR TITLE
sync: Update workflow templates from stranske/Workflows

### DIFF
--- a/.github/scripts/parse_chatgpt_topics.py
+++ b/.github/scripts/parse_chatgpt_topics.py
@@ -25,9 +25,7 @@ ALLOW_FALLBACK = os.environ.get("ALLOW_SINGLE_TOPIC", "0") in {"1", "true", "Tru
 def _load_text() -> str:
     try:
         text = INPUT_PATH.read_text(encoding="utf-8").strip()
-    except (
-        FileNotFoundError
-    ) as exc:  # pragma: no cover - guardrail for workflow execution
+    except FileNotFoundError as exc:  # pragma: no cover - guardrail for workflow execution
         raise SystemExit("No input.txt found to parse.") from exc
     if not text:
         raise SystemExit("No topic content provided.")
@@ -46,9 +44,7 @@ def _split_numbered_items(text: str) -> list[dict[str, str | list[str] | bool]]:
     Each returned item dict includes:
       title, lines, enumerator, continuity_break (bool)
     """
-    pattern = re.compile(
-        r"^\s*(?P<enum>(?:\d+|[A-Za-z]\d+|[A-Za-z]))[\).:\-]\s+(?P<title>.+)$"
-    )
+    pattern = re.compile(r"^\s*(?P<enum>(?:\d+|[A-Za-z]\d+|[A-Za-z]))[\).:\-]\s+(?P<title>.+)$")
     items: list[dict[str, str | list[str] | bool]] = []
     current: dict[str, str | list[str] | bool] | None = None
     style: str | None = None  # 'numeric' | 'alpha' | 'alphanum'
@@ -174,9 +170,7 @@ def _join_section(lines: list[str]) -> str:
     return "\n".join(lines).strip()
 
 
-def parse_text(
-    text: str, *, allow_single_fallback: bool = False
-) -> list[dict[str, object]]:
+def parse_text(text: str, *, allow_single_fallback: bool = False) -> list[dict[str, object]]:
     """Parse raw *text* into topic dictionaries.
 
     Parameters

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -106,3 +106,5 @@ jobs:
       caller_actor: ${{ needs.resolve.outputs.caller_actor }}
     secrets:
       service_bot_pat: ${{ secrets.SERVICE_BOT_PAT }}
+      WORKFLOWS_APP_ID: ${{ secrets.WORKFLOWS_APP_ID }}
+      WORKFLOWS_APP_PRIVATE_KEY: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Workflow Sync

    This PR updates thin caller workflows to match the latest templates from [stranske/Workflows](https://github.com/stranske/Workflows).

    **Template hash:** `3042d96946d1`

    ### Changed files
     agents-orchestrator.yml autofix.yml scripts/decode_raw_input.py scripts/parse_chatgpt_topics.py .gitignore

    ### What changed
    - Thin caller workflows (triggers/permissions) updated
    - Tool version pins may be updated
    - No changes to your repo-specific code

    ### Review checklist
    - [ ] No repo-specific customizations were overwritten
    - [ ] CI passes with new workflow versions

    ---
    *Automated by [Maint 68 Sync Consumer Repos](https://github.com/stranske/Workflows/actions/workflows/maint-68-sync-consumer-repos.yml)*