### PR TITLE
Issue #783: add planner-facing HTTP service runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,29 @@ To see usage information, run:
 fill-spreadsheet --help
 ```
 
+## Planner Service Runtime
+
+Start the planner-facing HTTP service locally with:
+
+```bash
+tpp-planner-service
+```
+
+The service exposes a thin HTTP wrapper around the planner-facing contract
+helpers in `travel_plan_permission.policy_api`:
+
+- `GET /healthz`
+- `GET /readyz`
+- `GET /api/planner/policy-snapshot`
+- `POST /api/planner/proposals`
+- `GET /api/planner/proposals/{proposal_id}/executions/{execution_id}`
+- `GET /api/planner/executions/{execution_id}/evaluation-result`
+
+`/readyz` returns `503` until `TPP_BASE_URL`, `TPP_ACCESS_TOKEN`, and
+`TPP_OIDC_PROVIDER` are present in the environment. For local live testing, the
+service also boots with a seeded demo trip `TRIP-PLANNER-2001` that matches the
+planner integration fixtures under `tests/fixtures/planner_integration/`.
+
 ## Documentation
 
 - [Policy API](docs/policy-api.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,13 @@ classifiers = [
 ]
 
 dependencies = [
+    "fastapi>=0.115.0",
     "pydantic>=2.0",
     "pyyaml>=6.0.2",
     "openpyxl>=3.1.5",
     "jinja2>=3.1.4",
     "reportlab>=4.2.5",
+    "uvicorn>=0.30.0",
 ]
 
 [project.optional-dependencies]
@@ -30,6 +32,7 @@ dev = [
     "pytest-cov>=7.0.0",
     "ruff==0.15.1",
     "black==26.1.0",
+    "httpx>=0.28.0",
     "mypy>=1.19.1",
     "types-PyYAML>=6.0.12",
     "numpy>=1.24.0",
@@ -50,6 +53,7 @@ orchestration = [
 [project.scripts]
 fill-spreadsheet = "travel_plan_permission.cli:main"
 orchestration-demo = "travel_plan_permission.orchestration.example:main"
+tpp-planner-service = "travel_plan_permission.planner_service:main"
 
 [build-system]
 requires = []
@@ -63,7 +67,7 @@ package-dir = { "" = "src" }
 where = ["src"]
 
 [tool.setuptools.package-data]
-travel_plan_permission = ["config/*.yaml", "templates/*.xlsx"]
+travel_plan_permission = ["config/*.json", "config/*.yaml", "templates/*.xlsx"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/travel_plan_permission/__init__.py
+++ b/src/travel_plan_permission/__init__.py
@@ -32,6 +32,8 @@ from .models import (
     build_exception_dashboard,
     determine_exception_approval_level,
 )
+from .planner_service import PlannerServiceStore, create_app
+from .planner_service import app as planner_service_app
 from .policy import (
     AdvanceBookingRule,
     CabinClassRule,
@@ -229,6 +231,7 @@ __all__ = [
     "PlannerRetryMetadata",
     "PlannerTransportPattern",
     "PlannerVersionContract",
+    "PlannerServiceStore",
     "PolicyVersion",
     "PolicyMigrationPlan",
     "PolicyMigrationPlanner",
@@ -277,6 +280,8 @@ __all__ = [
     "ValidationRule",
     "ValidationSeverity",
     "compare_results",
+    "create_app",
+    "planner_service_app",
     "required_field_gaps",
     "policy_version_hash",
     "Role",

--- a/src/travel_plan_permission/config/planner_service_demo_trip.json
+++ b/src/travel_plan_permission/config/planner_service_demo_trip.json
@@ -1,0 +1,47 @@
+{
+  "trip_id": "TRIP-PLANNER-2001",
+  "traveler_name": "Jordan Lee",
+  "traveler_role": "Program Manager",
+  "department": "Operations",
+  "destination": "Chicago, IL 60601",
+  "origin_city": "Austin, TX",
+  "destination_city": "Chicago, IL",
+  "departure_date": "2026-05-20",
+  "return_date": "2026-05-22",
+  "purpose": "Planner integration rehearsal",
+  "transportation_mode": "air",
+  "expected_costs": {
+    "airfare": 420.5,
+    "lodging": 610.0,
+    "meals": 160.0
+  },
+  "funding_source": "OPS-INT",
+  "estimated_cost": 1190.5,
+  "status": "submitted",
+  "expense_breakdown": {
+    "airfare": 420.5,
+    "lodging": 610.0,
+    "meals": 160.0
+  },
+  "selected_fare": 420.5,
+  "lowest_fare": 399.0,
+  "cabin_class": "economy",
+  "flight_duration_hours": 2.8,
+  "fare_evidence_attached": true,
+  "driving_cost": 280.0,
+  "flight_cost": 420.5,
+  "comparable_hotels": [
+    590.0,
+    610.0
+  ],
+  "overnight_stay": true,
+  "meals_provided": false,
+  "meal_per_diem_requested": true,
+  "selected_providers": {
+    "airfare": "Blue Skies Airlines",
+    "lodging": "Loop Business Hotel"
+  },
+  "validation_results": [],
+  "approval_history": [],
+  "exception_requests": []
+}

--- a/src/travel_plan_permission/planner_service.py
+++ b/src/travel_plan_permission/planner_service.py
@@ -1,0 +1,217 @@
+"""Runnable HTTP service for the planner-facing policy API."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from importlib import resources
+from typing import Annotated, Any
+
+import uvicorn
+from fastapi import Body, FastAPI, HTTPException
+from pydantic import BaseModel
+
+from .models import TripPlan
+from .policy_api import (
+    PlannerPolicySnapshot,
+    PlannerPolicySnapshotRequest,
+    PlannerProposalEvaluationRequest,
+    PlannerProposalEvaluationResult,
+    PlannerProposalOperationResponse,
+    PlannerProposalStatusRequest,
+    PlannerProposalSubmissionRequest,
+    get_evaluation_result,
+    get_policy_snapshot,
+    poll_execution_status,
+    submit_proposal,
+)
+
+REQUIRED_PLANNER_CONFIG = (
+    "TPP_BASE_URL",
+    "TPP_ACCESS_TOKEN",
+    "TPP_OIDC_PROVIDER",
+)
+
+
+def _load_demo_trip_plan() -> TripPlan:
+    raw = (
+        resources.files("travel_plan_permission.config")
+        .joinpath("planner_service_demo_trip.json")
+        .read_text(encoding="utf-8")
+    )
+    return TripPlan.model_validate_json(raw)
+
+
+@dataclass
+class PlannerServiceStore:
+    """In-memory trip-plan store for planner-facing live testing."""
+
+    trip_plans: dict[str, TripPlan] = field(default_factory=dict)
+
+    @classmethod
+    def with_demo_seed(cls) -> PlannerServiceStore:
+        store = cls()
+        demo_plan = _load_demo_trip_plan()
+        store.trip_plans[demo_plan.trip_id] = demo_plan
+        return store
+
+    def save_trip_plan(self, plan: TripPlan) -> None:
+        self.trip_plans[plan.trip_id] = plan
+
+    def get_trip_plan(self, trip_id: str) -> TripPlan:
+        plan = self.trip_plans.get(trip_id)
+        if plan is None:
+            raise KeyError(trip_id)
+        return plan
+
+
+class ProposalSubmissionEnvelope(BaseModel):
+    """HTTP request body for proposal submission."""
+
+    trip_plan: TripPlan
+    request: PlannerProposalSubmissionRequest
+
+
+class ReadinessResponse(BaseModel):
+    """Readiness status for the planner-facing service."""
+
+    ok: bool
+    missing_config: list[str]
+    seeded_trip_ids: list[str]
+
+
+def _missing_runtime_config() -> list[str]:
+    return [name for name in REQUIRED_PLANNER_CONFIG if not os.getenv(name)]
+
+
+def create_app(store: PlannerServiceStore | None = None) -> FastAPI:
+    """Create the planner-facing HTTP application."""
+
+    planner_store = store or PlannerServiceStore.with_demo_seed()
+    app = FastAPI(
+        title="Travel Plan Permission Planner Service",
+        version="0.1.0",
+        description="Thin HTTP wrapper around the planner-facing policy API.",
+    )
+    app.state.planner_store = planner_store
+
+    @app.get("/healthz")
+    def healthcheck() -> dict[str, Any]:
+        return {
+            "ok": True,
+            "service": "travel-plan-permission",
+            "planner_routes": [
+                "/api/planner/policy-snapshot",
+                "/api/planner/proposals",
+                "/api/planner/proposals/{proposal_id}/executions/{execution_id}",
+                "/api/planner/executions/{execution_id}/evaluation-result",
+            ],
+        }
+
+    @app.get("/readyz", response_model=ReadinessResponse)
+    def readiness() -> ReadinessResponse:
+        missing = _missing_runtime_config()
+        response = ReadinessResponse(
+            ok=not missing,
+            missing_config=missing,
+            seeded_trip_ids=sorted(planner_store.trip_plans),
+        )
+        if missing:
+            raise HTTPException(status_code=503, detail=response.model_dump(mode="json"))
+        return response
+
+    @app.get("/api/planner/policy-snapshot", response_model=PlannerPolicySnapshot)
+    def planner_policy_snapshot(
+        request: Annotated[PlannerPolicySnapshotRequest, Body(...)],
+    ) -> PlannerPolicySnapshot:
+        try:
+            plan = planner_store.get_trip_plan(request.trip_id)
+        except KeyError as exc:
+            raise HTTPException(
+                status_code=404,
+                detail=(
+                    "No planner trip is loaded for "
+                    f"{request.trip_id!r}. Submit the trip first or use the seeded "
+                    "demo trip id TRIP-PLANNER-2001."
+                ),
+            ) from exc
+        return get_policy_snapshot(plan, request=request)
+
+    @app.post(
+        "/api/planner/proposals",
+        response_model=PlannerProposalOperationResponse,
+        status_code=202,
+    )
+    def planner_proposal_submission(
+        envelope: ProposalSubmissionEnvelope,
+    ) -> PlannerProposalOperationResponse:
+        planner_store.save_trip_plan(envelope.trip_plan)
+        try:
+            return submit_proposal(envelope.trip_plan, envelope.request)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    @app.get(
+        "/api/planner/proposals/{proposal_id}/executions/{execution_id}",
+        response_model=PlannerProposalOperationResponse,
+    )
+    def planner_execution_status(
+        proposal_id: str,
+        execution_id: str,
+        request: Annotated[PlannerProposalStatusRequest, Body(...)],
+    ) -> PlannerProposalOperationResponse:
+        if request.proposal_id != proposal_id or request.execution_id != execution_id:
+            raise HTTPException(
+                status_code=400,
+                detail="Route parameters must match the status request payload.",
+            )
+        try:
+            plan = planner_store.get_trip_plan(request.trip_id)
+            return poll_execution_status(plan, request)
+        except KeyError as exc:
+            raise HTTPException(
+                status_code=404,
+                detail=f"No stored planner trip for {request.trip_id!r}.",
+            ) from exc
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    @app.get(
+        "/api/planner/executions/{execution_id}/evaluation-result",
+        response_model=PlannerProposalEvaluationResult,
+    )
+    def planner_evaluation_result(
+        execution_id: str,
+        request: Annotated[PlannerProposalEvaluationRequest, Body(...)],
+    ) -> PlannerProposalEvaluationResult:
+        if request.execution_id != execution_id:
+            raise HTTPException(
+                status_code=400,
+                detail="Route parameters must match the evaluation request payload.",
+            )
+        try:
+            plan = planner_store.get_trip_plan(request.trip_id)
+            return get_evaluation_result(plan, request)
+        except KeyError as exc:
+            raise HTTPException(
+                status_code=404,
+                detail=f"No stored planner trip for {request.trip_id!r}.",
+            ) from exc
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return app
+
+
+app = create_app()
+
+
+def main() -> None:
+    """Run the planner-facing HTTP service with uvicorn."""
+
+    uvicorn.run(
+        "travel_plan_permission.planner_service:app",
+        host=os.getenv("TPP_SERVICE_HOST", "127.0.0.1"),
+        port=int(os.getenv("TPP_SERVICE_PORT", "8000")),
+        reload=False,
+    )

--- a/tests/python/test_planner_service.py
+++ b/tests/python/test_planner_service.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from travel_plan_permission.planner_service import PlannerServiceStore, create_app
+
+FIXTURE_ROOT = Path(__file__).resolve().parents[1] / "fixtures" / "planner_integration"
+
+
+def _fixture(name: str) -> dict[str, object]:
+    return json.loads((FIXTURE_ROOT / name).read_text(encoding="utf-8"))
+
+
+def test_healthcheck_lists_planner_routes() -> None:
+    client = TestClient(create_app(PlannerServiceStore.with_demo_seed()))
+
+    response = client.get("/healthz")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True
+    assert "/api/planner/policy-snapshot" in payload["planner_routes"]
+
+
+def test_readiness_reports_missing_runtime_config(monkeypatch) -> None:
+    for key in ("TPP_BASE_URL", "TPP_ACCESS_TOKEN", "TPP_OIDC_PROVIDER"):
+        monkeypatch.delenv(key, raising=False)
+
+    client = TestClient(create_app(PlannerServiceStore.with_demo_seed()))
+    response = client.get("/readyz")
+
+    assert response.status_code == 503
+    detail = response.json()["detail"]
+    assert detail["ok"] is False
+    assert detail["missing_config"] == [
+        "TPP_BASE_URL",
+        "TPP_ACCESS_TOKEN",
+        "TPP_OIDC_PROVIDER",
+    ]
+    assert detail["seeded_trip_ids"] == ["TRIP-PLANNER-2001"]
+
+
+def test_snapshot_route_returns_documented_contract_shape() -> None:
+    client = TestClient(create_app(PlannerServiceStore.with_demo_seed()))
+
+    response = client.request(
+        "GET",
+        "/api/planner/policy-snapshot",
+        json=_fixture("policy_snapshot_request.json"),
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["trip_id"] == "TRIP-PLANNER-2001"
+    assert payload["auth"]["endpoint"] == "GET /api/planner/policy-snapshot"
+    assert payload["versioning"]["contract_version"] == "2026-04-11"
+
+
+def test_submission_status_and_evaluation_routes_share_stored_trip_state() -> None:
+    client = TestClient(create_app(PlannerServiceStore.with_demo_seed()))
+    trip_plan = _fixture("proposal_submission.json")
+    submission_request = {
+        "trip_id": "TRIP-PLANNER-2001",
+        "proposal_id": "proposal-123",
+        "proposal_version": "proposal-v1",
+        "payload": {
+            "selected_options": ["flight-1", "hotel-3"],
+            "submission_mode": "queue",
+        },
+        "request_id": "req-submit-001",
+        "correlation_id": {
+            "value": "corr-submit-001",
+            "issued_by": "trip-planner",
+        },
+        "transport_pattern": "deferred",
+        "organization_id": "org-acme",
+        "submitted_at": "2026-04-11T12:30:00Z",
+        "service_available": True,
+    }
+
+    submit_response = client.post(
+        "/api/planner/proposals",
+        json={
+            "trip_plan": trip_plan,
+            "request": submission_request,
+        },
+    )
+
+    assert submit_response.status_code == 202
+    submit_payload = submit_response.json()
+    execution_id = submit_payload["result_payload"]["execution_id"]
+    assert submit_payload["status_endpoint"].endswith(execution_id)
+
+    status_response = client.request(
+        "GET",
+        f"/api/planner/proposals/proposal-123/executions/{execution_id}",
+        json={
+            "trip_id": "TRIP-PLANNER-2001",
+            "proposal_id": "proposal-123",
+            "proposal_version": "proposal-v1",
+            "execution_id": execution_id,
+            "request_id": "req-status-001",
+            "correlation_id": {
+                "value": "corr-submit-001",
+                "issued_by": "trip-planner",
+            },
+            "transport_pattern": "deferred",
+            "requested_at": "2026-04-11T12:31:00Z",
+            "service_available": True,
+        },
+    )
+
+    assert status_response.status_code == 200
+    status_payload = status_response.json()
+    assert status_payload["operation"] == "poll_execution_status"
+    assert status_payload["result_payload"]["trip_id"] == "TRIP-PLANNER-2001"
+
+    evaluation_response = client.request(
+        "GET",
+        f"/api/planner/executions/{execution_id}/evaluation-result",
+        json={
+            "trip_id": "TRIP-PLANNER-2001",
+            "proposal_id": "proposal-123",
+            "proposal_version": "proposal-v1",
+            "execution_id": execution_id,
+            "request_id": "req-eval-001",
+            "correlation_id": {
+                "value": "corr-submit-001",
+                "issued_by": "trip-planner",
+            },
+            "requested_at": "2026-04-11T12:32:00Z",
+        },
+    )
+
+    assert evaluation_response.status_code == 200
+    evaluation_payload = evaluation_response.json()
+    assert evaluation_payload["execution_id"] == execution_id
+    assert evaluation_payload["status_endpoint"].endswith(execution_id)
+    assert evaluation_payload["policy_result"]["status"] in {"pass", "fail"}


### PR DESCRIPTION
Closes #783

## Summary
- add a FastAPI planner service that wraps the existing policy API contract helpers
- seed the service with the planner integration demo trip and expose health/readiness checks
- add route-level tests plus a documented `tpp-planner-service` startup command

## Validation
- PYTHONPATH=src /tmp/tpp-issue-783-codex/.venv312/bin/python -m pytest tests/python/test_planner_service.py tests/python/test_planner_integration_contract.py tests/python/test_policy_api.py -k "policy_snapshot or proposal or planner_service"
- PYTHONPATH=src /tmp/tpp-issue-783-codex/.venv312/bin/python -m ruff check src/travel_plan_permission/planner_service.py src/travel_plan_permission/__init__.py tests/python/test_planner_service.py