### PR TITLE
Issue #785: add planner HTTP smoke coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,18 @@ Use the emitted value as `Authorization: Bearer <token>` when calling planner
 routes. `TPP_AUTH_MODE="static-token"` plus `TPP_ACCESS_TOKEN` remains
 available for simple fixed-token environments.
 
+Run the repo-native live smoke command against a running service with:
+
+```bash
+tpp-planner-smoke
+```
+
+The command reuses the repo-owned planner fixtures, verifies that `/readyz`
+reports a healthy runtime, confirms the service rejects an unauthenticated
+snapshot request, and then exercises the full HTTP handshake over the live
+socket: policy snapshot, proposal submission, execution-status readback, and
+evaluation-result retrieval.
+
 ## Documentation
 
 - [Policy API](docs/policy-api.md)

--- a/docs/contracts/planner-integration.md
+++ b/docs/contracts/planner-integration.md
@@ -30,6 +30,12 @@ Fixture files for each flow live under
 `tests/fixtures/planner_integration/` and are validated in
 `tests/python/test_planner_integration_contract.py`.
 
+For live service validation, this repo also exposes the repo-native smoke
+command `tpp-planner-smoke`. It uses those same fixtures to exercise the HTTP
+handshake against a running TPP instance, checks `/readyz` before proceeding,
+and verifies that unauthenticated snapshot access is rejected before running
+the authorized planner flow.
+
 ## Transport Authentication
 
 ### Auth method

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ fill-spreadsheet = "travel_plan_permission.cli:main"
 orchestration-demo = "travel_plan_permission.orchestration.example:main"
 tpp-planner-token = "travel_plan_permission.planner_auth:main"
 tpp-planner-service = "travel_plan_permission.http_service:main"
+tpp-planner-smoke = "travel_plan_permission.planner_smoke:main"
 
 [build-system]
 requires = []

--- a/src/travel_plan_permission/planner_smoke.py
+++ b/src/travel_plan_permission/planner_smoke.py
@@ -21,6 +21,7 @@ from .security import Permission
 
 _FIXTURE_ROOT = Path(__file__).resolve().parents[2] / "tests" / "fixtures" / "planner_integration"
 _DEFAULT_TIMEOUT_SECONDS = 10.0
+_FIXTURE_DIR_ENV = "TPP_PLANNER_FIXTURES_DIR"
 
 
 class PlannerSmokeError(RuntimeError):
@@ -62,11 +63,31 @@ def _build_parser() -> argparse.ArgumentParser:
         default=_DEFAULT_TIMEOUT_SECONDS,
         help="Per-request timeout in seconds.",
     )
+    parser.add_argument(
+        "--fixtures-dir",
+        default=None,
+        help=(
+            "Directory containing planner integration JSON fixtures. "
+            f"Defaults to ${_FIXTURE_DIR_ENV} or the repo checkout fixtures."
+        ),
+    )
     return parser
 
 
-def _load_fixture(name: str) -> dict[str, object]:
-    fixture_path = _FIXTURE_ROOT / name
+def _resolve_fixture_root(args: argparse.Namespace) -> Path:
+    configured_root = args.fixtures_dir or os.getenv(_FIXTURE_DIR_ENV)
+    fixture_root = Path(configured_root).expanduser() if configured_root else _FIXTURE_ROOT
+    if fixture_root.is_dir():
+        return fixture_root
+    raise PlannerSmokeError(
+        "Planner smoke fixtures are unavailable. "
+        f"Expected {_FIXTURE_ROOT}, or set {_FIXTURE_DIR_ENV} / --fixtures-dir "
+        "when running outside a repo checkout."
+    )
+
+
+def _load_fixture(fixture_root: Path, name: str) -> dict[str, object]:
+    fixture_path = fixture_root / name
     try:
         payload = json.loads(fixture_path.read_text(encoding="utf-8"))
     except FileNotFoundError as exc:
