### PR TITLE
chore(format): bootstrap PR for issue #298

### DIFF
--- a/Issues.txt
+++ b/Issues.txt
@@ -150,15 +150,15 @@ Removing useful flexibility like allowing overrides (trip_id, origin_city) unles
 
 Tasks
 
- Designate the blessed API (recommended: load_trip_plan_input() from canonical.py).
+- [x] Designate the blessed API (recommended: load_trip_plan_input() from canonical.py).
 
- Update trip_plan_from_minimal to be a wrapper around canonical validation + conversion, applying overrides via TripPlan.model_copy(update=...) (or equivalent).
+- [x] Update trip_plan_from_minimal to be a wrapper around canonical validation + conversion, applying overrides via TripPlan.model_copy(update=...) (or equivalent).
 
- Update docs (docs/langgraph_quickstart.md) to reference one path, and move the rest into a short “alternatives” note (or deprecate).
+- [x] Update docs (docs/langgraph_quickstart.md) to reference one path, and move the rest into a short “alternatives” note (or deprecate).
 
- Update orchestration example to use the blessed loader/converter.
+- [x] Update orchestration example to use the blessed loader/converter.
 
- Add/update a test asserting the wrapper and the canonical loader produce consistent results for the same payload.
+- [x] Add/update a test asserting the wrapper and the canonical loader produce consistent results for the same payload.
 
 Acceptance Criteria
 

--- a/Issues.txt
+++ b/Issues.txt
@@ -163,7 +163,7 @@ Tasks
 Task Reconciliation (Issue 4 extras)
 
 - [x] Create a short alternatives note.
-- [x] Provide specific examples/tests that demonstrate delegation of logic for extra conversion helpers.
+- [x] Provide specific examples/tests that demonstrate delegation of logic for extra conversion helpers (tests/python/test_minimal_conversion.py, tests/python/test_canonical_trip_plan.py).
 
 Acceptance Criteria
 

--- a/Issues.txt
+++ b/Issues.txt
@@ -160,6 +160,11 @@ Tasks
 
 - [x] Add/update a test asserting the wrapper and the canonical loader produce consistent results for the same payload.
 
+Task Reconciliation (Issue 4 extras)
+
+- [x] Create a short alternatives note.
+- [x] Provide specific examples/tests that demonstrate delegation of logic for extra conversion helpers.
+
 Acceptance Criteria
 
  Docs present one primary conversion path for canonical intake.

--- a/agents/format-298.md
+++ b/agents/format-298.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for format on issue #298 -->

--- a/docs/langgraph_quickstart.md
+++ b/docs/langgraph_quickstart.md
@@ -67,6 +67,8 @@ Alternatives (advanced/legacy only):
 - `canonical_trip_plan_to_model` accepts an already-validated `CanonicalTripPlan`.
 - `trip_plan_from_minimal` is deprecated; it delegates to `load_trip_plan_input`
   and only applies overrides like `trip_id` or `origin_city`.
+- `load_trip_plan_payload` is deprecated; it delegates to `load_trip_plan_input`
+  and returns only the `TripPlan`.
 
 ## Run the minimal LangGraph flow locally
 

--- a/docs/langgraph_quickstart.md
+++ b/docs/langgraph_quickstart.md
@@ -36,11 +36,11 @@ Example payload (matches the canonical schema):
 The canonical schema is a lightweight payload used for early UI or LLM intake.
 Convert it into `TripPlan` before calling policy APIs.
 
-## Conversion process (minimal intake -> TripPlan)
+## Conversion process (canonical intake -> TripPlan)
 
-Use `trip_plan_from_minimal` in `src/travel_plan_permission/conversion.py` (or
-`canonical_trip_plan_to_model` in `src/travel_plan_permission/canonical.py`) to
-map the canonical JSON schema to the internal `TripPlan`. This function:
+Use `load_trip_plan_input` from `src/travel_plan_permission/canonical.py` to
+validate the canonical JSON schema and convert it into the internal `TripPlan`.
+This loader:
 
 - Builds `destination` from `city_state` + `destination_zip`.
 - Maps `business_purpose` to `TripPlan.purpose`.
@@ -52,18 +52,22 @@ Example:
 import json
 from pathlib import Path
 
-from travel_plan_permission import trip_plan_from_minimal
+from travel_plan_permission import load_trip_plan_input
 
 payload = json.loads(
     Path("tests/fixtures/sample_trip_plan_minimal.json").read_text(encoding="utf-8")
 )
 
