### PR TITLE
fix: ensure chatgpt-sync inputs are strings

### DIFF
--- a/.github/workflows/agents-chatgpt-sync.yml
+++ b/.github/workflows/agents-chatgpt-sync.yml
@@ -53,11 +53,11 @@ jobs:
     uses: stranske/Workflows/.github/workflows/agents-63-issue-intake.yml@main
     with:
       intake_mode: "chatgpt_sync"
-      source: ${{ inputs.source }}
-      raw_input: ${{ inputs.raw_input }}
-      source_url: ${{ inputs.source_url }}
-      apply_langchain_formatting: ${{ inputs.apply_langchain_formatting && 'true' || 'false' }}
-      debug: ${{ inputs.debug && 'true' || 'false' }}
+      source: ${{ inputs.source || '' }}
+      raw_input: ${{ inputs.raw_input || '' }}
+      source_url: ${{ inputs.source_url || '' }}
+      apply_langchain_formatting: ${{ inputs.apply_langchain_formatting == true && 'true' || 'false' }}
+      debug: ${{ inputs.debug == true && 'true' || 'false' }}
     secrets:
       service_bot_pat: ${{ secrets.SERVICE_BOT_PAT }}
       owner_pr_pat: ${{ secrets.OWNER_PR_PAT }}


### PR DESCRIPTION
## Problem

The chatgpt-sync workflow failed because the reusable workflow expects string types for all `workflow_call` inputs.

## Solution

- Use explicit `== true` check for boolean comparisons
- Use `|| ''` to ensure empty strings instead of null for optional inputs

This ensures compatibility with the Workflows repo reusable workflow which has string-typed inputs for `workflow_call`.