### PR TITLE
feat: add orchestration tests job to Gate workflow

### DIFF
--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -51,9 +51,31 @@ jobs:
       enable-soft-gate: true
     secrets: inherit
 
+  orchestration-tests:
+    name: Orchestration Tests (LangGraph)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies with orchestration extra
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[orchestration,dev]"
+
+      - name: Run LangGraph orchestration tests
+        run: |
+          pytest tests/orchestration_graph_test.py tests/python/test_langgraph_orchestration.py -v
+
   summary:
     name: gate-summary
-    needs: [python-ci]
+    needs: [python-ci, orchestration-tests]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     permissions:
@@ -75,10 +97,12 @@ jobs:
         id: summarize
         env:
           PYTHON_RESULT: ${{ needs.python-ci.result || 'skipped' }}
+          ORCHESTRATION_RESULT: ${{ needs.orchestration-tests.result || 'skipped' }}
         run: |
           set -euo pipefail
 
           python_result="${PYTHON_RESULT:-skipped}"
+          orchestration_result="${ORCHESTRATION_RESULT:-skipped}"
           state="success"
           description="All checks passed"
 
@@ -102,6 +126,31 @@ jobs:
             *)
               state="pending"
               description="Python CI status unknown"
+              ;;
+          esac
+
+          # Check orchestration result
+          case "$orchestration_result" in
+            failure)
+              state="failure"
+              description="Orchestration tests failed"
+              ;;
+            cancelled)
+              state="error"
+              description="Orchestration tests were cancelled"
+              ;;
+            skipped)
+              # Keep current state
+              ;;
+            success)
+              # Keep current state, update description if all passed
+              if [ "$state" = "success" ] && [ "$python_result" = "success" ]; then
+                description="All checks passed"
+              fi
+              ;;
+            *)
+              state="pending"
+              description="Orchestration tests status unknown"
               ;;
           esac
 


### PR DESCRIPTION
## Summary

Adds a dedicated CI job to test LangGraph orchestration functionality.

## Changes

- **New orchestration-tests job**: Installs `.[orchestration,dev]` extras and runs LangGraph-specific tests
- **Updated summary logic**: Aggregates orchestration test results alongside Python CI
- **Tests covered**: 
  - `tests/orchestration_graph_test.py`
  - `tests/python/test_langgraph_orchestration.py`

## Context

This addresses the requirement from issue #351 to add CI coverage for the LangGraph integration path. While PR #352 was merged successfully, this enhancement ensures ongoing coverage of orchestration features.

## Testing

- CI will run the new orchestration-tests job
- Existing Python CI jobs continue as before
- Summary job correctly aggregates results from both jobs

<!-- pr-preamble:start -->
> **Source:** Issue #351

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
PR #301 addressed issue #297 but verification identified concerns (verdict: **CONCERNS**). This follow-up addresses the remaining gaps with improved task structure to ensure the LangGraph integration is properly validated and tested in the CI environment.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#301](https://github.com/stranske/Travel-Plan-Permission/issues/301)
- [#297](https://github.com/stranske/Travel-Plan-Permission/issues/297)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Update the CI configuration to include a job that runs `pip install .[orchestration]` and executes the LangGraph-path test.
- [ ] Modify the LangGraph-path test module to remove or conditionally bypass the use of `pytest.importorskip` if running in CI.
- [ ] Add tests to `src/travel_plan_permission/orchestration/graph.py` to verify that when `prefer_langgraph` is True, the LangGraph compiled codepath is executed and the correct artifact is generated.
- [ ] Review and update the test suite configuration to ensure that new test modules are included in the test runs.

#### Acceptance criteria
- [ ] The CI configuration includes a job that runs `pip install .[orchestration]` and executes the LangGraph-path test module without skipping any tests.
- [ ] The LangGraph-path test module does not use `pytest.importorskip` when running in the CI environment.
- [ ] Tests in `tests/orchestration_graph_test.py` verify that when `prefer_langgraph` is True, the LangGraph compiled codepath is executed and the correct artifact is generated.

**Head SHA:** 4c30aa70bca69ecf1b2d6584d8fc02ed93d50b56
**Latest Runs:** ⏳ queued — Gate
**Required:** gate: ⏳ queued

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/20868101309) |
| Autofix | ⏳ queued | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/20868101325) |
| CI | ⏳ queued | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/20868101331) |
| Copilot code review | ⏳ queued | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/20868101710) |
| Gate | ⏳ queued | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/20868101332) |
| Health 45 Agents Guard | ❔ in progress | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/20868101228) |
<!-- auto-status-summary:end -->