### PR TITLE
Resolve issue #758 review-thread follow-up

### DIFF
--- a/docs/validation-rules.md
+++ b/docs/validation-rules.md
@@ -34,7 +34,7 @@ Each validation result contains:
 - `severity` - One of: `error`, `warning`, `info`
 - `rule_name` - Name of the rule that produced the result
 - `blocking` - Whether the violation prevents submission
-- `is_blocking` - Property that returns `True` when `blocking=True` AND `severity=error`
+- `is_blocking` - Property that returns `True` when `blocking=True` AND `severity='error'`
 
 ### Available Rules
 


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #758

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Issue was closed while merged PR still has unresolved inline review thread(s).

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#83](https://github.com/stranske/Travel-Plan-Permission/issues/83)
- [#76](https://github.com/stranske/Travel-Plan-Permission/issues/76)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Enumerate unresolved review threads on PR #83
- [x] Classify each thread: warranted fix vs not-warranted disposition
- [x] If warranted, implement bounded follow-up PR(s)
- [x] Post a PR comment documenting disposition for every unresolved thread
- [x] Confirm thread count is reduced to zero (or explicitly dispositioned)

#### Acceptance criteria
- [x] All unresolved inline comments are addressed or dispositioned with rationale
- [x] Follow-up fix PR(s), if any, are linked from the source PR

**Head SHA:** 0432432bc100652138a6d9c82c905ae90532c7bf
**Latest Runs:** ⏭️ skipped — Agents PR Event Hub
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24301376953) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24301376954) |
<!-- auto-status-summary:end -->

#### Disposition evidence
- Enumerated source PR #83 review threads; the only thread was [`discussion_r2641844568`](https://github.com/stranske/Travel-Plan-Permission/pull/83#discussion_r2641844568) on `docs/validation-rules.md`.
- Classified that thread as warranted because the docs wording did not match the implemented `ValidationSeverity.ERROR` / `"error"` behavior.
- Implemented and merged the bounded fix in PR #764 on 2026-04-12 at 07:23 UTC as commit `9dc694026a8f4e9b1bc4e57ea85b48a97d1ab730`.
- Linked the follow-up fix back on source PR #83 and re-checked at 2026-04-12T09:22Z that the unresolved review-thread count is now `0`.

