### PR TITLE
chore(format): bootstrap PR for issue #296

### DIFF
--- a/Issues.txt
+++ b/Issues.txt
@@ -64,6 +64,7 @@ Tasks
 
 - [x] Replace Path fields in state with str (or structured artifact metadata objects that serialize cleanly).
 - [x] Decide how to represent plan data in state (Option B: store plan_json dict + validate/construct TripPlan at node boundaries).
+- [x] Coerce assigned state models back into JSON-safe dicts.
 - [x] Ensure canonical intake representation in state is also JSON-safe (dict or pydantic model dump).
 - [x] Add a test asserting json.dumps(state.model_dump(mode="json")) succeeds for a “realistic” run.
 

--- a/Issues.txt
+++ b/Issues.txt
@@ -62,17 +62,12 @@ Refactoring the entire policy layer.
 
 Tasks
 
- Replace Path fields in state with str (or structured artifact metadata objects that serialize cleanly).
-
- Decide how to represent plan data in state:
-
-Option A: keep TripPlan but ensure dumps are JSON-safe, or
-
-Option B: store plan_json dict + validate/construct TripPlan at node boundaries.
-
- Ensure canonical intake representation in state is also JSON-safe (dict or pydantic model dump).
-
- Add a test asserting json.dumps(state.model_dump(mode="json")) succeeds for a “realistic” run.
+- [x] Replace Path fields in state with str (or structured artifact metadata objects that serialize cleanly).
+- [x] Decide how to represent plan data in state:
+- [ ] Option A: keep TripPlan but ensure dumps are JSON-safe, or
+- [x] Option B: store plan_json dict + validate/construct TripPlan at node boundaries.
+- [x] Ensure canonical intake representation in state is also JSON-safe (dict or pydantic model dump).
+- [x] Add a test asserting json.dumps(state.model_dump(mode="json")) succeeds for a “realistic” run.
 
 Acceptance Criteria
 

--- a/Issues.txt
+++ b/Issues.txt
@@ -63,9 +63,7 @@ Refactoring the entire policy layer.
 Tasks
 
 - [x] Replace Path fields in state with str (or structured artifact metadata objects that serialize cleanly).
-- [x] Decide how to represent plan data in state:
-- [ ] Option A: keep TripPlan but ensure dumps are JSON-safe, or
-- [x] Option B: store plan_json dict + validate/construct TripPlan at node boundaries.
+- [x] Decide how to represent plan data in state (Option B: store plan_json dict + validate/construct TripPlan at node boundaries).
 - [x] Ensure canonical intake representation in state is also JSON-safe (dict or pydantic model dump).
 - [x] Add a test asserting json.dumps(state.model_dump(mode="json")) succeeds for a “realistic” run.
 

--- a/agents/format-296.md
+++ b/agents/format-296.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for format on issue #296 -->

--- a/src/travel_plan_permission/orchestration/example.py
+++ b/src/travel_plan_permission/orchestration/example.py
@@ -97,7 +97,7 @@ def main() -> int:
     if state.policy_result is None:
         raise RuntimeError("No policy result returned from orchestration graph.")
 
-    print(f"Policy status: {state.policy_result.status}")
+    print(f"Policy status: {state.policy_result['status']}")
     print(f"Spreadsheet: {state.spreadsheet_path}")
     return 0
 

--- a/src/travel_plan_permission/orchestration/graph.py
+++ b/src/travel_plan_permission/orchestration/graph.py
@@ -70,6 +70,14 @@ class TripState(BaseModel):
             return value.model_dump(mode="json")
         return value  # type: ignore[return-value]
 
+    @field_serializer("policy_result", mode="plain")
+    def _serialize_policy_result(self, value: object) -> dict[str, object] | None:
+        if value is None:
+            return None
+        if isinstance(value, PolicyCheckResult):
+            return value.model_dump(mode="json")
+        return PolicyCheckResult.model_validate(value).model_dump(mode="json")
+
     @field_serializer("spreadsheet_path", mode="plain")
     def _serialize_spreadsheet_path(self, value: object) -> str | None:
         if isinstance(value, Path):

--- a/src/travel_plan_permission/orchestration/graph.py
+++ b/src/travel_plan_permission/orchestration/graph.py
@@ -150,7 +150,7 @@ class _SimplePolicyGraph:
 
 def _build_langgraph() -> PolicyGraph | None:
     try:
