### PR TITLE
sync: Update workflow templates from stranske/Workflows

### DIFF
--- a/.github/scripts/decode_raw_input.py
+++ b/.github/scripts/decode_raw_input.py
@@ -18,9 +18,7 @@ OUT_FILE = Path("input.txt")
 
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Decode or normalize topic input")
-    parser.add_argument(
-        "--passthrough", action="store_true", help="Read plain text from --in file"
-    )
+    parser.add_argument("--passthrough", action="store_true", help="Read plain text from --in file")
     parser.add_argument("--in", dest="in_file", help="Input file for passthrough mode")
     parser.add_argument(
         "--source",
@@ -33,9 +31,7 @@ def _parse_args() -> argparse.Namespace:
 def main() -> None:
     args = _parse_args()
     text: str = ""
-    source_used = args.source_tag or (
-        "passthrough" if args.passthrough else "raw_input"
-    )
+    source_used = args.source_tag or ("passthrough" if args.passthrough else "raw_input")
     if args.passthrough:
         if not args.in_file:
             return
@@ -49,7 +45,7 @@ def main() -> None:
         raw = RAW_FILE.read_text(encoding="utf-8")
         try:
             text = json.loads(raw) if raw not in ("", "null") else ""
-        except Exception:
+        except json.JSONDecodeError:
             text = raw
     original = text or ""
     # Normalize CR-only to LF and remove BOM if present
@@ -118,9 +114,7 @@ def main() -> None:
         rebuilt = s
         for m in markers:
             # replace occurrences not already preceded by newline
-            rebuilt = re.sub(
-                rf"(?<!\n){re.escape(m)}", "\n" + m.strip() + "\n", rebuilt
-            )
+            rebuilt = re.sub(rf"(?<!\n){re.escape(m)}", "\n" + m.strip() + "\n", rebuilt)
         if rebuilt != s:
             applied.append("sections")
         return rebuilt
@@ -170,9 +164,7 @@ def main() -> None:
     if text.strip():
         OUT_FILE.write_text(text + "\n", encoding="utf-8")
     # Always write diagnostics when debug artifact collection might happen
-    Path("decode_debug.json").write_text(
-        json.dumps(diagnostics, indent=2), encoding="utf-8"
-    )
+    Path("decode_debug.json").write_text(json.dumps(diagnostics, indent=2), encoding="utf-8")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/parse_chatgpt_topics.py
+++ b/.github/scripts/parse_chatgpt_topics.py
@@ -25,9 +25,7 @@ ALLOW_FALLBACK = os.environ.get("ALLOW_SINGLE_TOPIC", "0") in {"1", "true", "Tru
 def _load_text() -> str:
     try:
         text = INPUT_PATH.read_text(encoding="utf-8").strip()
-    except (
-        FileNotFoundError
-    ) as exc:  # pragma: no cover - guardrail for workflow execution
+    except FileNotFoundError as exc:  # pragma: no cover - guardrail for workflow execution
         raise SystemExit("No input.txt found to parse.") from exc
     if not text:
         raise SystemExit("No topic content provided.")
@@ -46,9 +44,7 @@ def _split_numbered_items(text: str) -> list[dict[str, str | list[str] | bool]]:
     Each returned item dict includes:
       title, lines, enumerator, continuity_break (bool)
     """
-    pattern = re.compile(
-        r"^\s*(?P<enum>(?:\d+|[A-Za-z]\d+|[A-Za-z]))[\).:\-]\s+(?P<title>.+)$"
-    )
+    pattern = re.compile(r"^\s*(?P<enum>(?:\d+|[A-Za-z]\d+|[A-Za-z]))[\).:\-]\s+(?P<title>.+)$")
     items: list[dict[str, str | list[str] | bool]] = []
     current: dict[str, str | list[str] | bool] | None = None
     style: str | None = None  # 'numeric' | 'alpha' | 'alphanum'
@@ -85,7 +81,7 @@ def _split_numbered_items(text: str) -> list[dict[str, str | list[str] | bool]]:
         if m:
             token = m.group("enum")
             title = m.group("title").strip()
-            # Clean simple markdown emphasis and stray trailing punctuation that harms GUID stability
+            # Clean markdown emphasis and trailing punctuation for GUID stability
             title = re.sub(r"^[*_`]+|[*_`]+$", "", title).strip()
             title = title.rstrip(". ")
             if current:
@@ -174,9 +170,7 @@ def _join_section(lines: list[str]) -> str:
     return "\n".join(lines).strip()
 
 
-def parse_text(
-    text: str, *, allow_single_fallback: bool = False
-) -> list[dict[str, object]]:
+def parse_text(text: str, *, allow_single_fallback: bool = False) -> list[dict[str, object]]:
     """Parse raw *text* into topic dictionaries.
 
     Parameters
@@ -213,7 +207,7 @@ def parse_text(
         else:
             raw_lines = []
         labels, sections, extras = _parse_sections(raw_lines)
-        data = {
+        data: dict[str, object] = {
             "title": str(item.get("title", "")).strip(),
             "labels": labels,
             "sections": {key: _join_section(value) for key, value in sections.items()},
@@ -221,7 +215,7 @@ def parse_text(
             "enumerator": item.get("enumerator"),
             "continuity_break": bool(item.get("continuity_break", False)),
         }
-        normalized_title = re.sub(r"\s+", " ", data["title"].strip().lower())
+        normalized_title = re.sub(r"\s+", " ", str(data["title"]).strip().lower())
         data["guid"] = str(uuid.uuid5(uuid.NAMESPACE_DNS, normalized_title))
         parsed.append(data)
     return parsed

--- a/.github/workflows/agents-63-issue-intake.yml
+++ b/.github/workflows/agents-63-issue-intake.yml
@@ -1176,5 +1176,5 @@ jobs:
       post_agent_comment: ${{ needs.normalize_inputs.outputs.post_codex_comment }}
       agent_pr_draft: ${{ needs.normalize_inputs.outputs.bridge_draft_pr }}
     secrets:
-      service_bot_pat: ${{ secrets.service_bot_pat }}
-      owner_pr_pat: ${{ secrets.owner_pr_pat }}
+      service_bot_pat: ${{ secrets.SERVICE_BOT_PAT }}
+      owner_pr_pat: ${{ secrets.OWNER_PR_PAT }}

--- a/.github/workflows/agents-bot-comment-handler.yml
+++ b/.github/workflows/agents-bot-comment-handler.yml
@@ -1,0 +1,178 @@
+# Bot Comment Handler - Thin caller for consumer repos
+#
+# Addresses unresolved review comments from bots (Copilot, CodeRabbit, etc.)
+# by dispatching the configured agent to fix them.
+#
+# Triggers:
+# - PR labeled with 'autofix:bot-comments' (manual trigger)
+# - Gate workflow completion (automatic for agent PRs)
+# - Manual dispatch for testing
+#
+# Agent selection:
+# - Uses PR's agent:* label (agent:codex, agent:claude, etc.)
+# - Falls back to Codex if no agent label
+#
+# Workflow file: .github/workflows/agents-bot-comment-handler.yml
+
+name: Agents Bot Comment Handler
+
+on:
+  # Manual trigger via label
+  pull_request:
+    types: [labeled]
+  
+  # Automatic trigger after Gate completes (for agent PRs)
+  # Note: branches-ignore is not supported for workflow_run, filtering is done in job logic
+  workflow_run:
+    workflows: ["Gate"]
+    types: [completed]
+  
+  # Manual dispatch for testing
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to process'
+        required: true
+        type: string
+      dry_run:
+        description: 'Preview without making changes'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  actions: read
+
+concurrency:
+  group: bot-comments-${{ github.event.pull_request.number || github.event.workflow_run.pull_requests[0].number || inputs.pr_number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  # Resolve PR number from different trigger types
+  resolve:
+    name: Resolve PR
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.resolve.outputs.pr_number }}
+      should_run: ${{ steps.resolve.outputs.should_run }}
+    steps:
+      - name: Resolve PR number and check conditions
+        id: resolve
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const eventName = context.eventName;
+            let prNumber = null;
+            let shouldRun = false;
+            
+            if (eventName === 'workflow_dispatch') {
+              prNumber = '${{ inputs.pr_number }}';
+              shouldRun = true;
+              console.log(`Manual dispatch for PR #${prNumber}`);
+            }
+            else if (eventName === 'pull_request') {
+              // Only run if labeled with autofix:bot-comments
+              const label = context.payload.label?.name;
+              if (label === 'autofix:bot-comments') {
+                prNumber = context.payload.pull_request.number;
+                shouldRun = true;
+                console.log(`Label trigger for PR #${prNumber}`);
+              } else {
+                console.log(`Ignoring label: ${label}`);
+              }
+            }
+            else if (eventName === 'workflow_run') {
+              // Only run if Gate succeeded and PR has agent:* label
+              const workflowRun = context.payload.workflow_run;
+              
+              // Skip main branch
+              if (workflowRun.head_branch === 'main') {
+                console.log('Skipping main branch');
+                core.setOutput('should_run', 'false');
+                return;
+              }
+              
+              if (workflowRun.conclusion !== 'success') {
+                console.log(`Gate did not succeed (${workflowRun.conclusion}), skipping`);
+                core.setOutput('should_run', 'false');
+                return;
+              }
+              
+              // Get PR from workflow run
+              const prs = workflowRun.pull_requests;
+              if (!prs || prs.length === 0) {
+                console.log('No PR associated with workflow run');
+                core.setOutput('should_run', 'false');
+                return;
+              }
+              
+              prNumber = prs[0].number;
+              
+              // Check if PR has agent label
+              let pr;
+              try {
+                const response = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: prNumber
+                });
+                pr = response.data;
+              } catch (error) {
+                console.log(`Failed to fetch PR #${prNumber} details, skipping. Error: ${error.message || error}`);
+                core.setOutput('should_run', 'false');
+                return;
+              }
+              
+              const hasAgentLabel = pr.labels.some(l => /^agent:/.test(l.name));
+              if (!hasAgentLabel) {
+                console.log(`PR #${prNumber} has no agent label, skipping`);
+                core.setOutput('should_run', 'false');
+                return;
+              }
+              
+              shouldRun = true;
+              console.log(`Gate completion trigger for agent PR #${prNumber}`);
+            }
+            
+            core.setOutput('pr_number', prNumber || '');
+            core.setOutput('should_run', shouldRun ? 'true' : 'false');
+
+  # Call the reusable workflow
+  handle:
+    name: Handle bot comments
+    needs: resolve
+    if: needs.resolve.outputs.should_run == 'true'
+    uses: stranske/Workflows/.github/workflows/reusable-bot-comment-handler.yml@main
+    with:
+      pr_number: ${{ needs.resolve.outputs.pr_number }}
+      dry_run: ${{ inputs.dry_run == true }}
+    secrets:
+      service_bot_pat: ${{ secrets.SERVICE_BOT_PAT }}
+      gh_app_id: ${{ secrets.GH_APP_ID }}
+      gh_app_private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+  # Remove the trigger label after processing
+  cleanup:
+    name: Cleanup
+    needs: [resolve, handle]
+    if: always() && github.event_name == 'pull_request' && github.event.label.name == 'autofix:bot-comments'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove trigger label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                name: 'autofix:bot-comments'
+              });
+              console.log('Removed autofix:bot-comments label');
+            } catch (error) {
+              console.log(`Could not remove label: ${error.message}`);
+            }

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -106,3 +106,5 @@ jobs:
       caller_actor: ${{ needs.resolve.outputs.caller_actor }}
     secrets:
       service_bot_pat: ${{ secrets.SERVICE_BOT_PAT }}
+      WORKFLOWS_APP_ID: ${{ secrets.WORKFLOWS_APP_ID }}
+      WORKFLOWS_APP_PRIVATE_KEY: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Workflow Sync

    This PR updates thin caller workflows to match the latest templates from [stranske/Workflows](https://github.com/stranske/Workflows).

    **Template hash:** `350c764eb43c`

    ### Changed files
     agents-orchestrator.yml autofix.yml agents-63-issue-intake.yml scripts/decode_raw_input.py scripts/parse_chatgpt_topics.py .gitignore

    ### What changed
    - Thin caller workflows (triggers/permissions) updated
    - Tool version pins may be updated
    - No changes to your repo-specific code

    ### Review checklist
    - [ ] No repo-specific customizations were overwritten
    - [ ] CI passes with new workflow versions

    ---
    *Automated by [Maint 68 Sync Consumer Repos](https://github.com/stranske/Workflows/actions/workflows/maint-68-sync-consumer-repos.yml)*