### PR TITLE
chore(format): bootstrap PR for issue #299

### DIFF
--- a/Issues.txt
+++ b/Issues.txt
@@ -214,27 +214,17 @@ Changing policy rule logic.
 
 Tasks
 
- Extend TripState to include:
-
-policy_missing_inputs (list/dict, JSON-safe)
-
-unfilled_mapping_report (JSON-safe summary)
-
- In the policy node:
-
-compute diagnostics and attach to state (using context extraction + diagnose_missing_inputs)
-
- In the spreadsheet node:
-
-instantiate a UnfilledMappingReport, pass it into spreadsheet fill/render, store a serialized form in state
-
- Update orchestration example to print/report these diagnostics.
-
- Add tests that confirm:
-
-diagnostics are present when expected (missing inputs scenario)
-
-mapping report includes missing/invalid entries in a controlled fixture scenario
+- [x] Extend TripState to include:
+- [x] policy_missing_inputs (list/dict, JSON-safe)
+- [x] unfilled_mapping_report (JSON-safe summary)
+- [x] In the policy node:
+- [x] compute diagnostics and attach to state (using context extraction + diagnose_missing_inputs)
+- [x] In the spreadsheet node:
+- [x] instantiate a UnfilledMappingReport, pass it into spreadsheet fill/render, store a serialized form in state
+- [x] Update orchestration example to print/report these diagnostics.
+- [x] Add tests that confirm:
+- [x] diagnostics are present when expected (missing inputs scenario)
+- [x] mapping report includes missing/invalid entries in a controlled fixture scenario
 
 Acceptance Criteria
 

--- a/agents/format-299.md
+++ b/agents/format-299.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for format on issue #299 -->

--- a/src/travel_plan_permission/orchestration/example.py
+++ b/src/travel_plan_permission/orchestration/example.py
@@ -98,6 +98,12 @@ def main() -> int:
         raise RuntimeError("No policy result returned from orchestration graph.")
 
     print(f"Policy status: {state.policy_result['status']}")
+    if state.policy_missing_inputs:
+        print("Missing policy inputs:")
+        print(json.dumps(state.policy_missing_inputs, indent=2))
+    if state.unfilled_mapping_report is not None:
+        print("Unfilled mapping report:")
+        print(json.dumps(state.unfilled_mapping_report, indent=2))
     print(f"Spreadsheet: {state.spreadsheet_path}")
     return 0
 

--- a/src/travel_plan_permission/orchestration/graph.py
+++ b/src/travel_plan_permission/orchestration/graph.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import tempfile
 from pathlib import Path
-from typing import Protocol
+from typing import Any, Protocol, Sequence
 
 from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator
 
@@ -168,7 +168,7 @@ def _policy_check_node(state: TripState) -> TripState:
     diagnostics = diagnose_missing_inputs(context)
     result = check_trip_plan(plan)
     state.policy_result = result.model_dump(mode="json")
-    state.policy_missing_inputs = diagnostics
+    state.policy_missing_inputs = diagnostics  # type: ignore[assignment]
     return state
 
 
@@ -197,7 +197,7 @@ def _spreadsheet_node(state: TripState) -> TripState:
             report=report,
         )
         state.spreadsheet_path = str(output_path)
-    state.unfilled_mapping_report = report
+    state.unfilled_mapping_report = report  # type: ignore[assignment]
     return state
 
 
