### PR TITLE
chore: add .github/CODEOWNERS for agents-guard compatibility

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+/schemas/            @stranske
+/docs/policy-lite-checklist.md  @stranske
+/docs/field-mapping.md          @stranske
+/docs/workflows.md              @stranske
+/policy/             @stranske
+/mapping/            @stranske
+/.github/workflows/**          @stranske


### PR DESCRIPTION
The agents-guard workflow looks for CODEOWNERS at `.github/CODEOWNERS` but the file was only at the root. This copy ensures the guard can properly validate CODEOWNER approvals for protected workflow changes.

This fixes the guard failing to find CODEOWNERS when validating Dependabot PRs like #180.

<!-- pr-preamble:start -->
> **Source:** Issue #180

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
_Scope section missing from source issue._

#### Tasks
- [ ] Tasks section missing from source issue.

#### Acceptance criteria
- [ ] Acceptance criteria section missing from source issue.

**Head SHA:** a5843b2b51491e72bbe37d61ef6695f12b7366eb
**Latest Runs:** ⏳ queued — Gate
**Required:** gate: ⏳ queued

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/20643928422) |
| Autofix | ⏳ queued | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/20643928387) |
| CI | ⏳ queued | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/20643928380) |
| Copilot code review | ⏳ queued | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/20643929399) |
| Gate | ⏳ queued | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/20643928411) |
| Health 45 Agents Guard | ❔ in progress | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/20643928352) |
<!-- auto-status-summary:end -->