### PR TITLE
Issue #784: harden planner HTTP auth bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,17 @@ Run the planner-facing HTTP adapter locally:
 ```bash
 export TPP_BASE_URL="http://127.0.0.1:8000"
 export TPP_ACCESS_TOKEN="dev-token"
+export TPP_ACCESS_TOKEN_SUBJECT="planner-preview"
+export TPP_ACCESS_TOKEN_ROLE="traveler"
 export TPP_OIDC_PROVIDER="google"
 tpp-planner-service --host 127.0.0.1 --port 8000
 ```
 
 Use `GET /healthz` for a basic liveness check and `GET /readyz` to verify that
 the required planner-facing runtime configuration is present before exercising
-the planner routes.
+the planner routes. The startup command now fails fast unless the bounded
+bootstrap auth contract is complete: base URL, bearer token, token subject,
+token role, and supported OIDC provider must all be configured.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -52,18 +52,27 @@ Run the planner-facing HTTP adapter locally:
 
 ```bash
 export TPP_BASE_URL="http://127.0.0.1:8000"
-export TPP_ACCESS_TOKEN="dev-token"
-export TPP_ACCESS_TOKEN_SUBJECT="planner-preview"
-export TPP_ACCESS_TOKEN_ROLE="traveler"
 export TPP_OIDC_PROVIDER="google"
+export TPP_AUTH_MODE="bootstrap-token"
+export TPP_BOOTSTRAP_SIGNING_SECRET="replace-with-a-local-preview-secret"
 tpp-planner-service --host 127.0.0.1 --port 8000
 ```
 
 Use `GET /healthz` for a basic liveness check and `GET /readyz` to verify that
 the required planner-facing runtime configuration is present before exercising
-the planner routes. The startup command now fails fast unless the bounded
-bootstrap auth contract is complete: base URL, bearer token, token subject,
-token role, and supported OIDC provider must all be configured.
+the planner routes. The startup command now fails fast unless the planner auth
+contract is complete: base URL, supported OIDC provider, and an explicit auth
+mode with its matching token configuration must all be present.
+
+For bounded local or preview testing, mint a short-lived planner token with:
+
+```bash
+tpp-planner-token --subject trip-planner-local
+```
+
+Use the emitted value as `Authorization: Bearer <token>` when calling planner
+routes. `TPP_AUTH_MODE="static-token"` plus `TPP_ACCESS_TOKEN` remains
+available for simple fixed-token environments.
 
 ## Documentation
 

--- a/docs/contracts/planner-integration.md
+++ b/docs/contracts/planner-integration.md
@@ -48,27 +48,27 @@ endpoint. The snapshot response itself publishes the auth contract:
 | Config | Required | Purpose |
 | --- | --- | --- |
 | `TPP_BASE_URL` | yes | Base URL for the TPP service |
-| `TPP_ACCESS_TOKEN` | yes | Bounded bootstrap bearer token presented to TPP for local/preview live tests |
-| `TPP_ACCESS_TOKEN_SUBJECT` | yes | Subject identity bound to the bootstrap token for endpoint authorization |
-| `TPP_ACCESS_TOKEN_ROLE` | yes | Role granted to the bootstrap token subject (`traveler`, `approver`, `finance_admin`, `policy_admin`, `system_admin`) |
 | `TPP_OIDC_PROVIDER` | yes | Identity provider name used to mint the bearer token |
+| `TPP_AUTH_MODE` | yes | Auth mode: `static-token` or `bootstrap-token` |
+| `TPP_ACCESS_TOKEN` | when `TPP_AUTH_MODE=static-token` | Fixed bearer token presented to TPP |
+| `TPP_BOOTSTRAP_SIGNING_SECRET` | when `TPP_AUTH_MODE=bootstrap-token` | Shared signing secret used to validate bounded bootstrap tokens |
+| `TPP_BOOTSTRAP_TOKEN_TTL_SECONDS` | no | Lifetime for locally minted bootstrap tokens |
 | `TPP_POLICY_SNAPSHOT_MAX_AGE_SECONDS` | no | Local cache TTL override for snapshot reuse |
 
 ### Expected request metadata
 
 When calling the planner snapshot seam, `trip-planner` should send:
 
-- `Authorization: Bearer <TPP_ACCESS_TOKEN>`
+- `Authorization: Bearer <planner bearer token>`
 - the `trip_id` in the request payload
 - `known_policy_version` when a cached snapshot already exists
 - `snapshot_generated_at` when the planner is re-checking a previously cached
   payload for freshness
 
-For local and preview live testing, the service treats `TPP_ACCESS_TOKEN` as a
-bounded bootstrap credential. Startup fails fast unless the token is paired
-with a configured subject and role, and each planner-facing endpoint still runs
-through the published endpoint permission map instead of bypassing
-authorization.
+For local or preview live testing, TPP can mint a bounded bootstrap token with
+`tpp-planner-token`. The token is short-lived and still carries explicit
+planner permissions (`view`, `create`) so endpoint authorization is exercised
+instead of bypassed.
 
 TPP returns the auth guidance for the seam inside `snapshot.auth`, so the
 planner can compare its runtime config to the server-advertised contract.

--- a/docs/contracts/planner-integration.md
+++ b/docs/contracts/planner-integration.md
@@ -48,7 +48,9 @@ endpoint. The snapshot response itself publishes the auth contract:
 | Config | Required | Purpose |
 | --- | --- | --- |
 | `TPP_BASE_URL` | yes | Base URL for the TPP service |
-| `TPP_ACCESS_TOKEN` | yes | Bearer token presented to TPP |
+| `TPP_ACCESS_TOKEN` | yes | Bounded bootstrap bearer token presented to TPP for local/preview live tests |
+| `TPP_ACCESS_TOKEN_SUBJECT` | yes | Subject identity bound to the bootstrap token for endpoint authorization |
+| `TPP_ACCESS_TOKEN_ROLE` | yes | Role granted to the bootstrap token subject (`traveler`, `approver`, `finance_admin`, `policy_admin`, `system_admin`) |
 | `TPP_OIDC_PROVIDER` | yes | Identity provider name used to mint the bearer token |
 | `TPP_POLICY_SNAPSHOT_MAX_AGE_SECONDS` | no | Local cache TTL override for snapshot reuse |
 
@@ -61,6 +63,12 @@ When calling the planner snapshot seam, `trip-planner` should send:
 - `known_policy_version` when a cached snapshot already exists
 - `snapshot_generated_at` when the planner is re-checking a previously cached
   payload for freshness
+
+For local and preview live testing, the service treats `TPP_ACCESS_TOKEN` as a
+bounded bootstrap credential. Startup fails fast unless the token is paired
+with a configured subject and role, and each planner-facing endpoint still runs
+through the published endpoint permission map instead of bypassing
+authorization.
 
 TPP returns the auth guidance for the seam inside `snapshot.auth`, so the
 planner can compare its runtime config to the server-advertised contract.

--- a/docs/policy-api.md
+++ b/docs/policy-api.md
@@ -208,6 +208,11 @@ Example JSON structure for proposal submission or status polling:
 For the full planner-facing transport, versioning, and fixture contract, see
 [`docs/contracts/planner-integration.md`](./contracts/planner-integration.md).
 
+For live HTTP testing, the runtime must also supply
+`TPP_ACCESS_TOKEN_SUBJECT` and `TPP_ACCESS_TOKEN_ROLE` alongside the bearer
+token so the service can authorize planner endpoints through the published
+permission model.
+
 ### PlannerProposalEvaluationResult (output)
 
 Example JSON structure for planner-facing evaluation results:

--- a/docs/policy-api.md
+++ b/docs/policy-api.md
@@ -395,8 +395,13 @@ objects.
 
 - Call the seam as `GET /api/planner/policy-snapshot`.
 - Access requires the `view` permission from the security model.