@@ -212,7 +212,7 @@ def _serialize_policy_missing_input(diagnostic: RuleDiagnostic) -> dict[str, obj
 def _serialize_unfilled_mapping_report(
     report: UnfilledMappingReport,
 ) -> dict[str, list[dict[str, object]]]:
-    def serialize_entries(entries: list[object]) -> list[dict[str, object]]:
+    def serialize_entries(entries: Sequence[Any]) -> list[dict[str, object]]:
         serialized: list[dict[str, object]] = []
         for entry in entries:
             if hasattr(entry, "field") and hasattr(entry, "cell") and hasattr(entry, "reason"):

--- a/src/travel_plan_permission/orchestration/graph.py
+++ b/src/travel_plan_permission/orchestration/graph.py
@@ -170,7 +170,9 @@ def _policy_check_node(state: TripState) -> TripState:
     diagnostics = diagnose_missing_inputs(context)
     result = check_trip_plan(plan)
     state.policy_result = result.model_dump(mode="json")
-    state.policy_missing_inputs = diagnostics  # type: ignore[assignment]
+    state.policy_missing_inputs = [
+        _serialize_policy_missing_input(diagnostic) for diagnostic in diagnostics
+    ]
     return state
 
 

--- a/src/travel_plan_permission/orchestration/graph.py
+++ b/src/travel_plan_permission/orchestration/graph.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import tempfile
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, Protocol, Sequence
+from typing import Any, Protocol
 
 from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator
 

--- a/tests/python/test_orchestration_smoke.py
+++ b/tests/python/test_orchestration_smoke.py
@@ -48,7 +48,6 @@ def test_policy_graph_smoke(tmp_path: Path) -> None:
     json.dumps(serialized)
 
 
-
 def test_policy_graph_records_missing_policy_inputs(tmp_path: Path) -> None:
     plan = TripPlan(
         trip_id="TRIP-ORCH-MISSING",

--- a/tests/python/test_orchestration_smoke.py
+++ b/tests/python/test_orchestration_smoke.py
@@ -24,9 +24,35 @@ def test_policy_graph_smoke(tmp_path: Path) -> None:
     assert state.policy_result is not None
     assert isinstance(state.policy_result, dict)
     assert state.policy_result["status"] == "fail"
+    assert isinstance(state.policy_missing_inputs, list)
+    assert state.unfilled_mapping_report is not None
     assert state.spreadsheet_path == str(output_path)
     assert output_path.exists()
     serialized = state.model_dump(mode="json")
     assert isinstance(serialized["policy_result"], dict)
     assert serialized["policy_result"]["status"] == "fail"
+    assert isinstance(serialized["policy_missing_inputs"], list)
+    assert serialized["unfilled_mapping_report"] is not None
     json.dumps(serialized)
+
+
+def test_policy_graph_records_missing_policy_inputs(tmp_path: Path) -> None:
+    plan = TripPlan(
+        trip_id="TRIP-ORCH-MISSING",
+        traveler_name="Sam Parker",
+        destination="Seattle, WA 98101",
+        departure_date=date(2025, 5, 10),
+        return_date=date(2025, 5, 12),
+        purpose="Project kickoff",
+        estimated_cost=Decimal("650.00"),
+    )
+
+    output_path = tmp_path / "travel_request.xlsx"
+    state = run_policy_graph(plan, output_path=output_path, prefer_langgraph=False)
+
+    missing = state.policy_missing_inputs
+    assert missing
+    rule_ids = {entry.get("rule_id") for entry in missing}
+    assert "advance_booking" in rule_ids
+    advance_booking = next(entry for entry in missing if entry.get("rule_id") == "advance_booking")
+    assert "booking_date" in advance_booking.get("missing_fields", [])

--- a/tests/python/test_orchestration_smoke.py
+++ b/tests/python/test_orchestration_smoke.py
@@ -68,6 +68,8 @@ def test_policy_graph_records_missing_policy_inputs(tmp_path: Path) -> None:
     assert "advance_booking" in rule_ids
     advance_booking = next(entry for entry in missing if entry.get("rule_id") == "advance_booking")
     assert "booking_date" in advance_booking.get("missing_fields", [])
+    assert isinstance(advance_booking.get("missing_fields"), list)
+    assert advance_booking.get("message", "").startswith("Missing required inputs:")
 
 
 @pytest.mark.filterwarnings("ignore:Pydantic serializer warnings.*:UserWarning")
@@ -119,6 +121,7 @@ def test_spreadsheet_node_records_unfilled_mapping_report_entries(
 
     report = state.unfilled_mapping_report
     assert report is not None
+    assert set(report.keys()) == {"cells", "dropdowns", "checkboxes"}
     cells = {(entry["field"], entry["reason"]) for entry in report["cells"]}
     assert ("event_registration_cost", "invalid_currency") in cells
     assert ("depart_date", "invalid_date") in cells

--- a/tests/python/test_orchestration_state_serialization.py
+++ b/tests/python/test_orchestration_state_serialization.py
@@ -191,3 +191,30 @@ def test_trip_state_coerces_assigned_unfilled_mapping_report(tmp_path: Path) -> 
         "checkboxes": [],
     }
     json.dumps(state.model_dump(mode="json"))
+
+
+def test_trip_state_accepts_dict_unfilled_mapping_report(tmp_path: Path) -> None:
+    fixture_path = (
+        Path(__file__).resolve().parents[1] / "fixtures" / "canonical_trip_plan_realistic.json"
+    )
+    payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    trip_input = load_trip_plan_input(payload)
+    spreadsheet_path = tmp_path / "travel_request.xlsx"
+
+    state = TripState(
+        plan_json=trip_input.plan.model_dump(mode="json"),
+        canonical_plan=(
+            trip_input.canonical.model_dump(mode="json") if trip_input.canonical else None
+        ),
+        spreadsheet_path=str(spreadsheet_path),
+    )
+
+    report = {
+        "cells": [{"field": "purpose", "cell": "B5", "reason": "missing"}],
+        "dropdowns": [],
+        "checkboxes": [],
+    }
+    state.unfilled_mapping_report = report
+
+    assert state.unfilled_mapping_report == report
+    json.dumps(state.model_dump(mode="json"))

--- a/tests/python/test_orchestration_state_serialization.py
+++ b/tests/python/test_orchestration_state_serialization.py
@@ -3,9 +3,8 @@ from pathlib import Path
 
 from travel_plan_permission.canonical import load_trip_plan_input
 from travel_plan_permission.orchestration import TripState
-from travel_plan_permission.policy_api import UnfilledMappingReport
+from travel_plan_permission.policy_api import UnfilledMappingReport, check_trip_plan
 from travel_plan_permission.policy_lite import RuleDiagnostic
-from travel_plan_permission.policy_api import check_trip_plan
 
 
 def test_trip_state_coerces_plans_to_json(tmp_path: Path) -> None:

--- a/tests/python/test_spreadsheet_fill.py
+++ b/tests/python/test_spreadsheet_fill.py
@@ -4,8 +4,8 @@ from decimal import Decimal
 from io import BytesIO
 from pathlib import Path
 
-from openpyxl import load_workbook
 import pytest
+from openpyxl import load_workbook
 
 import travel_plan_permission.policy_api as policy_api
 from travel_plan_permission import (


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #299

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
You already implemented:

- policy missing-input diagnostics (policy_lite.diagnose_missing_inputs)
- spreadsheet unfilled mapping reporting (UnfilledMappingReport)

However, orchestration doesn’t return these, so LangGraph can’t easily drive “ask next question” behavior or even report what’s missing.

#### Tasks
- [x] Extend TripState to include:
- [x] policy_missing_inputs (list/dict, JSON-safe) (verify: confirm completion in repo)
- [x] unfilled_mapping_report (JSON-safe summary) (verify: confirm completion in repo)
- [x] In the policy node:
- [x] Compute diagnostics using context extraction (verify: confirm completion in repo)
- [x] Attach diagnostics to state using diagnose_missing_inputs (verify: confirm completion in repo)
- [x] In the spreadsheet node:
- [x] Instantiate a UnfilledMappingReport (verify: confirm completion in repo)
- [x] Pass the report into spreadsheet fill (verify: confirm completion in repo)
- [x] Render (verify: confirm completion in repo)
- [x] Store a serialized form in state (verify: confirm completion in repo)
- [x] Update orchestration example to print/report these diagnostics.
- [x] Add tests that confirm:
- [x] Diagnostics are present when expected (missing inputs scenario).
- [x] Mapping report includes missing/invalid entries in a controlled fixture scenario.
## Deferred Tasks (Requires Human)
- [x] - None

#### Acceptance criteria
- [x] Orchestration returns a JSON object containing a list of missing policy inputs with their identifiers.
- [x] Orchestration returns a JSON object detailing each unfilled mapping with its corresponding key and reason for being unfilled.
- [x] These outputs are JSON-serializable and test-covered.
- [x] CI passes.

<!-- auto-status-summary:end -->