-plan = trip_plan_from_minimal(
-    payload,
-    trip_id="TRIP-1001",
-    origin_city="Austin, TX",
-)
+plan_input = load_trip_plan_input(payload)
+plan = plan_input.plan
 ```
+
+Alternatives (advanced/legacy):
+
+- `canonical_trip_plan_to_model` converts an already-validated
+  `CanonicalTripPlan` into `TripPlan`.
+- `trip_plan_from_minimal` is a deprecated wrapper that delegates to
+  `load_trip_plan_input` and applies overrides like `trip_id` or `origin_city`.
 
 ## Run the minimal LangGraph flow locally
 

--- a/docs/langgraph_quickstart.md
+++ b/docs/langgraph_quickstart.md
@@ -62,10 +62,11 @@ plan_input = load_trip_plan_input(payload)
 plan = plan_input.plan
 ```
 
-Alternatives (advanced/legacy): `canonical_trip_plan_to_model` accepts an
-already-validated `CanonicalTripPlan`, while `trip_plan_from_minimal` is a
-deprecated wrapper that delegates to `load_trip_plan_input` and applies
-overrides like `trip_id` or `origin_city`.
+Alternatives (advanced/legacy only):
+
+- `canonical_trip_plan_to_model` accepts an already-validated `CanonicalTripPlan`.
+- `trip_plan_from_minimal` is deprecated; it delegates to `load_trip_plan_input`
+  and only applies overrides like `trip_id` or `origin_city`.
 
 ## Run the minimal LangGraph flow locally
 

