### PR TITLE
chore: ignore keepalive status files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,6 +169,8 @@ ci/autofix/history.json
 ci/autofix/diagnostics.json
 
 # Metrics/history files (MEDIUM conflict risk)
+keepalive_status.md
+docs/keepalive/status/
 keepalive-metrics.ndjson
 coverage-trend-history.ndjson
 metrics-history.ndjson


### PR DESCRIPTION
## Problem

Autofix workflow fails with safe-sweep violations when keepalive status files are tracked.

## Solution

Add to .gitignore:
- `keepalive_status.md`
- `docs/keepalive/status/`

## Origin

Synced from stranske/Workflows PR #845