### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/workflows/agents-72-codex-belt-worker-dispatch.yml
+++ b/.github/workflows/agents-72-codex-belt-worker-dispatch.yml
@@ -35,8 +35,8 @@ on:
       max_parallel:
         description: 'Maximum concurrent worker runs permitted'
         required: false
-        default: 1
-        type: number
+        default: '1'
+        type: string
       keepalive:
         description: 'True when invocation originates from a keepalive sweep'
         required: false
@@ -52,7 +52,7 @@ permissions:
 jobs:
   run-worker:
     name: Run Codex belt worker
-    uses: ./.github/workflows/agents-72-codex-belt-worker.yaml
+    uses: ./.github/workflows/agents-72-codex-belt-worker.yml
     with:
       issue: ${{ inputs.issue }}
       branch: ${{ inputs.branch }}
@@ -60,7 +60,7 @@ jobs:
       source: ${{ inputs.source }}
       dry_run: ${{ inputs.dry_run }}
       use_step_branch: ${{ inputs.use_step_branch }}
-      max_parallel: ${{ inputs.max_parallel }}
+      max_parallel: ${{ fromJSON(inputs.max_parallel) }}
       keepalive: ${{ inputs.keepalive }}
     secrets:
       WORKFLOWS_APP_ID: ${{ secrets.WORKFLOWS_APP_ID }}

--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -876,7 +876,7 @@ jobs:
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     workflow_id: 'agents-72-codex-belt-worker-dispatch.yml',
-                    ref: 'main',
+                    ref: baseBranch,
                     inputs: {
                       issue: issueNumber.toString(),
                       branch: branchName,


### PR DESCRIPTION
## Sync Summary

### Files Updated
- agents-72-codex-belt-worker-dispatch.yml: Codex belt worker dispatch wrapper - allows workflow_dispatch for the worker
- agents-auto-pilot.yml: Auto-pilot - end-to-end automation orchestrator (format → optimize → agent → verify)

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- dependabot.yml: File exists and sync_mode is create_only

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** [stranske/Workflows](https://github.com/stranske/Workflows)
**Manifest:** [`.github/sync-manifest.yml`](https://github.com/stranske/Workflows/blob/main/.github/sync-manifest.yml)