-- The expected auth scheme is a bearer token obtained through one of the
-  configured SSO providers: `azure_ad`, `okta`, or `google`.
+- The expected auth scheme is a bearer token validated against one of the
+  configured auth modes:
+  - `static-token` using `TPP_ACCESS_TOKEN`
+  - `bootstrap-token` using short-lived tokens minted by
+    `tpp-planner-token` and validated against
+    `TPP_BOOTSTRAP_SIGNING_SECRET`
+- The configured provider must still be one of `azure_ad`, `okta`, or `google`.
 - Cache the response by `versioning.etag` and invalidate local planner guidance
   when `versioning.compatible_with_planner_cache` is `false`.
 - The canonical request/response examples for this seam live in

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -28,22 +28,38 @@ Core permissions: `view`, `create`, `approve`, `export`, `configure`.
 
 ## Planner integration auth contract
 
-The current planner-facing integration seam uses a bearer-token read contract
-for `GET /api/planner/policy-snapshot`.
+The current planner-facing integration seam uses a bearer-token contract for
+the planner HTTP surface. The service now requires an explicit auth mode so
+startup and readiness can fail deterministically before the service claims it is
+ready for planner traffic.
 
 When `trip-planner` calls TPP over a network boundary, it should send:
 
-- `Authorization: Bearer <TPP_ACCESS_TOKEN>`
+- `Authorization: Bearer <planner bearer token>`
 - a `trip_id` inside the snapshot request payload
 - `known_policy_version` when the planner is revalidating cached guidance
 
 The expected deployment config shape is:
 
 - `TPP_BASE_URL`
-- `TPP_ACCESS_TOKEN`
-- `TPP_ACCESS_TOKEN_SUBJECT`
-- `TPP_ACCESS_TOKEN_ROLE`
 - `TPP_OIDC_PROVIDER`
+- `TPP_AUTH_MODE`
+- `TPP_ACCESS_TOKEN` when `TPP_AUTH_MODE=static-token`
+- `TPP_BOOTSTRAP_SIGNING_SECRET` when `TPP_AUTH_MODE=bootstrap-token`
+- `TPP_BOOTSTRAP_TOKEN_TTL_SECONDS` optionally bounds local or preview bootstrap tokens
+
+### Supported auth modes
+
+- `static-token` keeps the existing fixed bearer-token model and is suitable for
+  simple environments where the caller and service share one secret.
+- `bootstrap-token` is the preferred local or preview mode. Operators mint a
+  short-lived token with `tpp-planner-token`, and the service validates its
+  signature, provider, expiry, and required endpoint permission.
+
+The planner-facing endpoints currently require:
+
+- `view` for policy snapshot, execution status, and evaluation-result reads
+- `create` for proposal submission
 
 The snapshot response advertises the currently supported SSO providers
 (`azure_ad`, `okta`, `google`) and the required `view` permission so planner

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -41,11 +41,19 @@ The expected deployment config shape is:
 
 - `TPP_BASE_URL`
 - `TPP_ACCESS_TOKEN`
+- `TPP_ACCESS_TOKEN_SUBJECT`
+- `TPP_ACCESS_TOKEN_ROLE`
 - `TPP_OIDC_PROVIDER`
 
 The snapshot response advertises the currently supported SSO providers
 (`azure_ad`, `okta`, `google`) and the required `view` permission so planner
 runtime config can be checked against the published seam.
+
+For local and preview live tests, `TPP_ACCESS_TOKEN` is a bounded bootstrap
+credential, not an auth bypass. Startup fails unless the token is paired with a
+subject and one of the modeled roles, and planner-facing routes still
+authorize that role against the endpoint permission map before serving the
+request.
 
 ## Delegation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ orchestration = [
 [project.scripts]
 fill-spreadsheet = "travel_plan_permission.cli:main"
 orchestration-demo = "travel_plan_permission.orchestration.example:main"
+tpp-planner-token = "travel_plan_permission.planner_auth:main"
 tpp-planner-service = "travel_plan_permission.http_service:main"
 
 [build-system]

--- a/src/travel_plan_permission/__init__.py
+++ b/src/travel_plan_permission/__init__.py
@@ -32,6 +32,12 @@ from .models import (
     build_exception_dashboard,
     determine_exception_approval_level,
 )
+from .planner_auth import (
+    PlannerAuthConfig,
+    PlannerAuthContext,
+    PlannerAuthMode,
+    mint_bootstrap_token,
+)
 from .policy import (
     AdvanceBookingRule,
     CabinClassRule,
@@ -212,6 +218,9 @@ __all__ = [
     "PlannerExecutionState",
     "PlannerOperationType",
     "PlannerApprovalTrigger",
+    "PlannerAuthConfig",
+    "PlannerAuthContext",
+    "PlannerAuthMode",
     "PlannerAuthContract",
     "PlannerBlockingIssue",
     "PlannerPolicyRequirement",
@@ -284,6 +293,7 @@ __all__ = [
     "RoleChangeState",
     "RoleName",
     "snapshot_from_plan",
+    "mint_bootstrap_token",
     "__version__",
 ]
 __version__ = "0.1.0"

--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -25,14 +25,29 @@ from .policy_api import (
     poll_execution_status,
     submit_proposal,
 )
+from .security import (
+    PLANNER_EVALUATION_RESULT_ENDPOINT,
+    PLANNER_EXECUTION_STATUS_ENDPOINT,
+    PLANNER_POLICY_SNAPSHOT_ENDPOINT,
+    PLANNER_PROPOSAL_SUBMISSION_ENDPOINT,
+    RoleName,
+    SecurityModel,
+)
 
 _REQUIRED_PLANNER_ENV_VARS = (
     "TPP_BASE_URL",
     "TPP_ACCESS_TOKEN",
+    "TPP_ACCESS_TOKEN_ROLE",
+    "TPP_ACCESS_TOKEN_SUBJECT",
     "TPP_OIDC_PROVIDER",
 )
 _SUPPORTED_OIDC_PROVIDERS = ("azure_ad", "okta", "google")
+_SUPPORTED_BOOTSTRAP_ROLES = tuple(role.value for role in RoleName)
 _OPTIONAL_SNAPSHOT_BODY = Body(default=None)
+
+
+class PlannerRuntimeConfigError(RuntimeError):
+    """Raised when the planner-facing HTTP runtime is misconfigured."""
 
 
 class PlannerRuntimeConfig(BaseModel):
@@ -40,44 +55,89 @@ class PlannerRuntimeConfig(BaseModel):
 
     base_url: str | None = Field(default=None)
     oidc_provider: str | None = Field(default=None)
+    access_token_role: str | None = Field(default=None)
+    access_token_subject: str | None = Field(default=None)
     access_token_configured: bool = Field(default=False)
     missing_config: list[str] = Field(default_factory=list)
+    invalid_config: list[str] = Field(default_factory=list)
 
     @classmethod
     def from_env(cls) -> PlannerRuntimeConfig:
         base_url = os.getenv("TPP_BASE_URL")
         access_token = os.getenv("TPP_ACCESS_TOKEN")
+        access_token_role = os.getenv("TPP_ACCESS_TOKEN_ROLE")
+        access_token_subject = os.getenv("TPP_ACCESS_TOKEN_SUBJECT")
         oidc_provider = os.getenv("TPP_OIDC_PROVIDER")
         missing = [
             env_var for env_var in _REQUIRED_PLANNER_ENV_VARS if not os.getenv(env_var)
         ]
+        invalid: list[str] = []
         if (
             oidc_provider
             and oidc_provider not in _SUPPORTED_OIDC_PROVIDERS
             and "TPP_OIDC_PROVIDER" not in missing
         ):
-            missing.append("TPP_OIDC_PROVIDER")
+            invalid.append("TPP_OIDC_PROVIDER")
+        if (
+            access_token_role
+            and access_token_role not in _SUPPORTED_BOOTSTRAP_ROLES
+            and "TPP_ACCESS_TOKEN_ROLE" not in missing
+        ):
+            invalid.append("TPP_ACCESS_TOKEN_ROLE")
         return cls(
             base_url=base_url,
             oidc_provider=oidc_provider,
+            access_token_role=access_token_role,
+            access_token_subject=access_token_subject,
             access_token_configured=bool(access_token),
             missing_config=missing,
+            invalid_config=invalid,
         )
 
     @property
     def is_ready(self) -> bool:
         """Return whether the required planner-facing config is present."""
 
-        return not self.missing_config
+        return not self.missing_config and not self.invalid_config
+
+    def ensure_valid(self) -> None:
+        """Raise a runtime error when the planner-facing config is not usable."""
+
+        if self.is_ready:
+            return
+        problems: list[str] = []
+        if self.missing_config:
+            problems.append("missing: " + ", ".join(sorted(self.missing_config)))
+        if self.invalid_config:
+            problems.append("invalid: " + ", ".join(sorted(self.invalid_config)))
+        supported_roles = ", ".join(_SUPPORTED_BOOTSTRAP_ROLES)
+        supported_providers = ", ".join(_SUPPORTED_OIDC_PROVIDERS)
+        raise PlannerRuntimeConfigError(
+            "Planner HTTP service runtime is misconfigured ("
+            + "; ".join(problems)
+            + f"). Supported TPP_ACCESS_TOKEN_ROLE values: {supported_roles}. "
+            + f"Supported TPP_OIDC_PROVIDER values: {supported_providers}."
+        )
 
 
-def _require_bearer_token(authorization: str | None) -> None:
-    expected = os.getenv("TPP_ACCESS_TOKEN")
-    if not expected:
+def _runtime_config_or_503() -> PlannerRuntimeConfig:
+    config = PlannerRuntimeConfig.from_env()
+    if not config.is_ready:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Planner access token is not configured.",
+            detail={
+                "message": "Planner runtime auth/config is not ready.",
+                "missing_config": config.missing_config,
+                "invalid_config": config.invalid_config,
+            },
         )
+    return config
+
+
+def _require_bearer_token(authorization: str | None, *, endpoint: str) -> None:
+    config = _runtime_config_or_503()
+    expected = os.getenv("TPP_ACCESS_TOKEN")
+    assert expected is not None
     if authorization is None or not authorization.startswith("Bearer "):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -87,6 +147,17 @@ def _require_bearer_token(authorization: str | None) -> None:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Invalid bearer token.",
+        )
+    assert config.access_token_subject is not None
+    assert config.access_token_role is not None
+    if not SecurityModel().authorize(
+        config.access_token_subject,
+        RoleName(config.access_token_role),
+        endpoint,
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Configured bearer token is not authorized for this endpoint.",
         )
 
 