@@ -206,9 +227,15 @@ def _validate_unauthorized_snapshot(
     print("unauthorized probe: service rejects missing bearer token")
 
 
-def _validate_smoke_flow(base_url: str, *, timeout: float, token: str) -> None:
-    trip_plan = _load_fixture("proposal_submission.json")
-    snapshot_request = _load_fixture("policy_snapshot_request.json")
+def _validate_smoke_flow(
+    base_url: str,
+    *,
+    fixture_root: Path,
+    timeout: float,
+    token: str,
+) -> None:
+    trip_plan = _load_fixture(fixture_root, "proposal_submission.json")
+    snapshot_request = _load_fixture(fixture_root, "policy_snapshot_request.json")
     headers = {"Authorization": f"Bearer {token}"}
 
     _validate_readyz(base_url, timeout=timeout)
@@ -306,8 +333,14 @@ def main(argv: list[str] | None = None) -> int:
     config = PlannerAuthConfig.from_env()
     try:
         base_url = _resolve_base_url(args, config)
+        fixture_root = _resolve_fixture_root(args)
         token = _resolve_token(args, config)
-        _validate_smoke_flow(base_url, timeout=args.timeout, token=token)
+        _validate_smoke_flow(
+            base_url,
+            fixture_root=fixture_root,
+            timeout=args.timeout,
+            token=token,
+        )
     except PlannerSmokeError as exc:
         print(str(exc), file=sys.stderr)
         return 1

--- a/src/travel_plan_permission/planner_smoke.py
+++ b/src/travel_plan_permission/planner_smoke.py
@@ -145,7 +145,7 @@ def _resolve_token(
     args: argparse.Namespace,
     config: PlannerAuthConfig,
 ) -> str:
-    if args.token:
+    if isinstance(args.token, str) and args.token:
         return args.token
 
     if config.auth_mode == PlannerAuthMode.STATIC_TOKEN:

--- a/src/travel_plan_permission/planner_smoke.py
+++ b/src/travel_plan_permission/planner_smoke.py
@@ -1,0 +1,320 @@
+"""Live HTTP smoke test entrypoint for planner-facing TPP integration."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib import error, request
+
+from .planner_auth import PlannerAuthConfig, PlannerAuthMode, mint_bootstrap_token
+from .policy_api import (
+    PlannerPolicySnapshot,
+    PlannerProposalEvaluationResult,
+    PlannerProposalOperationResponse,
+)
+from .security import Permission
+
+_FIXTURE_ROOT = Path(__file__).resolve().parents[2] / "tests" / "fixtures" / "planner_integration"
+_DEFAULT_TIMEOUT_SECONDS = 10.0
+
+
+class PlannerSmokeError(RuntimeError):
+    """Raised when the live smoke command cannot complete successfully."""
+
+
+@dataclass(frozen=True)
+class JsonResponse:
+    """Minimal JSON-aware HTTP response wrapper."""
+
+    status_code: int
+    body: Any
+    text: str
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="tpp-planner-smoke",
+        description="Exercise the live planner-facing HTTP handshake against a running TPP service.",
+    )
+    parser.add_argument(
+        "--base-url",
+        default=None,
+        help="Service base URL. Defaults to TPP_BASE_URL.",
+    )
+    parser.add_argument(
+        "--token",
+        default=None,
+        help="Explicit bearer token. Defaults to the configured static token or a minted bootstrap token.",
+    )
+    parser.add_argument(
+        "--subject",
+        default="trip-planner-local",
+        help="Subject to embed when minting a bootstrap token.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=_DEFAULT_TIMEOUT_SECONDS,
+        help="Per-request timeout in seconds.",
+    )
+    return parser
+
+
+def _load_fixture(name: str) -> dict[str, object]:
+    fixture_path = _FIXTURE_ROOT / name
+    try:
+        payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise PlannerSmokeError(
+            f"Required planner integration fixture is missing: {fixture_path}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise PlannerSmokeError(f"Fixture {fixture_path} must contain a JSON object.")
+    return payload
+
+
+def _request_json(
+    method: str,
+    url: str,
+    *,
+    timeout: float,
+    json_body: dict[str, object] | None = None,
+    headers: dict[str, str] | None = None,
+) -> JsonResponse:
+    encoded_body = None
+    request_headers = dict(headers or {})
+    if json_body is not None:
+        encoded_body = json.dumps(json_body).encode("utf-8")
+        request_headers.setdefault("Content-Type", "application/json")
+    req = request.Request(url, data=encoded_body, headers=request_headers, method=method)
+    try:
+        with request.urlopen(req, timeout=timeout) as response:
+            raw = response.read().decode("utf-8")
+            status_code = response.status
+    except error.HTTPError as exc:
+        raw = exc.read().decode("utf-8")
+        status_code = exc.code
+    except error.URLError as exc:
+        raise PlannerSmokeError(f"{method} {url} failed: {exc.reason}") from exc
+
+    body: Any = None
+    if raw:
+        try:
+            body = json.loads(raw)
+        except json.JSONDecodeError:
+            body = raw
+    return JsonResponse(status_code=status_code, body=body, text=raw)
+
+
+def _resolve_base_url(args: argparse.Namespace, config: PlannerAuthConfig) -> str:
+    base_url = args.base_url or config.base_url
+    if not base_url:
+        raise PlannerSmokeError(
+            "Planner smoke needs a service URL. Set TPP_BASE_URL or pass --base-url."
+        )
+    return base_url.rstrip("/")
+
+
+def _resolve_token(
+    args: argparse.Namespace,
+    config: PlannerAuthConfig,
+) -> str:
+    if args.token:
+        return args.token
+
+    if config.auth_mode == PlannerAuthMode.STATIC_TOKEN:
+        token = os.getenv("TPP_ACCESS_TOKEN")
+        if token:
+            return token
+        raise PlannerSmokeError(
+            "TPP_AUTH_MODE=static-token requires TPP_ACCESS_TOKEN for planner smoke."
+        )
+
+    if config.auth_mode == PlannerAuthMode.BOOTSTRAP_TOKEN:
+        if config.oidc_provider is None:
+            raise PlannerSmokeError("TPP_OIDC_PROVIDER must be set for bootstrap planner smoke.")
+        secret = os.getenv("TPP_BOOTSTRAP_SIGNING_SECRET")
+        if secret is None:
+            raise PlannerSmokeError(
+                "TPP_BOOTSTRAP_SIGNING_SECRET must be set to mint a bootstrap smoke token."
+            )
+        return mint_bootstrap_token(
+            subject=args.subject,
+            permissions=(Permission.VIEW, Permission.CREATE),
+            provider=config.oidc_provider,
+            secret=secret,
+            expires_in_seconds=config.bootstrap_ttl_seconds or 900,
+        )
+
+    raise PlannerSmokeError(
+        "Planner smoke needs TPP_AUTH_MODE to be configured as static-token or bootstrap-token."
+    )
+
+
+def _proposal_request(trip_plan: dict[str, object]) -> dict[str, object]:
+    trip_id = trip_plan.get("trip_id")
+    if not isinstance(trip_id, str) or not trip_id:
+        raise PlannerSmokeError("Proposal submission fixture is missing a valid trip_id.")
+    return {
+        "trip_id": trip_id,
+        "proposal_id": "proposal-123",
+        "proposal_version": "proposal-v1",
+        "payload": {"selected_options": ["flight-1", "hotel-3"]},
+    }
+
+
+def _expect_json_object(response: JsonResponse, *, step: str) -> dict[str, object]:
+    if not isinstance(response.body, dict):
+        raise PlannerSmokeError(
+            f"{step} returned non-object JSON: status={response.status_code} body={response.text!r}"
+        )
+    return response.body
+
+
+def _validate_readyz(base_url: str, *, timeout: float) -> None:
+    response = _request_json("GET", f"{base_url}/readyz", timeout=timeout)
+    payload = _expect_json_object(response, step="readiness check")
+    if response.status_code != 200 or payload.get("status") != "ready":
+        raise PlannerSmokeError(
+            f"Planner service is not ready: status={response.status_code} payload={payload}"
+        )
+    print("readyz: service reports ready")
+
+
+def _validate_unauthorized_snapshot(
+    base_url: str,
+    *,
+    timeout: float,
+    trip_plan: dict[str, object],
+    snapshot_request: dict[str, object],
+) -> None:
+    response = _request_json(
+        "GET",
+        f"{base_url}/api/planner/policy-snapshot",
+        timeout=timeout,
+        json_body={"trip_plan": trip_plan, "request": snapshot_request},
+    )
+    if response.status_code != 401:
+        raise PlannerSmokeError(
+            f"Unauthorized snapshot probe expected 401, got {response.status_code}: {response.text}"
+        )
+    print("unauthorized probe: service rejects missing bearer token")
+
+
+def _validate_smoke_flow(base_url: str, *, timeout: float, token: str) -> None:
+    trip_plan = _load_fixture("proposal_submission.json")
+    snapshot_request = _load_fixture("policy_snapshot_request.json")
+    headers = {"Authorization": f"Bearer {token}"}
+
+    _validate_readyz(base_url, timeout=timeout)
+    _validate_unauthorized_snapshot(
+        base_url,
+        timeout=timeout,
+        trip_plan=trip_plan,
+        snapshot_request=snapshot_request,
+    )
+
+    snapshot_response = _request_json(
+        "GET",
+        f"{base_url}/api/planner/policy-snapshot",
+        timeout=timeout,
+        headers=headers,
+        json_body={"trip_plan": trip_plan, "request": snapshot_request},
+    )
+    snapshot_payload = _expect_json_object(snapshot_response, step="policy snapshot")
+    if snapshot_response.status_code != 200:
+        raise PlannerSmokeError(
+            f"Policy snapshot failed: status={snapshot_response.status_code} payload={snapshot_payload}"
+        )
+    snapshot = PlannerPolicySnapshot.model_validate(snapshot_payload)
+    print(f"policy snapshot: ok for trip {snapshot.trip_id}")
+
+    proposal_request = _proposal_request(trip_plan)
+    submit_response = _request_json(
+        "POST",
+        f"{base_url}/api/planner/proposals",
+        timeout=timeout,
+        headers=headers,
+        json_body={"trip_plan": trip_plan, "request": proposal_request},
+    )
+    submit_payload = _expect_json_object(submit_response, step="proposal submission")
+    if submit_response.status_code != 200:
+        raise PlannerSmokeError(
+            f"Proposal submission failed: status={submit_response.status_code} payload={submit_payload}"
+        )
+    submit = PlannerProposalOperationResponse.model_validate(submit_payload)
+    execution_id = submit.result_payload.get("execution_id")
+    if not isinstance(execution_id, str) or not execution_id:
+        raise PlannerSmokeError(
+            f"Proposal submission did not return a valid execution_id: {submit.result_payload}"
+        )
+    print(f"proposal submission: ok with execution {execution_id}")
+
+    proposal_id = str(proposal_request["proposal_id"])
+    status_response = _request_json(
+        "GET",
+        f"{base_url}/api/planner/proposals/{proposal_id}/executions/{execution_id}",
+        timeout=timeout,
+        headers=headers,
+    )
+    status_payload = _expect_json_object(status_response, step="proposal status")
+    if status_response.status_code != 200:
+        raise PlannerSmokeError(
+            f"Proposal status failed: status={status_response.status_code} payload={status_payload}"
+        )
+    status_model = PlannerProposalOperationResponse.model_validate(status_payload)
+    if status_model.result_payload.get("execution_id") != execution_id:
+        raise PlannerSmokeError(
+            "Proposal status response returned an execution_id that does not match submission."
+        )
+    print("proposal status: ok")
+
+    evaluation_response = _request_json(
+        "GET",
+        f"{base_url}/api/planner/executions/{execution_id}/evaluation-result",
+        timeout=timeout,
+        headers=headers,
+    )
+    evaluation_payload = _expect_json_object(evaluation_response, step="evaluation result")
+    if evaluation_response.status_code != 200:
+        raise PlannerSmokeError(
+            f"Evaluation result failed: status={evaluation_response.status_code} payload={evaluation_payload}"
+        )
+    evaluation = PlannerProposalEvaluationResult.model_validate(evaluation_payload)
+    if evaluation.execution_id != execution_id:
+        raise PlannerSmokeError(
+            "Evaluation result response returned an execution_id that does not match submission."
+        )
+    expected_suffix = f"/proposals/{proposal_id}/executions/{execution_id}"
+    if not evaluation.status_endpoint.endswith(expected_suffix):
+        raise PlannerSmokeError(
+            f"Evaluation result returned an unexpected status_endpoint: {evaluation.status_endpoint}"
+        )
+    print(f"evaluation result: ok with outcome {evaluation.outcome}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Exercise the planner-facing HTTP seam over a live network socket."""
+
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    config = PlannerAuthConfig.from_env()
+    try:
+        base_url = _resolve_base_url(args, config)
+        token = _resolve_token(args, config)
+        _validate_smoke_flow(base_url, timeout=args.timeout, token=token)
+    except PlannerSmokeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print("Planner HTTP smoke passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/python/test_planner_smoke.py
+++ b/tests/python/test_planner_smoke.py
@@ -18,16 +18,8 @@ def _set_static_runtime_env(monkeypatch, *, base_url: str, provider: str = "goog
     monkeypatch.delenv("TPP_BOOTSTRAP_SIGNING_SECRET", raising=False)
 
 
-def _pick_free_port() -> int:
-    with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
-        sock.bind(("127.0.0.1", 0))
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        return int(sock.getsockname()[1])
-
-
 @contextlib.contextmanager
-def _run_live_service() -> str:
-    port = _pick_free_port()
+def _run_live_service(port: int) -> str:
     base_url = f"http://127.0.0.1:{port}"
     config = uvicorn.Config(
         "travel_plan_permission.http_service:create_app",
@@ -58,8 +50,8 @@ def _run_live_service() -> str:
         thread.join(timeout=10)
 
 
-def test_planner_smoke_main_succeeds_against_live_service(monkeypatch, capsys) -> None:
-    with _run_live_service() as base_url:
+def test_planner_smoke_main_succeeds_against_live_service(monkeypatch, capsys, unused_tcp_port: int) -> None:
+    with _run_live_service(unused_tcp_port) as base_url:
         _set_static_runtime_env(monkeypatch, base_url=base_url)
 
         exit_code = main([])
@@ -70,8 +62,8 @@ def test_planner_smoke_main_succeeds_against_live_service(monkeypatch, capsys) -
     assert "unauthorized probe" in captured.out
 
 
-def test_planner_smoke_fails_when_service_is_not_ready(monkeypatch, capsys) -> None:
-    with _run_live_service() as base_url:
+def test_planner_smoke_fails_when_service_is_not_ready(monkeypatch, capsys, unused_tcp_port: int) -> None:
+    with _run_live_service(unused_tcp_port) as base_url:
         _set_static_runtime_env(monkeypatch, base_url=base_url, provider="github")
 
         exit_code = main([])
@@ -92,3 +84,17 @@ def test_planner_smoke_requires_base_url(monkeypatch, capsys) -> None:
     captured = capsys.readouterr()
     assert exit_code == 1
     assert "Planner smoke needs a service URL" in captured.err
+
+
+def test_planner_smoke_requires_repo_checkout_or_fixtures_override(monkeypatch, capsys, tmp_path) -> None:
+    monkeypatch.setenv("TPP_BASE_URL", "http://127.0.0.1:9999")
+    monkeypatch.setenv("TPP_AUTH_MODE", "static-token")
+    monkeypatch.setenv("TPP_ACCESS_TOKEN", "dev-token")
+    monkeypatch.setenv("TPP_OIDC_PROVIDER", "google")
+    monkeypatch.setenv("TPP_PLANNER_FIXTURES_DIR", str(tmp_path / "missing-fixtures"))
+
+    exit_code = main([])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "Planner smoke fixtures are unavailable" in captured.err

--- a/tests/python/test_planner_smoke.py
+++ b/tests/python/test_planner_smoke.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import contextlib
+import socket
+import threading
+import time
+
+import uvicorn
+
+from travel_plan_permission.planner_smoke import main
+
+
+def _set_static_runtime_env(monkeypatch, *, base_url: str, provider: str = "google") -> None:
+    monkeypatch.setenv("TPP_BASE_URL", base_url)
+    monkeypatch.setenv("TPP_OIDC_PROVIDER", provider)
+    monkeypatch.setenv("TPP_AUTH_MODE", "static-token")
+    monkeypatch.setenv("TPP_ACCESS_TOKEN", "dev-token")
+    monkeypatch.delenv("TPP_BOOTSTRAP_SIGNING_SECRET", raising=False)
+
+
+def _pick_free_port() -> int:
+    with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        sock.bind(("127.0.0.1", 0))
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        return int(sock.getsockname()[1])
+
+
+@contextlib.contextmanager
+def _run_live_service() -> str:
+    port = _pick_free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    config = uvicorn.Config(
+        "travel_plan_permission.http_service:create_app",
+        factory=True,
+        host="127.0.0.1",
+        port=port,
+        log_level="warning",
+    )
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+            probe.settimeout(0.25)
+            if probe.connect_ex(("127.0.0.1", port)) == 0:
+                break
+        time.sleep(0.05)
+    else:
+        server.should_exit = True
+        thread.join(timeout=10)
+        raise RuntimeError("Live planner HTTP service failed to start in time.")
+
+    try:
+        yield base_url
+    finally:
+        server.should_exit = True
+        thread.join(timeout=10)
+
+
+def test_planner_smoke_main_succeeds_against_live_service(monkeypatch, capsys) -> None:
+    with _run_live_service() as base_url:
+        _set_static_runtime_env(monkeypatch, base_url=base_url)
+
+        exit_code = main([])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Planner HTTP smoke passed" in captured.out
+    assert "unauthorized probe" in captured.out
+
+
+def test_planner_smoke_fails_when_service_is_not_ready(monkeypatch, capsys) -> None:
+    with _run_live_service() as base_url:
+        _set_static_runtime_env(monkeypatch, base_url=base_url, provider="github")
+
+        exit_code = main([])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "Planner service is not ready" in captured.err
+
+
+def test_planner_smoke_requires_base_url(monkeypatch, capsys) -> None:
+    monkeypatch.delenv("TPP_BASE_URL", raising=False)
+    monkeypatch.setenv("TPP_AUTH_MODE", "static-token")
+    monkeypatch.setenv("TPP_ACCESS_TOKEN", "dev-token")
+    monkeypatch.setenv("TPP_OIDC_PROVIDER", "google")
+
+    exit_code = main([])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "Planner smoke needs a service URL" in captured.err

--- a/tests/python/test_planner_smoke.py
+++ b/tests/python/test_planner_smoke.py
@@ -4,13 +4,21 @@ import contextlib
 import socket
 import threading
 import time
+from collections.abc import Iterator
+from pathlib import Path
 
+import pytest
 import uvicorn
 
 from travel_plan_permission.planner_smoke import main
 
 
-def _set_static_runtime_env(monkeypatch, *, base_url: str, provider: str = "google") -> None:
+def _set_static_runtime_env(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    base_url: str,
+    provider: str = "google",
+) -> None:
     monkeypatch.setenv("TPP_BASE_URL", base_url)
     monkeypatch.setenv("TPP_OIDC_PROVIDER", provider)
     monkeypatch.setenv("TPP_AUTH_MODE", "static-token")
@@ -19,7 +27,7 @@ def _set_static_runtime_env(monkeypatch, *, base_url: str, provider: str = "goog
 
 
 @contextlib.contextmanager
-def _run_live_service(port: int) -> str:
+def _run_live_service(port: int) -> Iterator[str]:
     base_url = f"http://127.0.0.1:{port}"
     config = uvicorn.Config(
         "travel_plan_permission.http_service:create_app",
@@ -50,7 +58,11 @@ def _run_live_service(port: int) -> str:
         thread.join(timeout=10)
 
 
-def test_planner_smoke_main_succeeds_against_live_service(monkeypatch, capsys, unused_tcp_port: int) -> None:
+def test_planner_smoke_main_succeeds_against_live_service(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    unused_tcp_port: int,
+) -> None:
     with _run_live_service(unused_tcp_port) as base_url:
         _set_static_runtime_env(monkeypatch, base_url=base_url)
 
@@ -62,7 +74,11 @@ def test_planner_smoke_main_succeeds_against_live_service(monkeypatch, capsys, u
     assert "unauthorized probe" in captured.out
 
 
-def test_planner_smoke_fails_when_service_is_not_ready(monkeypatch, capsys, unused_tcp_port: int) -> None:
+def test_planner_smoke_fails_when_service_is_not_ready(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    unused_tcp_port: int,
+) -> None:
     with _run_live_service(unused_tcp_port) as base_url:
         _set_static_runtime_env(monkeypatch, base_url=base_url, provider="github")
 
@@ -73,7 +89,10 @@ def test_planner_smoke_fails_when_service_is_not_ready(monkeypatch, capsys, unus
     assert "Planner service is not ready" in captured.err
 
 
-def test_planner_smoke_requires_base_url(monkeypatch, capsys) -> None:
+def test_planner_smoke_requires_base_url(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     monkeypatch.delenv("TPP_BASE_URL", raising=False)
     monkeypatch.setenv("TPP_AUTH_MODE", "static-token")
     monkeypatch.setenv("TPP_ACCESS_TOKEN", "dev-token")
@@ -86,7 +105,11 @@ def test_planner_smoke_requires_base_url(monkeypatch, capsys) -> None:
     assert "Planner smoke needs a service URL" in captured.err
 
 
-def test_planner_smoke_requires_repo_checkout_or_fixtures_override(monkeypatch, capsys, tmp_path) -> None:
+def test_planner_smoke_requires_repo_checkout_or_fixtures_override(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
     monkeypatch.setenv("TPP_BASE_URL", "http://127.0.0.1:9999")
     monkeypatch.setenv("TPP_AUTH_MODE", "static-token")
     monkeypatch.setenv("TPP_ACCESS_TOKEN", "dev-token")

--- a/tests/python/test_planner_smoke.py
+++ b/tests/python/test_planner_smoke.py
@@ -27,7 +27,12 @@ def _set_static_runtime_env(
 
 
 @contextlib.contextmanager
-def _run_live_service(port: int) -> Iterator[str]:
+def _run_live_service() -> Iterator[str]:
+    server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server_socket.bind(("127.0.0.1", 0))
+    server_socket.listen(2048)
+    port = int(server_socket.getsockname()[1])
     base_url = f"http://127.0.0.1:{port}"
     config = uvicorn.Config(
         "travel_plan_permission.http_service:create_app",
@@ -37,7 +42,7 @@ def _run_live_service(port: int) -> Iterator[str]:
         log_level="warning",
     )
     server = uvicorn.Server(config)
-    thread = threading.Thread(target=server.run, daemon=True)
+    thread = threading.Thread(target=server.run, kwargs={"sockets": [server_socket]}, daemon=True)
     thread.start()
     deadline = time.monotonic() + 10
     while time.monotonic() < deadline:
@@ -56,14 +61,14 @@ def _run_live_service(port: int) -> Iterator[str]:
     finally:
         server.should_exit = True
         thread.join(timeout=10)
+        server_socket.close()
 
 
 def test_planner_smoke_main_succeeds_against_live_service(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
-    unused_tcp_port: int,
 ) -> None:
-    with _run_live_service(unused_tcp_port) as base_url:
+    with _run_live_service() as base_url:
         _set_static_runtime_env(monkeypatch, base_url=base_url)
 
         exit_code = main([])
@@ -77,9 +82,8 @@ def test_planner_smoke_main_succeeds_against_live_service(
 def test_planner_smoke_fails_when_service_is_not_ready(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
-    unused_tcp_port: int,
 ) -> None:
-    with _run_live_service(unused_tcp_port) as base_url:
+    with _run_live_service() as base_url:
         _set_static_runtime_env(monkeypatch, base_url=base_url, provider="github")
 
         exit_code = main([])


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #785

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The repo currently proves planner-facing behavior mainly through contract and
library tests. That is necessary, but it is not enough for live testing.
Before `trip-planner` can rely on TPP in a realistic environment, this repo
needs one end-to-end smoke path that exercises the actual HTTP handshake against
a running service.

Parent epic: #782

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#782](https://github.com/stranske/Travel-Plan-Permission/issues/782)
- [#783](https://github.com/stranske/Travel-Plan-Permission/issues/783)
- [#784](https://github.com/stranske/Travel-Plan-Permission/issues/784)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Add a smoke harness that targets a running local or preview TPP service over HTTP.
- [x] Exercise the supported planner handshake in order: policy snapshot, proposal submission, execution-status readback, and evaluation-result retrieval.
- [x] Validate smoke responses against the canonical planner integration contract or its fixture expectations.
- [x] Cover key negative cases such as unauthorized access and an unavailable or misconfigured service.
- [x] Expose the smoke path through one blessed repo-native command so local verification, docs, and later CI wiring all point to the same entrypoint.

#### Acceptance criteria
- [x] One documented command proves the planner-facing HTTP seam end to end against a running service.
- [x] The smoke path fails loudly when contract shape, auth, or runtime wiring drifts.
- [x] The handshake coverage includes all currently supported planner-facing flows.
- [x] The smoke command is practical for both local developer use and future preview or CI checks.

**Head SHA:** 215557d7a252dfe3ab23829d97c4bfff8378fad8
**Latest Runs:** ⏭️ skipped — Agents PR Event Hub
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24390370734) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24390370675) |
<!-- auto-status-summary:end -->