-        from langgraph.graph import END, StateGraph  
+        from langgraph.graph import END, StateGraph
     except ImportError:
         return None
 

--- a/src/travel_plan_permission/orchestration/graph.py
+++ b/src/travel_plan_permission/orchestration/graph.py
@@ -32,6 +32,8 @@ class TripState(BaseModel):
     def _coerce_plan(cls, value: object) -> dict[str, object]:
         if isinstance(value, TripPlan):
             return value.model_dump(mode="json")
+        if isinstance(value, dict):
+            return TripPlan.model_validate(value).model_dump(mode="json")
         return value  # type: ignore[return-value]
 
     @field_validator("canonical_plan", mode="before")
@@ -41,6 +43,8 @@ class TripState(BaseModel):
             return None
         if isinstance(value, CanonicalTripPlan):
             return value.model_dump(mode="json")
+        if isinstance(value, dict):
+            return CanonicalTripPlan.model_validate(value).model_dump(mode="json")
         return value  # type: ignore[return-value]
 
     @field_validator("spreadsheet_path", mode="before")

--- a/src/travel_plan_permission/orchestration/graph.py
+++ b/src/travel_plan_permission/orchestration/graph.py
@@ -125,9 +125,9 @@ def run_policy_graph(
     graph = build_policy_graph(prefer_langgraph=prefer_langgraph)
     state = TripState(
         plan=plan.model_dump(mode="json"),
-        canonical_plan=canonical_plan.model_dump(mode="json")
-        if canonical_plan is not None
-        else None,
+        canonical_plan=(
+            canonical_plan.model_dump(mode="json") if canonical_plan is not None else None
+        ),
         spreadsheet_path=spreadsheet_path,
     )
     return graph.invoke(state)

--- a/src/travel_plan_permission/orchestration/graph.py
+++ b/src/travel_plan_permission/orchestration/graph.py
@@ -21,13 +21,13 @@ from ..policy_api import (
 class TripState(BaseModel):
     """State container for the orchestration flow."""
 
-    plan: dict[str, object]
+    plan_json: dict[str, object]
     canonical_plan: dict[str, object] | None = None
     policy_result: PolicyCheckResult | None = None
     spreadsheet_path: str | None = None
     errors: list[str] = Field(default_factory=list)
 
-    @field_validator("plan", mode="before")
+    @field_validator("plan_json", mode="before")
     @classmethod
     def _coerce_plan(cls, value: object) -> dict[str, object]:
         if isinstance(value, TripPlan):
@@ -56,7 +56,7 @@ def _default_spreadsheet_path(plan: TripPlan) -> Path:
 
 
 def _load_plan(state: TripState) -> TripPlan:
-    return TripPlan.model_validate(state.plan)
+    return TripPlan.model_validate(state.plan_json)
 
 
 def _load_canonical_plan(state: TripState) -> CanonicalTripPlan | None:
@@ -140,7 +140,7 @@ def run_policy_graph(
     spreadsheet_path = str(Path(output_path)) if output_path is not None else None
     graph = build_policy_graph(prefer_langgraph=prefer_langgraph)
     state = TripState(
-        plan=plan.model_dump(mode="json"),
+        plan_json=plan.model_dump(mode="json"),
         canonical_plan=(
             canonical_plan.model_dump(mode="json") if canonical_plan is not None else None
         ),

--- a/src/travel_plan_permission/orchestration/graph.py
+++ b/src/travel_plan_permission/orchestration/graph.py
@@ -43,6 +43,15 @@ class TripState(BaseModel):
             return value.model_dump(mode="json")
         return value  # type: ignore[return-value]
 
+    @field_validator("spreadsheet_path", mode="before")
+    @classmethod
+    def _coerce_spreadsheet_path(cls, value: object) -> str | None:
+        if value is None:
+            return None
+        if isinstance(value, Path):
+            return str(value)
+        return value  # type: ignore[return-value]
+
 
 class PolicyGraph(Protocol):
     """Minimal interface for invoking orchestration graphs."""

--- a/src/travel_plan_permission/orchestration/graph.py
+++ b/src/travel_plan_permission/orchestration/graph.py
@@ -6,7 +6,7 @@ import tempfile
 from pathlib import Path
 from typing import Protocol
 
-from pydantic import BaseModel, Field, field_serializer, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator
 
 from ..canonical import CanonicalTripPlan
 from ..models import TripPlan
@@ -20,6 +20,8 @@ from ..policy_api import (
 
 class TripState(BaseModel):
     """State container for the orchestration flow."""
+
+    model_config = ConfigDict(validate_assignment=True)
 
     plan_json: dict[str, object]
     canonical_plan: dict[str, object] | None = None

--- a/src/travel_plan_permission/orchestration/graph.py
+++ b/src/travel_plan_permission/orchestration/graph.py
@@ -70,6 +70,12 @@ class TripState(BaseModel):
             return value.model_dump(mode="json")
         return value  # type: ignore[return-value]
 
+    @field_serializer("spreadsheet_path", mode="plain")
+    def _serialize_spreadsheet_path(self, value: object) -> str | None:
+        if isinstance(value, Path):
+            return str(value)
+        return value  # type: ignore[return-value]
+
 
 class PolicyGraph(Protocol):
     """Minimal interface for invoking orchestration graphs."""

--- a/src/travel_plan_permission/orchestration/graph.py
+++ b/src/travel_plan_permission/orchestration/graph.py
@@ -150,7 +150,7 @@ class _SimplePolicyGraph:
 
 def _build_langgraph() -> PolicyGraph | None:
     try:
-        from langgraph.graph import END, StateGraph
+        from langgraph.graph import END, StateGraph  # type: ignore[import-not-found]
     except ImportError:
         return None
 
@@ -160,7 +160,7 @@ def _build_langgraph() -> PolicyGraph | None:
     graph.add_edge("policy_check", "spreadsheet")
     graph.add_edge("spreadsheet", END)
     graph.set_entry_point("policy_check")
-    return graph.compile()  # type: ignore[return-value]
+    return graph.compile()  # type: ignore[no-any-return,return-value]
 
 
 def build_policy_graph(*, prefer_langgraph: bool = True) -> PolicyGraph:

--- a/src/travel_plan_permission/orchestration/graph.py
+++ b/src/travel_plan_permission/orchestration/graph.py
@@ -6,7 +6,7 @@ import tempfile
 from pathlib import Path
 from typing import Protocol
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_serializer, field_validator
 
 from ..canonical import CanonicalTripPlan
 from ..models import TripPlan
@@ -54,6 +54,18 @@ class TripState(BaseModel):
             return None
         if isinstance(value, Path):
             return str(value)
+        return value  # type: ignore[return-value]
+
+    @field_serializer("plan_json", mode="plain")
+    def _serialize_plan(self, value: object) -> dict[str, object]:
+        if isinstance(value, TripPlan):
+            return value.model_dump(mode="json")
+        return value  # type: ignore[return-value]
+
+    @field_serializer("canonical_plan", mode="plain")
+    def _serialize_canonical_plan(self, value: object) -> dict[str, object] | None:
+        if isinstance(value, CanonicalTripPlan):
+            return value.model_dump(mode="json")
         return value  # type: ignore[return-value]
 
 

--- a/src/travel_plan_permission/orchestration/graph.py
+++ b/src/travel_plan_permission/orchestration/graph.py
@@ -160,7 +160,7 @@ def _build_langgraph() -> PolicyGraph | None:
     graph.add_edge("policy_check", "spreadsheet")
     graph.add_edge("spreadsheet", END)
     graph.set_entry_point("policy_check")
-    return graph.compile()  # type: ignore[no-any-return,return-value]
+    return graph.compile()  # type: ignore[no-any-return]
 
 
 def build_policy_graph(*, prefer_langgraph: bool = True) -> PolicyGraph:

--- a/src/travel_plan_permission/orchestration/graph.py
+++ b/src/travel_plan_permission/orchestration/graph.py
@@ -111,7 +111,8 @@ def _load_canonical_plan(state: TripState) -> CanonicalTripPlan | None:
 
 def _policy_check_node(state: TripState) -> TripState:
     plan = _load_plan(state)
-    state.policy_result = check_trip_plan(plan)
+    result = check_trip_plan(plan)
+    state.policy_result = result.model_dump(mode="json")
     return state
 
 
@@ -149,7 +150,7 @@ class _SimplePolicyGraph:
 
 def _build_langgraph() -> PolicyGraph | None:
     try:
-        from langgraph.graph import END, StateGraph  # type: ignore[import-not-found]
+        from langgraph.graph import END, StateGraph  
     except ImportError:
         return None
 
@@ -159,7 +160,7 @@ def _build_langgraph() -> PolicyGraph | None:
     graph.add_edge("policy_check", "spreadsheet")
     graph.add_edge("spreadsheet", END)
     graph.set_entry_point("policy_check")
-    return graph.compile()  # type: ignore[no-any-return]
+    return graph.compile()  # type: ignore[return-value]
 
 
 def build_policy_graph(*, prefer_langgraph: bool = True) -> PolicyGraph:

--- a/tests/python/test_orchestration_canonical_spreadsheet.py
+++ b/tests/python/test_orchestration_canonical_spreadsheet.py
@@ -21,7 +21,7 @@ def test_policy_graph_retains_canonical_fields(tmp_path: Path) -> None:
         prefer_langgraph=False,
     )
 
-    assert state.spreadsheet_path == output_path
+    assert state.spreadsheet_path == str(output_path)
 
     workbook = load_workbook(output_path)
     sheet = workbook.active
@@ -31,3 +31,21 @@ def test_policy_graph_retains_canonical_fields(tmp_path: Path) -> None:
     assert sheet["B12"].value == "88 Mission St"
     assert sheet["D12"].value == "San Francisco, CA"
     workbook.close()
+
+
+def test_policy_graph_state_is_json_serializable(tmp_path: Path) -> None:
+    fixture_path = (
+        Path(__file__).resolve().parents[1] / "fixtures" / "canonical_trip_plan_realistic.json"
+    )
+    payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    trip_input = load_trip_plan_input(payload)
+
+    output_path = tmp_path / "travel_request.xlsx"
+    state = run_policy_graph(
+        trip_input.plan,
+        canonical_plan=trip_input.canonical,
+        output_path=output_path,
+        prefer_langgraph=False,
+    )
+
+    json.dumps(state.model_dump(mode="json"))

--- a/tests/python/test_orchestration_smoke.py
+++ b/tests/python/test_orchestration_smoke.py
@@ -22,5 +22,5 @@ def test_policy_graph_smoke(tmp_path: Path) -> None:
 
     assert state.policy_result is not None
     assert state.policy_result.status == "fail"
-    assert state.spreadsheet_path == output_path
+    assert state.spreadsheet_path == str(output_path)
     assert output_path.exists()

--- a/tests/python/test_orchestration_smoke.py
+++ b/tests/python/test_orchestration_smoke.py
@@ -1,3 +1,4 @@
+import json
 from datetime import date
 from decimal import Decimal
 from pathlib import Path
@@ -24,3 +25,4 @@ def test_policy_graph_smoke(tmp_path: Path) -> None:
     assert state.policy_result.status == "fail"
     assert state.spreadsheet_path == str(output_path)
     assert output_path.exists()
+    json.dumps(state.model_dump(mode="json"))

--- a/tests/python/test_orchestration_smoke.py
+++ b/tests/python/test_orchestration_smoke.py
@@ -25,4 +25,7 @@ def test_policy_graph_smoke(tmp_path: Path) -> None:
     assert state.policy_result.status == "fail"
     assert state.spreadsheet_path == str(output_path)
     assert output_path.exists()
-    json.dumps(state.model_dump(mode="json"))
+    serialized = state.model_dump(mode="json")
+    assert isinstance(serialized["policy_result"], dict)
+    assert serialized["policy_result"]["status"] == "fail"
+    json.dumps(serialized)

--- a/tests/python/test_orchestration_smoke.py
+++ b/tests/python/test_orchestration_smoke.py
@@ -22,7 +22,8 @@ def test_policy_graph_smoke(tmp_path: Path) -> None:
     state = run_policy_graph(plan, output_path=output_path, prefer_langgraph=False)
 
     assert state.policy_result is not None
-    assert state.policy_result.status == "fail"
+    assert isinstance(state.policy_result, dict)
+    assert state.policy_result["status"] == "fail"
     assert state.spreadsheet_path == str(output_path)
     assert output_path.exists()
     serialized = state.model_dump(mode="json")

--- a/tests/python/test_orchestration_state_serialization.py
+++ b/tests/python/test_orchestration_state_serialization.py
@@ -1,0 +1,21 @@
+import json
+from pathlib import Path
+
+from travel_plan_permission.canonical import load_trip_plan_input
+from travel_plan_permission.orchestration import TripState
+
+
+def test_trip_state_coerces_plans_to_json(tmp_path: Path) -> None:
+    fixture_path = (
+        Path(__file__).resolve().parents[1] / "fixtures" / "canonical_trip_plan_realistic.json"
+    )
+    payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    trip_input = load_trip_plan_input(payload)
+
+    state = TripState(
+        plan=trip_input.plan,
+        canonical_plan=trip_input.canonical,
+        spreadsheet_path=str(tmp_path / "travel_request.xlsx"),
+    )
+
+    json.dumps(state.model_dump(mode="json"))

--- a/tests/python/test_orchestration_state_serialization.py
+++ b/tests/python/test_orchestration_state_serialization.py
@@ -13,7 +13,7 @@ def test_trip_state_coerces_plans_to_json(tmp_path: Path) -> None:
     trip_input = load_trip_plan_input(payload)
 
     state = TripState(
-        plan=trip_input.plan,
+        plan_json=trip_input.plan,
         canonical_plan=trip_input.canonical,
         spreadsheet_path=str(tmp_path / "travel_request.xlsx"),
     )

--- a/tests/python/test_orchestration_state_serialization.py
+++ b/tests/python/test_orchestration_state_serialization.py
@@ -64,4 +64,6 @@ def test_trip_state_serializes_assigned_models(tmp_path: Path) -> None:
     state.plan_json = trip_input.plan
     state.canonical_plan = trip_input.canonical
 
+    assert isinstance(state.plan_json, dict)
+    assert isinstance(state.canonical_plan, dict)
     json.dumps(state.model_dump(mode="json"))

--- a/tests/python/test_orchestration_state_serialization.py
+++ b/tests/python/test_orchestration_state_serialization.py
@@ -43,3 +43,25 @@ def test_trip_state_coerces_dict_plans_to_json(tmp_path: Path) -> None:
     assert isinstance(state.plan_json, dict)
     assert isinstance(state.canonical_plan, dict)
     json.dumps(state.model_dump(mode="json"))
+
+
+def test_trip_state_serializes_assigned_models(tmp_path: Path) -> None:
+    fixture_path = (
+        Path(__file__).resolve().parents[1] / "fixtures" / "canonical_trip_plan_realistic.json"
+    )
+    payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    trip_input = load_trip_plan_input(payload)
+    spreadsheet_path = tmp_path / "travel_request.xlsx"
+
+    state = TripState(
+        plan_json=trip_input.plan.model_dump(mode="json"),
+        canonical_plan=(
+            trip_input.canonical.model_dump(mode="json") if trip_input.canonical else None
+        ),
+        spreadsheet_path=spreadsheet_path,
+    )
+
+    state.plan_json = trip_input.plan
+    state.canonical_plan = trip_input.canonical
+
+    json.dumps(state.model_dump(mode="json"))

--- a/tests/python/test_orchestration_state_serialization.py
+++ b/tests/python/test_orchestration_state_serialization.py
@@ -19,5 +19,7 @@ def test_trip_state_coerces_plans_to_json(tmp_path: Path) -> None:
         spreadsheet_path=spreadsheet_path,
     )
 
+    assert isinstance(state.plan_json, dict)
+    assert isinstance(state.canonical_plan, dict)
     assert state.spreadsheet_path == str(spreadsheet_path)
     json.dumps(state.model_dump(mode="json"))

--- a/tests/python/test_orchestration_state_serialization.py
+++ b/tests/python/test_orchestration_state_serialization.py
@@ -23,3 +23,23 @@ def test_trip_state_coerces_plans_to_json(tmp_path: Path) -> None:
     assert isinstance(state.canonical_plan, dict)
     assert state.spreadsheet_path == str(spreadsheet_path)
     json.dumps(state.model_dump(mode="json"))
+
+
+def test_trip_state_coerces_dict_plans_to_json(tmp_path: Path) -> None:
+    fixture_path = (
+        Path(__file__).resolve().parents[1] / "fixtures" / "canonical_trip_plan_realistic.json"
+    )
+    payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    trip_input = load_trip_plan_input(payload)
+    assert trip_input.canonical is not None
+    spreadsheet_path = tmp_path / "travel_request.xlsx"
+
+    state = TripState(
+        plan_json=trip_input.plan.model_dump(),
+        canonical_plan=trip_input.canonical.model_dump(),
+        spreadsheet_path=spreadsheet_path,
+    )
+
+    assert isinstance(state.plan_json, dict)
+    assert isinstance(state.canonical_plan, dict)
+    json.dumps(state.model_dump(mode="json"))

--- a/tests/python/test_orchestration_state_serialization.py
+++ b/tests/python/test_orchestration_state_serialization.py
@@ -11,11 +11,13 @@ def test_trip_state_coerces_plans_to_json(tmp_path: Path) -> None:
     )
     payload = json.loads(fixture_path.read_text(encoding="utf-8"))
     trip_input = load_trip_plan_input(payload)
+    spreadsheet_path = tmp_path / "travel_request.xlsx"
 
     state = TripState(
         plan_json=trip_input.plan,
         canonical_plan=trip_input.canonical,
-        spreadsheet_path=str(tmp_path / "travel_request.xlsx"),
+        spreadsheet_path=spreadsheet_path,
     )
 
+    assert state.spreadsheet_path == str(spreadsheet_path)
     json.dumps(state.model_dump(mode="json"))

--- a/tests/python/test_orchestration_state_serialization.py
+++ b/tests/python/test_orchestration_state_serialization.py
@@ -67,3 +67,25 @@ def test_trip_state_serializes_assigned_models(tmp_path: Path) -> None:
     assert isinstance(state.plan_json, dict)
     assert isinstance(state.canonical_plan, dict)
     json.dumps(state.model_dump(mode="json"))
+
+
+def test_trip_state_coerces_assigned_spreadsheet_path(tmp_path: Path) -> None:
+    fixture_path = (
+        Path(__file__).resolve().parents[1] / "fixtures" / "canonical_trip_plan_realistic.json"
+    )
+    payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    trip_input = load_trip_plan_input(payload)
+    spreadsheet_path = tmp_path / "travel_request.xlsx"
+
+    state = TripState(
+        plan_json=trip_input.plan.model_dump(mode="json"),
+        canonical_plan=(
+            trip_input.canonical.model_dump(mode="json") if trip_input.canonical else None
+        ),
+        spreadsheet_path=str(spreadsheet_path),
+    )
+
+    state.spreadsheet_path = spreadsheet_path
+
+    assert state.spreadsheet_path == str(spreadsheet_path)
+    json.dumps(state.model_dump(mode="json"))


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Current TripState contains Path and a full TripPlan object. That’s fine for a demo, but it becomes annoying when you want checkpointing, persistence, or tooling that expects JSON-serializable state.

#### Tasks
- [x] Replace Path fields in state with str (or structured artifact metadata objects that serialize cleanly).
- [x] Decide how to represent plan data in state:
- [x] - Option A: keep TripPlan but ensure dumps are JSON-safe, or
- [x] - Option B: store plan_json dict + validate/construct TripPlan at node boundaries.
- [x] Ensure canonical intake representation in state is also JSON-safe (dict or pydantic model dump).
- [x] Add a test asserting json.dumps(state.model_dump(mode="json")) succeeds for a “realistic” run.

#### Acceptance criteria
- [x] TripState.model_dump(mode="json") produces JSON-serializable output (no TypeError on json.dumps(...)).
- [x] No Path objects or other arbitrary types remain in state.
- [x] CI passes.

<!-- auto-status-summary:end -->

### Source Issue #296: Orchestration: make graph state JSON-serializable (checkpoint-friendly)

Base: main
Head: codex/issue-296

Source: https://github.com/stranske/Travel-Plan-Permission/issues/296

### Issue Details

## Why
Current TripState contains Path and a full TripPlan object. That’s fine for a demo, but it becomes annoying when you want checkpointing, persistence, or tooling that expects JSON-serializable state.

## Scope
Make orchestration state safe to serialize via model_dump(mode="json") and json.dumps(...).

Avoid non-JSON-native types in state (Path, raw Decimal/date not encoded, etc.).

## Non-Goals
Implementing a persistent checkpointer backend (SQLite/Postgres/etc.) unless it’s needed to validate serialization correctness.

Refactoring the entire policy layer.

## Tasks
- [x] Replace Path fields in state with str (or structured artifact metadata objects that serialize cleanly).
- [ ] Decide how to represent plan data in state:
  - Option A: keep TripPlan but ensure dumps are JSON-safe, or
  - Option B: store plan_json dict + validate/construct TripPlan at node boundaries.
- [x] Ensure canonical intake representation in state is also JSON-safe (dict or pydantic model dump).
- [x] Add a test asserting json.dumps(state.model_dump(mode="json")) succeeds for a “realistic” run.

## Acceptance Criteria
- [x] TripState.model_dump(mode="json") produces JSON-serializable output (no TypeError on json.dumps(...)).
- [x] No Path objects or other arbitrary types remain in state.
- [x] CI passes.

## Implementation Notes
Relevant files:
- src/travel_plan_permission/orchestration/graph.py
- tests/python/ (new test file, likely test_orchestration_state_serialization.py)

<details>
<summary>Original Issue</summary>

````text
## Why

Why

Current TripState contains Path and a full TripPlan object. That’s fine for a demo, but it becomes annoying when you want checkpointing, persistence, or tooling that expects JSON-serializable state.

Scope

Make orchestration state safe to serialize via model_dump(mode="json") and json.dumps(...).

Avoid non-JSON-native types in state (Path, raw Decimal/date not encoded, etc.).

Non-Goals

Implementing a persistent checkpointer backend (SQLite/Postgres/etc.) unless it’s needed to validate serialization correctness.

Refactoring the entire policy layer.

Tasks

 Replace Path fields in state with str (or structured artifact metadata objects that serialize cleanly).

 Decide how to represent plan data in state:

Option A: keep TripPlan but ensure dumps are JSON-safe, or

Option B: store plan_json dict + validate/construct TripPlan at node boundaries.

 Ensure canonical intake representation in state is also JSON-safe (dict or pydantic model dump).

 Add a test asserting json.dumps(state.model_dump(mode="json")) succeeds for a “realistic” run.

Acceptance Criteria

 TripState.model_dump(mode="json") produces JSON-serializable output (no TypeError on json.dumps(...)).

 No Path objects or other arbitrary types remain in state.

 CI passes.

Implementation Notes

Relevant files:

src/travel_plan_permission/orchestration/graph.py

tests/python/ (new test file, likely test_orchestration_state_serialization.py)

## Scope

Topic GUID: 0a57061b-3171-59bd-8dcf-f886d7dbb0c9

## Non-Goals

_Not provided._

## Tasks

- [ ] _Not provided._

## Acceptance Criteria

- [ ] _Not provided._

## Implementation Notes

_Not provided._

---
Synced by [workflow run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/20770123300).

<details>
<summary>Original Issue</summary>

```text
Topic GUID: 0a57061b-3171-59bd-8dcf-f886d7dbb0c9

## Why
Why

Current TripState contains Path and a full TripPlan object. That’s fine for a demo, but it becomes annoying when you want checkpointing, persistence, or tooling that expects JSON-serializable state.

Scope

Make orchestration state safe to serialize via model_dump(mode="json") and json.dumps(...).

Avoid non-JSON-native types in state (Path, raw Decimal/date not encoded, etc.).

Non-Goals

Implementing a persistent checkpointer backend (SQLite/Postgres/etc.) unless it’s needed to validate serialization correctness.

Refactoring the entire policy layer.

Tasks

 Replace Path fields in state with str (or structured artifact metadata objects that serialize cleanly).

 Decide how to represent plan data in state:

Option A: keep TripPlan but ensure dumps are JSON-safe, or

Option B: store plan_json dict + validate/construct TripPlan at node boundaries.

 Ensure canonical intake representation in state is also JSON-safe (dict or pydantic model dump).

 Add a test asserting json.dumps(state.model_dump(mode="json")) succeeds for a “realistic” run.

Acceptance Criteria

 TripState.model_dump(mode="json") produces JSON-serializable output (no TypeError on json.dumps(...)).

 No Path objects or other arbitrary types remain in state.

 CI passes.

Implementation Notes

Relevant files:

src/travel_plan_permission/orchestration/graph.py

tests/python/ (new test file, likely test_orchestration_state_serialization.py)

## Tasks
_Not provided._

## Acceptance criteria
_Not provided._

## Implementation notes
_Not provided._

---
Synced by [workflow run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/20770123300).
```
</details>
````
</details>

<!-- pr-preamble:start -->
> **Source:** Issue #296

<!-- pr-preamble:end -->
