### PR TITLE
fix: remove permissions blocks from chatgpt-sync workflow

### DIFF
--- a/.github/workflows/agents-chatgpt-sync.yml
+++ b/.github/workflows/agents-chatgpt-sync.yml
@@ -40,14 +40,6 @@ on:
         type: boolean
         default: false
 
-permissions:
-  contents: read
-  issues: write
-
-concurrency:
-  group: chatgpt-sync-${{ github.run_id }}
-  cancel-in-progress: false
-
 jobs:
   sync:
     uses: stranske/Workflows/.github/workflows/agents-63-issue-intake.yml@main


### PR DESCRIPTION
## Problem

The chatgpt-sync workflow was failing with startup_failure because reusable workflows don't inherit permissions from the caller - they use the permissions defined in the reusable workflow itself.

## Solution

Removed  and  blocks from the caller workflow to match the working test workflow configuration.

## Testing

The test workflow without these blocks works successfully and creates issues.