@@ -247,7 +318,10 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         request_body: PlannerPolicySnapshotHttpRequest | None = _OPTIONAL_SNAPSHOT_BODY,
         authorization: str | None = Header(default=None),
     ) -> PlannerPolicySnapshot:
-        _require_bearer_token(authorization)
+        _require_bearer_token(
+            authorization,
+            endpoint=PLANNER_POLICY_SNAPSHOT_ENDPOINT,
+        )
         trip_plan: TripPlan | None = None
         snapshot_request: PlannerPolicySnapshotRequest | None = None
 
@@ -291,7 +365,10 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         payload: PlannerProposalSubmissionHttpRequest,
         authorization: str | None = Header(default=None),
     ) -> PlannerProposalOperationResponse:
-        _require_bearer_token(authorization)
+        _require_bearer_token(
+            authorization,
+            endpoint=PLANNER_PROPOSAL_SUBMISSION_ENDPOINT,
+        )
         try:
             planner_response = submit_proposal(payload.trip_plan, payload.request)
         except ValueError as exc:
@@ -315,7 +392,10 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         execution_id: str,
         authorization: str | None = Header(default=None),
     ) -> PlannerProposalOperationResponse:
-        _require_bearer_token(authorization)
+        _require_bearer_token(
+            authorization,
+            endpoint=PLANNER_EXECUTION_STATUS_ENDPOINT,
+        )
         stored = proposal_store.lookup_submission(execution_id)
         if stored is None:
             raise HTTPException(
@@ -350,7 +430,10 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         execution_id: str,
         authorization: str | None = Header(default=None),
     ) -> PlannerProposalEvaluationResult:
-        _require_bearer_token(authorization)
+        _require_bearer_token(
+            authorization,
+            endpoint=PLANNER_EVALUATION_RESULT_ENDPOINT,
+        )
         stored = proposal_store.lookup_submission(execution_id)
         if stored is None:
             raise HTTPException(
@@ -394,9 +477,9 @@ def main(argv: list[str] | None = None) -> int:
 
     parser = _build_parser()
     args = parser.parse_args(argv)
+    PlannerRuntimeConfig.from_env().ensure_valid()
     uvicorn.run(
-        "travel_plan_permission.http_service:create_app",
-        factory=True,
+        create_app(),
         host=args.host,
         port=args.port,
         reload=args.reload,

--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import os
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 
@@ -12,6 +11,7 @@ from fastapi import Body, FastAPI, Header, HTTPException, Query, Response, statu
 from pydantic import BaseModel, Field
 
 from .models import TripPlan
+from .planner_auth import PlannerAuthConfig, authenticate_request
 from .policy_api import (
     PlannerPolicySnapshot,
     PlannerPolicySnapshotRequest,
@@ -25,24 +25,8 @@ from .policy_api import (
     poll_execution_status,
     submit_proposal,
 )
-from .security import (
-    PLANNER_EVALUATION_RESULT_ENDPOINT,
-    PLANNER_EXECUTION_STATUS_ENDPOINT,
-    PLANNER_POLICY_SNAPSHOT_ENDPOINT,
-    PLANNER_PROPOSAL_SUBMISSION_ENDPOINT,
-    RoleName,
-    SecurityModel,
-)
+from .security import Permission
 
-_REQUIRED_PLANNER_ENV_VARS = (
-    "TPP_BASE_URL",
-    "TPP_ACCESS_TOKEN",
-    "TPP_ACCESS_TOKEN_ROLE",
-    "TPP_ACCESS_TOKEN_SUBJECT",
-    "TPP_OIDC_PROVIDER",
-)
-_SUPPORTED_OIDC_PROVIDERS = ("azure_ad", "okta", "google")
-_SUPPORTED_BOOTSTRAP_ROLES = tuple(role.value for role in RoleName)
 _OPTIONAL_SNAPSHOT_BODY = Body(default=None)
 
 
@@ -55,43 +39,25 @@ class PlannerRuntimeConfig(BaseModel):
 
     base_url: str | None = Field(default=None)
     oidc_provider: str | None = Field(default=None)
-    access_token_role: str | None = Field(default=None)
-    access_token_subject: str | None = Field(default=None)
+    auth_mode: str | None = Field(default=None)
     access_token_configured: bool = Field(default=False)
+    bootstrap_secret_configured: bool = Field(default=False)
+    bootstrap_ttl_seconds: int | None = Field(default=None)
     missing_config: list[str] = Field(default_factory=list)
     invalid_config: list[str] = Field(default_factory=list)
 
     @classmethod
     def from_env(cls) -> PlannerRuntimeConfig:
-        base_url = os.getenv("TPP_BASE_URL")
-        access_token = os.getenv("TPP_ACCESS_TOKEN")
-        access_token_role = os.getenv("TPP_ACCESS_TOKEN_ROLE")
-        access_token_subject = os.getenv("TPP_ACCESS_TOKEN_SUBJECT")
-        oidc_provider = os.getenv("TPP_OIDC_PROVIDER")
-        missing = [
-            env_var for env_var in _REQUIRED_PLANNER_ENV_VARS if not os.getenv(env_var)
-        ]
-        invalid: list[str] = []
-        if (
-            oidc_provider
-            and oidc_provider not in _SUPPORTED_OIDC_PROVIDERS
-            and "TPP_OIDC_PROVIDER" not in missing
-        ):
-            invalid.append("TPP_OIDC_PROVIDER")
-        if (
-            access_token_role
-            and access_token_role not in _SUPPORTED_BOOTSTRAP_ROLES
-            and "TPP_ACCESS_TOKEN_ROLE" not in missing
-        ):
-            invalid.append("TPP_ACCESS_TOKEN_ROLE")
+        config = PlannerAuthConfig.from_env()
         return cls(
-            base_url=base_url,
-            oidc_provider=oidc_provider,
-            access_token_role=access_token_role,
-            access_token_subject=access_token_subject,
-            access_token_configured=bool(access_token),
-            missing_config=missing,
-            invalid_config=invalid,
+            base_url=config.base_url,
+            oidc_provider=config.oidc_provider,
+            auth_mode=config.auth_mode.value if config.auth_mode else None,
+            access_token_configured=config.access_token_configured,
+            bootstrap_secret_configured=config.bootstrap_secret_configured,
+            bootstrap_ttl_seconds=config.bootstrap_ttl_seconds,
+            missing_config=list(config.missing_config),
+            invalid_config=list(config.invalid_config),
         )
 
     @property
@@ -110,55 +76,44 @@ class PlannerRuntimeConfig(BaseModel):
             problems.append("missing: " + ", ".join(sorted(self.missing_config)))
         if self.invalid_config:
             problems.append("invalid: " + ", ".join(sorted(self.invalid_config)))
-        supported_roles = ", ".join(_SUPPORTED_BOOTSTRAP_ROLES)
-        supported_providers = ", ".join(_SUPPORTED_OIDC_PROVIDERS)
         raise PlannerRuntimeConfigError(
             "Planner HTTP service runtime is misconfigured ("
             + "; ".join(problems)
-            + f"). Supported TPP_ACCESS_TOKEN_ROLE values: {supported_roles}. "
-            + f"Supported TPP_OIDC_PROVIDER values: {supported_providers}."
+            + "). Supported auth modes: static-token, bootstrap-token. "
+            + "Supported TPP_OIDC_PROVIDER values: azure_ad, okta, google."
         )
 
 
-def _runtime_config_or_503() -> PlannerRuntimeConfig:
-    config = PlannerRuntimeConfig.from_env()
+def _authorize_request(
+    authorization: str | None,
+    *,
+    required_permission: Permission,
+) -> None:
+    config = PlannerAuthConfig.from_env()
     if not config.is_ready:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail={
-                "message": "Planner runtime auth/config is not ready.",
-                "missing_config": config.missing_config,
-                "invalid_config": config.invalid_config,
-            },
+            detail="Planner auth config is not ready.",
         )
-    return config
-
-
-def _require_bearer_token(authorization: str | None, *, endpoint: str) -> None:
-    config = _runtime_config_or_503()
-    expected = os.getenv("TPP_ACCESS_TOKEN")
-    assert expected is not None
-    if authorization is None or not authorization.startswith("Bearer "):
+    try:
+        authenticate_request(
+            authorization,
+            config=config,
+            required_permission=required_permission,
+        )
+    except PermissionError as exc:
+        detail = str(exc)
+        status_code = (
+            status.HTTP_401_UNAUTHORIZED
+            if detail == "Missing bearer token."
+            else status.HTTP_403_FORBIDDEN
+        )
+        raise HTTPException(status_code=status_code, detail=detail) from exc
+    except ValueError as exc:
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Missing bearer token.",
-        )
-    if authorization.removeprefix("Bearer ").strip() != expected:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Invalid bearer token.",
-        )
-    assert config.access_token_subject is not None
-    assert config.access_token_role is not None
-    if not SecurityModel().authorize(
-        config.access_token_subject,
-        RoleName(config.access_token_role),
-        endpoint,
-    ):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Configured bearer token is not authorized for this endpoint.",
-        )
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=str(exc),
+        ) from exc
 
 
 class PlannerReadinessResponse(BaseModel):
@@ -318,9 +273,9 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         request_body: PlannerPolicySnapshotHttpRequest | None = _OPTIONAL_SNAPSHOT_BODY,
         authorization: str | None = Header(default=None),
     ) -> PlannerPolicySnapshot:
-        _require_bearer_token(
+        _authorize_request(
             authorization,
-            endpoint=PLANNER_POLICY_SNAPSHOT_ENDPOINT,
+            required_permission=Permission.VIEW,
         )
         trip_plan: TripPlan | None = None
         snapshot_request: PlannerPolicySnapshotRequest | None = None
@@ -365,9 +320,9 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         payload: PlannerProposalSubmissionHttpRequest,
         authorization: str | None = Header(default=None),
     ) -> PlannerProposalOperationResponse:
-        _require_bearer_token(
+        _authorize_request(
             authorization,
-            endpoint=PLANNER_PROPOSAL_SUBMISSION_ENDPOINT,
+            required_permission=Permission.CREATE,
         )
         try:
             planner_response = submit_proposal(payload.trip_plan, payload.request)
@@ -392,9 +347,9 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         execution_id: str,
         authorization: str | None = Header(default=None),
     ) -> PlannerProposalOperationResponse:
-        _require_bearer_token(
+        _authorize_request(
             authorization,
-            endpoint=PLANNER_EXECUTION_STATUS_ENDPOINT,
+            required_permission=Permission.VIEW,
         )
         stored = proposal_store.lookup_submission(execution_id)
         if stored is None:
@@ -430,9 +385,9 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         execution_id: str,
         authorization: str | None = Header(default=None),
     ) -> PlannerProposalEvaluationResult:
-        _require_bearer_token(
+        _authorize_request(
             authorization,
-            endpoint=PLANNER_EVALUATION_RESULT_ENDPOINT,
+            required_permission=Permission.VIEW,
         )
         stored = proposal_store.lookup_submission(execution_id)
         if stored is None:
@@ -479,7 +434,8 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     PlannerRuntimeConfig.from_env().ensure_valid()
     uvicorn.run(
-        create_app(),
+        "travel_plan_permission.http_service:create_app",
+        factory=True,
         host=args.host,
         port=args.port,
         reload=args.reload,

--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 
@@ -268,7 +269,6 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
 
     @app.get("/api/planner/policy-snapshot", response_model=PlannerPolicySnapshot)
     def policy_snapshot(
-        response: Response,
         trip_id: str | None = Query(default=None),
         request_body: PlannerPolicySnapshotHttpRequest | None = _OPTIONAL_SNAPSHOT_BODY,
         authorization: str | None = Header(default=None),
@@ -301,9 +301,6 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         snapshot_request = snapshot_request or PlannerPolicySnapshotRequest(
             trip_id=trip_plan.trip_id
         )
-        readiness = _readiness_response()
-        if readiness.status != "ready":
-            response.headers["x-tpp-readiness"] = "misconfigured"
         try:
             return get_policy_snapshot(trip_plan, snapshot_request)
         except ValueError as exc:
@@ -432,7 +429,11 @@ def main(argv: list[str] | None = None) -> int:
 
     parser = _build_parser()
     args = parser.parse_args(argv)
-    PlannerRuntimeConfig.from_env().ensure_valid()
+    try:
+        PlannerRuntimeConfig.from_env().ensure_valid()
+    except PlannerRuntimeConfigError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
     uvicorn.run(
         "travel_plan_permission.http_service:create_app",
         factory=True,

--- a/src/travel_plan_permission/planner_auth.py
+++ b/src/travel_plan_permission/planner_auth.py
@@ -1,0 +1,347 @@
+"""Planner-facing auth configuration and bounded bootstrap token support."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import hmac
+import json
+import os
+import secrets
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from enum import StrEnum
+
+from .security import Permission
+
+_SUPPORTED_OIDC_PROVIDERS = ("azure_ad", "okta", "google")
+_TOKEN_VERSION = "tppv1"
+_DEFAULT_BOOTSTRAP_TTL_SECONDS = 900
+_MIN_SIGNING_SECRET_LENGTH = 16
+_PLANNER_TOKEN_AUDIENCE = "planner-service"
+_PLANNER_STATIC_TOKEN_SUBJECT = "planner-static-client"
+
+
+class PlannerAuthMode(StrEnum):
+    """Configured planner-facing authentication mode."""
+
+    STATIC_TOKEN = "static-token"
+    BOOTSTRAP_TOKEN = "bootstrap-token"
+
+
+@dataclass(frozen=True)
+class PlannerAuthContext:
+    """Authenticated caller context for planner-facing endpoints."""
+
+    subject: str
+    permissions: tuple[Permission, ...]
+    provider: str
+    expires_at: datetime | None
+    auth_mode: PlannerAuthMode
+
+    def can(self, permission: Permission) -> bool:
+        """Return whether the caller has the required permission."""
+
+        return permission in self.permissions
+
+
+@dataclass(frozen=True)
+class PlannerBootstrapTokenClaims:
+    """Claims encoded inside a bounded bootstrap token."""
+
+    sub: str
+    permissions: tuple[Permission, ...]
+    provider: str
+    aud: str
+    iat: int
+    exp: int
+
+
+@dataclass(frozen=True)
+class PlannerAuthConfig:
+    """Runtime config contract for planner-facing authentication."""
+
+    base_url: str | None
+    oidc_provider: str | None
+    auth_mode: PlannerAuthMode | None
+    access_token_configured: bool
+    bootstrap_secret_configured: bool
+    bootstrap_ttl_seconds: int | None
+    missing_config: tuple[str, ...]
+    invalid_config: tuple[str, ...]
+
+    @classmethod
+    def from_env(cls) -> PlannerAuthConfig:
+        base_url = os.getenv("TPP_BASE_URL")
+        oidc_provider = os.getenv("TPP_OIDC_PROVIDER")
+        auth_mode_raw = os.getenv("TPP_AUTH_MODE")
+        access_token = os.getenv("TPP_ACCESS_TOKEN")
+        bootstrap_secret = os.getenv("TPP_BOOTSTRAP_SIGNING_SECRET")
+        ttl_raw = os.getenv("TPP_BOOTSTRAP_TOKEN_TTL_SECONDS")
+
+        missing: list[str] = []
+        invalid: list[str] = []
+
+        if not base_url:
+            missing.append("TPP_BASE_URL")
+        if not oidc_provider:
+            missing.append("TPP_OIDC_PROVIDER")
+        elif oidc_provider not in _SUPPORTED_OIDC_PROVIDERS:
+            invalid.append("TPP_OIDC_PROVIDER")
+
+        auth_mode: PlannerAuthMode | None = None
+        if not auth_mode_raw:
+            missing.append("TPP_AUTH_MODE")
+        else:
+            try:
+                auth_mode = PlannerAuthMode(auth_mode_raw)
+            except ValueError:
+                invalid.append("TPP_AUTH_MODE")
+
+        bootstrap_ttl_seconds: int | None = None
+        if ttl_raw:
+            try:
+                bootstrap_ttl_seconds = int(ttl_raw)
+            except ValueError:
+                invalid.append("TPP_BOOTSTRAP_TOKEN_TTL_SECONDS")
+            else:
+                if bootstrap_ttl_seconds <= 0:
+                    invalid.append("TPP_BOOTSTRAP_TOKEN_TTL_SECONDS")
+
+        if auth_mode == PlannerAuthMode.STATIC_TOKEN and not access_token:
+            missing.append("TPP_ACCESS_TOKEN")
+        if auth_mode == PlannerAuthMode.BOOTSTRAP_TOKEN:
+            if not bootstrap_secret:
+                missing.append("TPP_BOOTSTRAP_SIGNING_SECRET")
+            elif len(bootstrap_secret) < _MIN_SIGNING_SECRET_LENGTH:
+                invalid.append("TPP_BOOTSTRAP_SIGNING_SECRET")
+
+        return cls(
+            base_url=base_url,
+            oidc_provider=oidc_provider,
+            auth_mode=auth_mode,
+            access_token_configured=bool(access_token),
+            bootstrap_secret_configured=bool(bootstrap_secret),
+            bootstrap_ttl_seconds=bootstrap_ttl_seconds
+            or _DEFAULT_BOOTSTRAP_TTL_SECONDS,
+            missing_config=tuple(missing),
+            invalid_config=tuple(invalid),
+        )
+
+    @property
+    def is_ready(self) -> bool:
+        """Return whether planner-facing auth config is valid."""
+
+        return not self.missing_config and not self.invalid_config
+
+
+def _b64url_encode(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _b64url_decode(raw: str) -> bytes:
+    padding = "=" * (-len(raw) % 4)
+    return base64.urlsafe_b64decode(f"{raw}{padding}")
+
+
+def _signed_token(payload: dict[str, object], secret: str) -> str:
+    payload_bytes = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    encoded_payload = _b64url_encode(payload_bytes)
+    signature = hmac.new(
+        secret.encode("utf-8"),
+        encoded_payload.encode("utf-8"),
+        hashlib.sha256,
+    ).digest()
+    return f"{_TOKEN_VERSION}.{encoded_payload}.{_b64url_encode(signature)}"
+
+
+def mint_bootstrap_token(
+    *,
+    subject: str,
+    permissions: tuple[Permission, ...],
+    provider: str,
+    secret: str,
+    expires_in_seconds: int,
+    now: datetime | None = None,
+) -> str:
+    """Create a short-lived bootstrap bearer token for local or preview tests."""
+
+    current_time = now or datetime.now(UTC)
+    issued_at = int(current_time.timestamp())
+    expires_at = int((current_time + timedelta(seconds=expires_in_seconds)).timestamp())
+    payload = {
+        "aud": _PLANNER_TOKEN_AUDIENCE,
+        "exp": expires_at,
+        "iat": issued_at,
+        "permissions": [permission.value for permission in permissions],
+        "provider": provider,
+        "sub": subject,
+    }
+    return _signed_token(payload, secret)
+
+
+def _parse_bootstrap_token(token: str, *, secret: str) -> PlannerBootstrapTokenClaims:
+    try:
+        version, encoded_payload, encoded_signature = token.split(".")
+    except ValueError as exc:
+        raise ValueError("Malformed bootstrap token.") from exc
+    if version != _TOKEN_VERSION:
+        raise ValueError("Unsupported bootstrap token version.")
+
+    expected_signature = hmac.new(
+        secret.encode("utf-8"),
+        encoded_payload.encode("utf-8"),
+        hashlib.sha256,
+    ).digest()
+    actual_signature = _b64url_decode(encoded_signature)
+    if not secrets.compare_digest(actual_signature, expected_signature):
+        raise ValueError("Invalid bootstrap token signature.")
+
+    try:
+        payload = json.loads(_b64url_decode(encoded_payload))
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise ValueError("Malformed bootstrap token payload.") from exc
+
+    try:
+        permissions = tuple(Permission(value) for value in payload["permissions"])
+        return PlannerBootstrapTokenClaims(
+            sub=str(payload["sub"]),
+            permissions=permissions,
+            provider=str(payload["provider"]),
+            aud=str(payload["aud"]),
+            iat=int(payload["iat"]),
+            exp=int(payload["exp"]),
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError("Malformed bootstrap token claims.") from exc
+
+
+def authenticate_request(
+    authorization: str | None,
+    *,
+    config: PlannerAuthConfig,
+    required_permission: Permission,
+    now: datetime | None = None,
+) -> PlannerAuthContext:
+    """Validate the request bearer token against the configured planner auth mode."""
+
+    if not config.is_ready:
+        raise ValueError("Planner auth config is not ready.")
+    if authorization is None or not authorization.startswith("Bearer "):
+        raise PermissionError("Missing bearer token.")
+
+    token = authorization.removeprefix("Bearer ").strip()
+    if config.auth_mode == PlannerAuthMode.STATIC_TOKEN:
+        expected = os.getenv("TPP_ACCESS_TOKEN")
+        if expected is None or not secrets.compare_digest(token, expected):
+            raise PermissionError("Invalid bearer token.")
+        permissions = (Permission.VIEW, Permission.CREATE)
+        if required_permission not in permissions:
+            raise PermissionError(
+                f"Static planner token does not grant '{required_permission.value}'."
+            )
+        if config.oidc_provider is None:
+            raise ValueError("Planner auth config is not ready.")
+        return PlannerAuthContext(
+            subject=_PLANNER_STATIC_TOKEN_SUBJECT,
+            permissions=permissions,
+            provider=config.oidc_provider,
+            expires_at=None,
+            auth_mode=PlannerAuthMode.STATIC_TOKEN,
+        )
+
+    if config.auth_mode != PlannerAuthMode.BOOTSTRAP_TOKEN:
+        raise ValueError("Unsupported planner auth mode.")
+
+    secret = os.getenv("TPP_BOOTSTRAP_SIGNING_SECRET")
+    if secret is None:
+        raise ValueError("Planner auth config is not ready.")
+
+    claims = _parse_bootstrap_token(token, secret=secret)
+    if claims.aud != _PLANNER_TOKEN_AUDIENCE:
+        raise PermissionError("Bootstrap token audience is invalid.")
+    if config.oidc_provider is None or claims.provider != config.oidc_provider:
+        raise PermissionError("Bootstrap token provider does not match service config.")
+
+    current_time = now or datetime.now(UTC)
+    if int(current_time.timestamp()) >= claims.exp:
+        raise PermissionError("Bootstrap token has expired.")
+    if required_permission not in claims.permissions:
+        raise PermissionError(
+            f"Bootstrap token does not grant '{required_permission.value}'."
+        )
+    return PlannerAuthContext(
+        subject=claims.sub,
+        permissions=claims.permissions,
+        provider=claims.provider,
+        expires_at=datetime.fromtimestamp(claims.exp, tz=UTC),
+        auth_mode=PlannerAuthMode.BOOTSTRAP_TOKEN,
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="tpp-planner-token",
+        description="Mint a bounded bootstrap token for planner-facing live tests.",
+    )
+    parser.add_argument(
+        "--subject",
+        default="trip-planner-local",
+        help="Subject recorded in the minted bootstrap token.",
+    )
+    parser.add_argument(
+        "--permission",
+        action="append",
+        dest="permissions",
+        choices=[permission.value for permission in Permission],
+        help="Permission to embed in the token. Defaults to view and create.",
+    )
+    parser.add_argument(
+        "--expires-in",
+        type=int,
+        default=None,
+        help="Token lifetime in seconds. Defaults to TPP_BOOTSTRAP_TOKEN_TTL_SECONDS or 900.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Print a bounded bootstrap token for local or preview planner tests."""
+
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    config = PlannerAuthConfig.from_env()
+    if config.auth_mode != PlannerAuthMode.BOOTSTRAP_TOKEN:
+        parser.error(
+            "TPP_AUTH_MODE must be set to 'bootstrap-token' to mint planner tokens."
+        )
+    if not config.is_ready:
+        parser.error(
+            "Planner auth config is incomplete. Set TPP_BASE_URL, TPP_OIDC_PROVIDER, "
+            "TPP_AUTH_MODE=bootstrap-token, and TPP_BOOTSTRAP_SIGNING_SECRET."
+        )
+
+    secret = os.getenv("TPP_BOOTSTRAP_SIGNING_SECRET")
+    if secret is None or config.oidc_provider is None:
+        parser.error("Planner auth config is incomplete.")
+
+    permissions = tuple(
+        Permission(permission)
+        for permission in (
+            args.permissions or [Permission.VIEW.value, Permission.CREATE.value]
+        )
+    )
+    token = mint_bootstrap_token(
+        subject=args.subject,
+        permissions=permissions,
+        provider=config.oidc_provider,
+        secret=secret,
+        expires_in_seconds=args.expires_in or config.bootstrap_ttl_seconds or 900,
+    )
+    print(token)
+    return 0

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -7,7 +7,6 @@ from fastapi.testclient import TestClient
 
 from travel_plan_permission.http_service import (
     PlannerProposalStore,
-    PlannerRuntimeConfigError,
     create_app,
     main,
 )
@@ -213,22 +212,16 @@ def test_bootstrap_token_rejects_missing_create_permission(monkeypatch) -> None:
     assert "does not grant 'create'" in response.json()["detail"]
 
 
-def test_main_fails_fast_when_runtime_is_misconfigured(monkeypatch) -> None:
+def test_main_fails_fast_when_runtime_is_misconfigured(monkeypatch, capsys) -> None:
     monkeypatch.delenv("TPP_BASE_URL", raising=False)
     monkeypatch.delenv("TPP_ACCESS_TOKEN", raising=False)
     monkeypatch.delenv("TPP_OIDC_PROVIDER", raising=False)
     monkeypatch.delenv("TPP_AUTH_MODE", raising=False)
     monkeypatch.delenv("TPP_BOOTSTRAP_SIGNING_SECRET", raising=False)
 
-    try:
-        main([])
-    except PlannerRuntimeConfigError as exc:
-        message = str(exc)
-    else:
-        raise AssertionError("Expected PlannerRuntimeConfigError")
-
-    assert "missing:" in message
-    assert "TPP_AUTH_MODE" in message
+    exit_code = main([])
+    assert exit_code == 1
+    assert "missing:" in capsys.readouterr().err
 
 
 def test_snapshot_route_returns_bad_request_for_contract_mismatch(monkeypatch) -> None:

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -5,7 +5,12 @@ from pathlib import Path
 
 from fastapi.testclient import TestClient
 
-from travel_plan_permission.http_service import PlannerProposalStore, create_app
+from travel_plan_permission.http_service import (
+    PlannerProposalStore,
+    PlannerRuntimeConfigError,
+    create_app,
+    main,
+)
 from travel_plan_permission.policy_api import PlannerProposalOperationResponse
 
 FIXTURE_ROOT = Path(__file__).resolve().parents[1] / "fixtures" / "planner_integration"
@@ -19,6 +24,8 @@ def _load_fixture(name: str) -> dict[str, object]:
 def _set_runtime_env(monkeypatch, *, provider: str = "google") -> None:
     monkeypatch.setenv("TPP_BASE_URL", "http://127.0.0.1:8000")
     monkeypatch.setenv("TPP_ACCESS_TOKEN", "dev-token")
+    monkeypatch.setenv("TPP_ACCESS_TOKEN_SUBJECT", "planner-preview")
+    monkeypatch.setenv("TPP_ACCESS_TOKEN_ROLE", "traveler")
     monkeypatch.setenv("TPP_OIDC_PROVIDER", provider)
 
 
@@ -37,8 +44,11 @@ def test_readyz_reports_missing_runtime_config(monkeypatch) -> None:
     assert payload["config"]["missing_config"] == [
         "TPP_BASE_URL",
         "TPP_ACCESS_TOKEN",
+        "TPP_ACCESS_TOKEN_ROLE",
+        "TPP_ACCESS_TOKEN_SUBJECT",
         "TPP_OIDC_PROVIDER",
     ]
+    assert payload["config"]["invalid_config"] == []
 
 
 def test_snapshot_route_returns_planner_contract(monkeypatch) -> None:
@@ -116,7 +126,8 @@ def test_readyz_reports_invalid_oidc_provider(monkeypatch) -> None:
     assert response.status_code == 503
     payload = response.json()
     assert payload["status"] == "misconfigured"
-    assert payload["config"]["missing_config"] == ["TPP_OIDC_PROVIDER"]
+    assert payload["config"]["missing_config"] == []
+    assert payload["config"]["invalid_config"] == ["TPP_OIDC_PROVIDER"]
 
 
 def test_planner_routes_require_bearer_token(monkeypatch) -> None:
@@ -141,6 +152,51 @@ def test_planner_routes_require_bearer_token(monkeypatch) -> None:
     assert missing.json()["detail"] == "Missing bearer token."
     assert invalid.status_code == 403
     assert invalid.json()["detail"] == "Invalid bearer token."
+
+
+def test_planner_routes_reject_insufficient_bootstrap_role(monkeypatch) -> None:
+    _set_runtime_env(monkeypatch)
+    monkeypatch.setenv("TPP_ACCESS_TOKEN_ROLE", "policy_admin")
+
+    client = TestClient(create_app())
+    trip_plan = _load_fixture("proposal_submission.json")
+    request_payload = {
+        "trip_id": trip_plan["trip_id"],
+        "proposal_id": "proposal-123",
+        "proposal_version": "proposal-v1",
+        "payload": {"selected_options": ["flight-1", "hotel-3"]},
+    }
+
+    response = client.post(
+        "/api/planner/proposals",
+        headers=AUTH_HEADER,
+        json={"trip_plan": trip_plan, "request": request_payload},
+    )
+
+    assert response.status_code == 403
+    assert (
+        response.json()["detail"]
+        == "Configured bearer token is not authorized for this endpoint."
+    )
+
+
+def test_main_fails_fast_when_runtime_is_misconfigured(monkeypatch) -> None:
+    monkeypatch.delenv("TPP_BASE_URL", raising=False)
+    monkeypatch.delenv("TPP_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("TPP_ACCESS_TOKEN_ROLE", raising=False)
+    monkeypatch.delenv("TPP_ACCESS_TOKEN_SUBJECT", raising=False)
+    monkeypatch.delenv("TPP_OIDC_PROVIDER", raising=False)
+
+    try:
+        main([])
+    except PlannerRuntimeConfigError as exc:
+        message = str(exc)
+    else:
+        raise AssertionError("Expected PlannerRuntimeConfigError")
+
+    assert "missing:" in message
+    assert "TPP_ACCESS_TOKEN_ROLE" in message
+    assert "TPP_ACCESS_TOKEN_SUBJECT" in message
 
 
 def test_snapshot_route_returns_bad_request_for_contract_mismatch(monkeypatch) -> None:

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -11,7 +11,9 @@ from travel_plan_permission.http_service import (
     create_app,
     main,
 )
+from travel_plan_permission.planner_auth import mint_bootstrap_token
 from travel_plan_permission.policy_api import PlannerProposalOperationResponse
+from travel_plan_permission.security import Permission
 
 FIXTURE_ROOT = Path(__file__).resolve().parents[1] / "fixtures" / "planner_integration"
 AUTH_HEADER = {"Authorization": "Bearer dev-token"}
@@ -23,16 +25,24 @@ def _load_fixture(name: str) -> dict[str, object]:
 
 def _set_runtime_env(monkeypatch, *, provider: str = "google") -> None:
     monkeypatch.setenv("TPP_BASE_URL", "http://127.0.0.1:8000")
-    monkeypatch.setenv("TPP_ACCESS_TOKEN", "dev-token")
-    monkeypatch.setenv("TPP_ACCESS_TOKEN_SUBJECT", "planner-preview")
-    monkeypatch.setenv("TPP_ACCESS_TOKEN_ROLE", "traveler")
     monkeypatch.setenv("TPP_OIDC_PROVIDER", provider)
+    monkeypatch.setenv("TPP_AUTH_MODE", "static-token")
+    monkeypatch.setenv("TPP_ACCESS_TOKEN", "dev-token")
+
+
+def _set_bootstrap_runtime_env(monkeypatch, *, provider: str = "google") -> None:
+    monkeypatch.setenv("TPP_BASE_URL", "http://127.0.0.1:8000")
+    monkeypatch.setenv("TPP_OIDC_PROVIDER", provider)
+    monkeypatch.setenv("TPP_AUTH_MODE", "bootstrap-token")
+    monkeypatch.setenv("TPP_BOOTSTRAP_SIGNING_SECRET", "bootstrap-secret-123")
 
 
 def test_readyz_reports_missing_runtime_config(monkeypatch) -> None:
     monkeypatch.delenv("TPP_BASE_URL", raising=False)
     monkeypatch.delenv("TPP_ACCESS_TOKEN", raising=False)
     monkeypatch.delenv("TPP_OIDC_PROVIDER", raising=False)
+    monkeypatch.delenv("TPP_AUTH_MODE", raising=False)
+    monkeypatch.delenv("TPP_BOOTSTRAP_SIGNING_SECRET", raising=False)
 
     client = TestClient(create_app())
 
@@ -43,10 +53,8 @@ def test_readyz_reports_missing_runtime_config(monkeypatch) -> None:
     assert payload["status"] == "misconfigured"
     assert payload["config"]["missing_config"] == [
         "TPP_BASE_URL",
-        "TPP_ACCESS_TOKEN",
-        "TPP_ACCESS_TOKEN_ROLE",
-        "TPP_ACCESS_TOKEN_SUBJECT",
         "TPP_OIDC_PROVIDER",
+        "TPP_AUTH_MODE",
     ]
     assert payload["config"]["invalid_config"] == []
 
@@ -154,12 +162,40 @@ def test_planner_routes_require_bearer_token(monkeypatch) -> None:
     assert invalid.json()["detail"] == "Invalid bearer token."
 
 
-def test_planner_routes_reject_insufficient_bootstrap_role(monkeypatch) -> None:
-    _set_runtime_env(monkeypatch)
-    monkeypatch.setenv("TPP_ACCESS_TOKEN_ROLE", "policy_admin")
-
+def test_bootstrap_token_allows_planner_routes(monkeypatch) -> None:
+    _set_bootstrap_runtime_env(monkeypatch)
     client = TestClient(create_app())
     trip_plan = _load_fixture("proposal_submission.json")
+    snapshot_request = _load_fixture("policy_snapshot_request.json")
+    token = mint_bootstrap_token(
+        subject="trip-planner-preview",
+        permissions=(Permission.VIEW, Permission.CREATE),
+        provider="google",
+        secret="bootstrap-secret-123",
+        expires_in_seconds=600,
+    )
+
+    response = client.request(
+        "GET",
+        "/api/planner/policy-snapshot",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"trip_plan": trip_plan, "request": snapshot_request},
+    )
+
+    assert response.status_code == 200
+
+
+def test_bootstrap_token_rejects_missing_create_permission(monkeypatch) -> None:
+    _set_bootstrap_runtime_env(monkeypatch)
+    client = TestClient(create_app())
+    trip_plan = _load_fixture("proposal_submission.json")
+    token = mint_bootstrap_token(
+        subject="trip-planner-preview",
+        permissions=(Permission.VIEW,),
+        provider="google",
+        secret="bootstrap-secret-123",
+        expires_in_seconds=600,
+    )
     request_payload = {
         "trip_id": trip_plan["trip_id"],
         "proposal_id": "proposal-123",
@@ -169,23 +205,20 @@ def test_planner_routes_reject_insufficient_bootstrap_role(monkeypatch) -> None:
 
     response = client.post(
         "/api/planner/proposals",
-        headers=AUTH_HEADER,
+        headers={"Authorization": f"Bearer {token}"},
         json={"trip_plan": trip_plan, "request": request_payload},
     )
 
     assert response.status_code == 403
-    assert (
-        response.json()["detail"]
-        == "Configured bearer token is not authorized for this endpoint."
-    )
+    assert "does not grant 'create'" in response.json()["detail"]
 
 
 def test_main_fails_fast_when_runtime_is_misconfigured(monkeypatch) -> None:
     monkeypatch.delenv("TPP_BASE_URL", raising=False)
     monkeypatch.delenv("TPP_ACCESS_TOKEN", raising=False)
-    monkeypatch.delenv("TPP_ACCESS_TOKEN_ROLE", raising=False)
-    monkeypatch.delenv("TPP_ACCESS_TOKEN_SUBJECT", raising=False)
     monkeypatch.delenv("TPP_OIDC_PROVIDER", raising=False)
+    monkeypatch.delenv("TPP_AUTH_MODE", raising=False)
+    monkeypatch.delenv("TPP_BOOTSTRAP_SIGNING_SECRET", raising=False)
 
     try:
         main([])
@@ -195,8 +228,7 @@ def test_main_fails_fast_when_runtime_is_misconfigured(monkeypatch) -> None:
         raise AssertionError("Expected PlannerRuntimeConfigError")
 
     assert "missing:" in message
-    assert "TPP_ACCESS_TOKEN_ROLE" in message
-    assert "TPP_ACCESS_TOKEN_SUBJECT" in message
+    assert "TPP_AUTH_MODE" in message
 
 
 def test_snapshot_route_returns_bad_request_for_contract_mismatch(monkeypatch) -> None:

--- a/tests/python/test_planner_auth.py
+++ b/tests/python/test_planner_auth.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from travel_plan_permission.planner_auth import (
+    PlannerAuthConfig,
+    PlannerAuthMode,
+    authenticate_request,
+    mint_bootstrap_token,
+)
+from travel_plan_permission.security import Permission
+
+
+def _set_bootstrap_env(monkeypatch) -> None:
+    monkeypatch.setenv("TPP_BASE_URL", "http://127.0.0.1:8000")
+    monkeypatch.setenv("TPP_OIDC_PROVIDER", "google")
+    monkeypatch.setenv("TPP_AUTH_MODE", "bootstrap-token")
+    monkeypatch.setenv("TPP_BOOTSTRAP_SIGNING_SECRET", "bootstrap-secret-123")
+
+
+def test_bootstrap_auth_config_requires_explicit_mode(monkeypatch) -> None:
+    monkeypatch.setenv("TPP_BASE_URL", "http://127.0.0.1:8000")
+    monkeypatch.setenv("TPP_OIDC_PROVIDER", "google")
+    config = PlannerAuthConfig.from_env()
+
+    assert config.auth_mode is None
+    assert config.missing_config == ("TPP_AUTH_MODE",)
+
+
+def test_bootstrap_token_authenticates_required_permission(monkeypatch) -> None:
+    _set_bootstrap_env(monkeypatch)
+    now = datetime(2026, 4, 14, 7, 0, tzinfo=UTC)
+    token = mint_bootstrap_token(
+        subject="planner-preview",
+        permissions=(Permission.VIEW, Permission.CREATE),
+        provider="google",
+        secret="bootstrap-secret-123",
+        expires_in_seconds=600,
+        now=now,
+    )
+
+    context = authenticate_request(
+        f"Bearer {token}",
+        config=PlannerAuthConfig.from_env(),
+        required_permission=Permission.CREATE,
+        now=now + timedelta(seconds=60),
+    )
+
+    assert context.auth_mode == PlannerAuthMode.BOOTSTRAP_TOKEN
+    assert context.subject == "planner-preview"
+    assert context.can(Permission.VIEW)
+    assert context.can(Permission.CREATE)
+
+
+def test_bootstrap_token_rejects_missing_permission(monkeypatch) -> None:
+    _set_bootstrap_env(monkeypatch)
+    token = mint_bootstrap_token(
+        subject="planner-preview",
+        permissions=(Permission.VIEW,),
+        provider="google",
+        secret="bootstrap-secret-123",
+        expires_in_seconds=600,
+    )
+
+    with pytest.raises(PermissionError, match="does not grant 'create'"):
+        authenticate_request(
+            f"Bearer {token}",
+            config=PlannerAuthConfig.from_env(),
+            required_permission=Permission.CREATE,
+        )
+
+
+def test_bootstrap_token_rejects_expired_token(monkeypatch) -> None:
+    _set_bootstrap_env(monkeypatch)
+    issued_at = datetime(2026, 4, 14, 7, 0, tzinfo=UTC)
+    token = mint_bootstrap_token(
+        subject="planner-preview",
+        permissions=(Permission.VIEW, Permission.CREATE),
+        provider="google",
+        secret="bootstrap-secret-123",
+        expires_in_seconds=30,
+        now=issued_at,
+    )
+
+    with pytest.raises(PermissionError, match="has expired"):
+        authenticate_request(
+            f"Bearer {token}",
+            config=PlannerAuthConfig.from_env(),
+            required_permission=Permission.VIEW,
+            now=issued_at + timedelta(seconds=45),
+        )


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #784

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The planner integration contract already says callers need `TPP_BASE_URL`,
`TPP_ACCESS_TOKEN`, and `TPP_OIDC_PROVIDER`, but the repo does not yet make the
service-side auth/bootstrap story concrete enough for real live testing. A test
service needs a fail-fast configuration model and a bounded way to exercise the
planner-facing auth contract without hidden operator knowledge or silently
weakening authorization.

Parent epic: #782

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#782](https://github.com/stranske/Travel-Plan-Permission/issues/782)
- [#783](https://github.com/stranske/Travel-Plan-Permission/issues/783)
- [#785](https://github.com/stranske/Travel-Plan-Permission/issues/785)
- [#786](https://github.com/stranske/Travel-Plan-Permission/issues/786)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Define the server-side environment contract for planner-facing auth and required service configuration.
- [x] Add startup validation so missing or invalid planner-facing auth config fails clearly before the service claims readiness.
- [x] Add a bounded local or preview bearer-token bootstrap path that still exercises endpoint permission checks instead of bypassing auth entirely.
- [x] Add tests covering authorized access, missing-token access, invalid-token access, and misconfigured-auth startup behavior.
- [x] Update the security and integration docs so an operator can configure auth without tribal knowledge.

#### Acceptance criteria
- [x] Planner-facing endpoints return deterministic auth failures for missing or invalid credentials.
- [x] Service startup or readiness fails clearly when required planner-facing auth/config is absent.
- [x] A live-test operator can configure a valid auth path using repo docs only.
- [x] Tests cover both happy-path authorization and the main auth/config failure modes.

**Head SHA:** c7e00b3f2101fad6bf7464d180428165ce1463fb
**Latest Runs:** ⏭️ skipped — Agents PR Event Hub
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24384296361) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24384296379) |
<!-- auto-status-summary:end -->