--- a/docs/langgraph_quickstart.md
+++ b/docs/langgraph_quickstart.md
@@ -62,12 +62,10 @@ plan_input = load_trip_plan_input(payload)
 plan = plan_input.plan
 ```
 
-Alternatives (advanced/legacy):
-
-- `canonical_trip_plan_to_model` converts an already-validated
-  `CanonicalTripPlan` into `TripPlan`.
-- `trip_plan_from_minimal` is a deprecated wrapper that delegates to
-  `load_trip_plan_input` and applies overrides like `trip_id` or `origin_city`.
+Alternatives (advanced/legacy): `canonical_trip_plan_to_model` accepts an
+already-validated `CanonicalTripPlan`, while `trip_plan_from_minimal` is a
+deprecated wrapper that delegates to `load_trip_plan_input` and applies
+overrides like `trip_id` or `origin_city`.
 
 ## Run the minimal LangGraph flow locally
 

--- a/src/travel_plan_permission/__init__.py
+++ b/src/travel_plan_permission/__init__.py
@@ -8,6 +8,7 @@ from .approval_packet import (
     build_approval_packet,
     generate_packet_pdf,
 )
+from .canonical import load_trip_plan_input
 from .conversion import trip_plan_from_minimal
 from .export import ExportService
 from .mapping import DEFAULT_TEMPLATE_VERSION, TemplateMapping, load_template_mapping
@@ -206,6 +207,7 @@ __all__ = [
     "TripPlan",
     "TripStatus",
     "trip_plan_from_minimal",
+    "load_trip_plan_input",
     "determine_exception_approval_level",
     "ValidationAdvanceBookingRule",
     "ValidationComparison",

--- a/src/travel_plan_permission/canonical.py
+++ b/src/travel_plan_permission/canonical.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import warnings
 from dataclasses import dataclass
 from datetime import date
 from decimal import Decimal
@@ -176,4 +177,9 @@ def load_trip_plan_input(payload: dict[str, object]) -> TripPlanInput:
 def load_trip_plan_payload(payload: dict[str, object]) -> TripPlan:
     """Load either canonical schema payloads or internal TripPlan payloads."""
 
+    warnings.warn(
+        "load_trip_plan_payload is deprecated; use load_trip_plan_input instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return load_trip_plan_input(payload).plan

--- a/src/travel_plan_permission/conversion.py
+++ b/src/travel_plan_permission/conversion.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 import warnings
+from collections.abc import Mapping
 from typing import Any, Literal
 
 from .canonical import load_trip_plan_input

--- a/src/travel_plan_permission/conversion.py
+++ b/src/travel_plan_permission/conversion.py
@@ -30,7 +30,9 @@ def trip_plan_from_minimal(
         stacklevel=2,
     )
 
-    plan_input = load_trip_plan_input(dict(payload))
+    payload_dict = dict(payload)
+    payload_dict.setdefault("type", "trip")
+    plan_input = load_trip_plan_input(payload_dict)
     overrides: dict[str, object] = {"trip_id": trip_id, "status": status}
     if traveler_role is not None:
         overrides["traveler_role"] = traveler_role

--- a/tests/python/test_canonical_trip_plan.py
+++ b/tests/python/test_canonical_trip_plan.py
@@ -71,3 +71,13 @@ def test_load_trip_plan_payload_matches_loader() -> None:
         trip_plan = load_trip_plan_payload(payload)
 
     assert trip_plan.model_dump() == plan_input.plan.model_dump()
+
+
+def test_canonical_trip_plan_to_model_matches_loader() -> None:
+    payload = _load_fixture()
+
+    canonical_plan = CanonicalTripPlan.model_validate(payload)
+    trip_plan = canonical_trip_plan_to_model(canonical_plan)
+    plan_input = load_trip_plan_input(payload)
+
+    assert trip_plan.model_dump() == plan_input.plan.model_dump()

--- a/tests/python/test_canonical_trip_plan.py
+++ b/tests/python/test_canonical_trip_plan.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from travel_plan_permission.canonical import (
     CanonicalTripPlan,
     canonical_trip_plan_to_model,
+    load_trip_plan_input,
     load_trip_plan_payload,
 )
 from travel_plan_permission.models import ExpenseCategory, TripPlan
@@ -59,3 +60,14 @@ def test_load_trip_plan_payload_handles_canonical() -> None:
     assert trip_plan.trip_id.startswith("TRIP-")
     assert trip_plan.traveler_name == payload["traveler_name"]
     assert trip_plan.destination.endswith(payload["destination_zip"])
+
+
+def test_load_trip_plan_payload_matches_loader() -> None:
+    payload = _load_fixture()
+
+    plan_input = load_trip_plan_input(payload)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        trip_plan = load_trip_plan_payload(payload)
+
+    assert trip_plan.model_dump() == plan_input.plan.model_dump()

--- a/tests/python/test_canonical_trip_plan.py
+++ b/tests/python/test_canonical_trip_plan.py
@@ -108,7 +108,7 @@ def test_load_trip_plan_payload_returns_loader_plan(monkeypatch) -> None:
     base_plan = load_trip_plan_input(payload).plan
     delegated_plan = base_plan.model_copy(update={"traveler_name": "Delegated Traveler"})
 
-    def _wrapped_loader(payload_dict: dict[str, object]) -> TripPlanInput:
+    def _wrapped_loader(_payload_dict: dict[str, object]) -> TripPlanInput:
         return TripPlanInput(plan=delegated_plan)
 
     monkeypatch.setattr(canonical, "load_trip_plan_input", _wrapped_loader)

--- a/tests/python/test_canonical_trip_plan.py
+++ b/tests/python/test_canonical_trip_plan.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import warnings
 from decimal import Decimal
 from pathlib import Path
 
@@ -50,7 +51,9 @@ def test_canonical_conversion_builds_trip_plan() -> None:
 def test_load_trip_plan_payload_handles_canonical() -> None:
     payload = _load_fixture()
 
-    trip_plan = load_trip_plan_payload(payload)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        trip_plan = load_trip_plan_payload(payload)
 
     assert isinstance(trip_plan, TripPlan)
     assert trip_plan.trip_id.startswith("TRIP-")

--- a/tests/python/test_minimal_conversion.py
+++ b/tests/python/test_minimal_conversion.py
@@ -1,9 +1,10 @@
 import json
+import warnings
 from datetime import date
 from decimal import Decimal
 from pathlib import Path
 
-from travel_plan_permission import ExpenseCategory, trip_plan_from_minimal
+from travel_plan_permission import ExpenseCategory, load_trip_plan_input, trip_plan_from_minimal
 
 
 def test_trip_plan_from_minimal_builds_plan() -> None:
@@ -11,11 +12,13 @@ def test_trip_plan_from_minimal_builds_plan() -> None:
         Path("tests/fixtures/sample_trip_plan_minimal.json").read_text(encoding="utf-8")
     )
 
-    plan = trip_plan_from_minimal(
-        payload,
-        trip_id="TRIP-1001",
-        origin_city="Austin, TX",
-    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        plan = trip_plan_from_minimal(
+            payload,
+            trip_id="TRIP-1001",
+            origin_city="Austin, TX",
+        )
 
     assert plan.trip_id == "TRIP-1001"
     assert plan.traveler_name == payload["traveler_name"]
@@ -36,3 +39,16 @@ def test_trip_plan_from_minimal_builds_plan() -> None:
     assert plan.expense_breakdown[ExpenseCategory.LODGING] == expected_lodging
     assert plan.expense_breakdown[ExpenseCategory.CONFERENCE_FEES] == expected_fees
     assert plan.expense_breakdown[ExpenseCategory.GROUND_TRANSPORT] == expected_parking
+
+
+def test_trip_plan_from_minimal_matches_canonical_loader() -> None:
+    payload = json.loads(
+        Path("tests/fixtures/sample_trip_plan_minimal.json").read_text(encoding="utf-8")
+    )
+
+    plan_input = load_trip_plan_input(payload)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        plan = trip_plan_from_minimal(payload, trip_id=plan_input.plan.trip_id)
+
+    assert plan.model_dump() == plan_input.plan.model_dump()

--- a/tests/python/test_minimal_conversion.py
+++ b/tests/python/test_minimal_conversion.py
@@ -129,7 +129,7 @@ def test_trip_plan_from_minimal_uses_loader_plan(monkeypatch) -> None:
     base_plan = load_trip_plan_input(payload).plan
     delegated_plan = base_plan.model_copy(update={"traveler_name": "Delegated Traveler"})
 
-    def _wrapped_loader(payload_dict: dict[str, object]) -> TripPlanInput:
+    def _wrapped_loader(_payload_dict: dict[str, object]) -> TripPlanInput:
         return TripPlanInput(plan=delegated_plan)
 
     monkeypatch.setattr(conversion, "load_trip_plan_input", _wrapped_loader)

--- a/tests/python/test_minimal_conversion.py
+++ b/tests/python/test_minimal_conversion.py
@@ -5,7 +5,12 @@ from decimal import Decimal
 from pathlib import Path
 
 import travel_plan_permission.conversion as conversion
-from travel_plan_permission import ExpenseCategory, load_trip_plan_input, trip_plan_from_minimal
+from travel_plan_permission import (
+    ExpenseCategory,
+    TripStatus,
+    load_trip_plan_input,
+    trip_plan_from_minimal,
+)
 
 
 def test_trip_plan_from_minimal_builds_plan() -> None:
@@ -40,6 +45,25 @@ def test_trip_plan_from_minimal_builds_plan() -> None:
     assert plan.expense_breakdown[ExpenseCategory.LODGING] == expected_lodging
     assert plan.expense_breakdown[ExpenseCategory.CONFERENCE_FEES] == expected_fees
     assert plan.expense_breakdown[ExpenseCategory.GROUND_TRANSPORT] == expected_parking
+
+
+def test_trip_plan_from_minimal_applies_overrides() -> None:
+    payload = json.loads(
+        Path("tests/fixtures/sample_trip_plan_minimal.json").read_text(encoding="utf-8")
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        plan = trip_plan_from_minimal(
+            payload,
+            trip_id="TRIP-3001",
+            status=TripStatus.SUBMITTED,
+            origin_city="Seattle, WA",
+        )
+
+    assert plan.trip_id == "TRIP-3001"
+    assert plan.status == TripStatus.SUBMITTED
+    assert plan.origin_city == "Seattle, WA"
 
 
 def test_trip_plan_from_minimal_matches_canonical_loader() -> None:


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #298

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The documentation currently references multiple conversion utilities (trip_plan_from_minimal, canonical_trip_plan_to_model, load_trip_plan_input). While this is manageable today, it can lead to subtle inconsistencies over time.

#### Tasks
- [x] Designate the blessed API (recommended: load_trip_plan_input() from canonical.py).
- [x] Update trip_plan_from_minimal to be a wrapper around canonical validation:
- [x] Confirm completion in the repository.
- [x] Implement conversion logic in the wrapper:
- [x] Confirm completion in the repository.
- [x] Apply overrides via TripPlan.model_copy(update=...) or equivalent:
- [x] Confirm completion in the repository.
- [x] Update docs (docs/langgraph_quickstart.md) to reference one path:
- [x] Update docs to reference the primary conversion path.
- [x] Create a short "alternatives" note.
- [x] Deprecate the outdated conversion paths.
- [x] Update orchestration example to use the blessed loader/converter.
- [x] Add/update a test asserting the wrapper and the canonical loader produce consistent results for the same payload.
## Deferred Tasks (Requires Human)
- [x] Define the specific documentation changes required to clarify the primary conversion path.
- [x] Provide specific examples or tests that demonstrate the delegation of logic for the "extra" conversion helpers.

#### Acceptance criteria
- [x] Documentation presents one primary conversion path for canonical intake.
- [x] The “extra” conversion helpers do not implement separate logic paths; they delegate.
- [x] CLI and orchestration use the same conversion surface.
- [x] Continuous Integration (CI) passes.

<!-- auto-status-summary:end -->
