### PR TITLE
Issue #786: publish planner live-test runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ fill-spreadsheet --help
 
 ## Planner HTTP Service
 
+For the full local or preview live-test path, use the
+[`Planner Live-Test Runbook`](docs/planner-live-test-runbook.md).
+
 Run the planner-facing HTTP adapter locally:
 
 ```bash
@@ -88,7 +91,9 @@ evaluation-result retrieval.
 
 ## Documentation
 
+- [Planner Live-Test Runbook](docs/planner-live-test-runbook.md)
 - [Policy API](docs/policy-api.md)
+- [Planner Integration Contract](docs/contracts/planner-integration.md)
 - [LangGraph Quickstart](docs/langgraph_quickstart.md)
 
 ## Contributing

--- a/docs/contracts/planner-integration.md
+++ b/docs/contracts/planner-integration.md
@@ -17,6 +17,10 @@ This document defines the planner-facing integration seam between
 The goal is to let `trip-planner` integrate without relying on undocumented
 headers, hidden cache rules, or ad hoc payload interpretation.
 
+For the operator-facing startup, auth bootstrap, and smoke-test procedure that
+drives this contract over a live HTTP service, see the
+[`Planner Live-Test Runbook`](../planner-live-test-runbook.md).
+
 ## Supported Flows
 
 The current first-pass contract supports these planner-facing flows:

--- a/docs/planner-live-test-runbook.md
+++ b/docs/planner-live-test-runbook.md
@@ -1,0 +1,202 @@
+# Planner Live-Test Runbook
+
+This is the source-of-truth operator path for running the planner-facing Travel
+Plan Permission service and exercising the live HTTP planner handshake.
+
+Use it when you need to:
+
+- start the planner-facing service locally or against a preview deployment,
+- mint or configure a planner bearer token,
+- run the blessed smoke path with repo-owned fixtures,
+- debug readiness, auth, or contract mismatches without digging through old PRs.
+
+## Prerequisites
+
+Install the package plus development dependencies from the repo root:
+
+```bash
+pip install -e ".[dev]"
+```
+
+If you prefer `uv`, the equivalent setup is:
+
+```bash
+uv sync --extra dev
+```
+
+The repo-native entrypoints used below are:
+
+- `tpp-planner-service`
+- `tpp-planner-token`
+- `tpp-planner-smoke`
+
+If they are not on your shell `PATH`, run them via `uv run <command>`.
+
+## Required Runtime Configuration
+
+Set the planner-facing base URL and auth contract before starting the service:
+
+| Variable | Required | Notes |
+| --- | --- | --- |
+| `TPP_BASE_URL` | yes | Base URL that callers use for the live service |
+| `TPP_OIDC_PROVIDER` | yes | Must be `azure_ad`, `okta`, or `google` |
+| `TPP_AUTH_MODE` | yes | `static-token` or `bootstrap-token` |
+| `TPP_ACCESS_TOKEN` | for `static-token` | Fixed bearer token for simple local or preview tests |
+| `TPP_BOOTSTRAP_SIGNING_SECRET` | for `bootstrap-token` | Shared secret for bounded bootstrap tokens |
+| `TPP_BOOTSTRAP_TOKEN_TTL_SECONDS` | optional | Defaults to `900` seconds |
+
+## Blessed Local Path
+
+### 1. Export runtime configuration
+
+Bootstrap-token mode is the preferred local path because it exercises the
+service-side token validation flow:
+
+```bash
+export TPP_BASE_URL="http://127.0.0.1:8000"
+export TPP_OIDC_PROVIDER="google"
+export TPP_AUTH_MODE="bootstrap-token"
+export TPP_BOOTSTRAP_SIGNING_SECRET="replace-with-a-local-preview-secret"
+```
+
+If you need the simplest fixed-token path instead:
+
+```bash
+export TPP_BASE_URL="http://127.0.0.1:8000"
+export TPP_OIDC_PROVIDER="google"
+export TPP_AUTH_MODE="static-token"
+export TPP_ACCESS_TOKEN="dev-token"
+```
+
+### 2. Start the planner-facing service
+
+```bash
+tpp-planner-service --host 127.0.0.1 --port 8000
+```
+
+Use `--reload` for local development if you want `uvicorn` auto-reload.
+
+### 3. Confirm liveness and readiness
+
+In a second shell:
+
+```bash
+curl -s http://127.0.0.1:8000/healthz
+curl -s http://127.0.0.1:8000/readyz
+```
+
+`/healthz` should return `{"status":"ok"}`. `/readyz` should return HTTP `200`
+with `"status":"ready"` before you attempt the planner routes or smoke command.
+
+### 4. Mint a bootstrap token when using bootstrap mode
+
+```bash
+tpp-planner-token --subject trip-planner-local
+```
+
+The command prints a short-lived bearer token. Use it as:
+
+```bash
+Authorization: Bearer <token>
+```
+
+You can mint narrower or longer-lived tokens if needed:
+
+```bash
+tpp-planner-token --subject trip-planner-local --permission view --permission create --expires-in 1800
+```
+
+Skip this step when `TPP_AUTH_MODE=static-token`; the service will accept the
+configured `TPP_ACCESS_TOKEN` directly.
+
+### 5. Run the blessed smoke path
+
+```bash
+tpp-planner-smoke
+```
+
+The smoke command:
+
+- checks `/readyz` before continuing,
+- confirms unauthenticated snapshot access returns `401`,
+- exercises the policy snapshot flow,
+- submits a proposal over HTTP,
+- reads execution status back,
+- fetches the evaluation result.
+
+By default it uses the packaged planner fixtures shipped with the repo. Override
+them only when you need explicit external test data:
+
+```bash
+tpp-planner-smoke --fixtures-dir path/to/planner-fixtures
+```
+
+The same override also works through `TPP_PLANNER_FIXTURES_DIR`.
+
+## Preview Or Remote Base URLs
+
+For preview or shared environments, point the same commands at the deployed base
+URL instead of localhost:
+
+```bash
+export TPP_BASE_URL="https://preview.example.net"
+```
+
+Then reuse the same `tpp-planner-token` or `TPP_ACCESS_TOKEN` flow and run:
+
+```bash
+tpp-planner-smoke --base-url "$TPP_BASE_URL"
+```
+
+## Troubleshooting
+
+### `/readyz` returns `503`
+
+The runtime config is incomplete or invalid. Check for:
+
+- missing `TPP_BASE_URL`,
+- missing or invalid `TPP_OIDC_PROVIDER`,
+- missing `TPP_AUTH_MODE`,
+- missing `TPP_ACCESS_TOKEN` for `static-token`,
+- missing or too-short `TPP_BOOTSTRAP_SIGNING_SECRET` for `bootstrap-token`.
+
+### `tpp-planner-token` exits with a config error
+
+The token command only works in bootstrap mode. Confirm:
+
+```bash
+echo "$TPP_AUTH_MODE"
+echo "$TPP_BOOTSTRAP_SIGNING_SECRET"
+```
+
+The expected mode is `bootstrap-token`, and the signing secret must be present.
+
+### Smoke fails with `Missing bearer token` or `Invalid bearer token`
+
+The running service and the shell where you minted or supplied the token do not
+agree on auth mode or token value. Re-export the auth variables and restart the
+service if needed so both shells use the same config.
+
+### Smoke fails because fixtures are unavailable
+
+By default the command reads the packaged planner fixtures. If you passed
+`--fixtures-dir` or `TPP_PLANNER_FIXTURES_DIR`, verify that the directory exists
+and contains the expected planner integration JSON files.
+
+### Planner routes return `404` for proposal or execution lookups
+
+The service keeps proposal state in memory for bounded local or preview smoke
+testing. Re-run the flow from proposal submission rather than calling status or
+evaluation endpoints against a fresh process.
+
+### Planner snapshot or evaluation payload looks wrong
+
+Compare the live output to the canonical examples under
+`tests/fixtures/planner_integration/` and the contract in
+[`docs/contracts/planner-integration.md`](./contracts/planner-integration.md).
+
+## Related References
+
+- [`README.md`](../README.md)
+- [`docs/policy-api.md`](./policy-api.md)
+- [`docs/contracts/planner-integration.md`](./contracts/planner-integration.md)

--- a/docs/planner-live-test-runbook.md
+++ b/docs/planner-live-test-runbook.md
@@ -1,7 +1,7 @@
 # Planner Live-Test Runbook
 
-This is the source-of-truth operator path for running the planner-facing Travel
-Plan Permission service and exercising the live HTTP planner handshake.
+This is the source-of-truth operator runbook for running the planner-facing
+Travel Plan Permission service and exercising the live HTTP planner handshake.
 
 Use it when you need to:
 
@@ -36,14 +36,16 @@ If they are not on your shell `PATH`, run them via `uv run <command>`.
 
 Set the planner-facing base URL and auth contract before starting the service:
 
-| Variable | Required | Notes |
-| --- | --- | --- |
-| `TPP_BASE_URL` | yes | Base URL that callers use for the live service |
-| `TPP_OIDC_PROVIDER` | yes | Must be `azure_ad`, `okta`, or `google` |
-| `TPP_AUTH_MODE` | yes | `static-token` or `bootstrap-token` |
-| `TPP_ACCESS_TOKEN` | for `static-token` | Fixed bearer token for simple local or preview tests |
-| `TPP_BOOTSTRAP_SIGNING_SECRET` | for `bootstrap-token` | Shared secret for bounded bootstrap tokens |
-| `TPP_BOOTSTRAP_TOKEN_TTL_SECONDS` | optional | Defaults to `900` seconds |
+- `TPP_BASE_URL` is required and sets the base URL callers use for the live
+  service.
+- `TPP_OIDC_PROVIDER` is required and must be `azure_ad`, `okta`, or `google`.
+- `TPP_AUTH_MODE` is required and must be `static-token` or
+  `bootstrap-token`.
+- `TPP_ACCESS_TOKEN` is required only for `static-token` mode and provides the
+  fixed bearer token for simple local or preview tests.
+- `TPP_BOOTSTRAP_SIGNING_SECRET` is required only for `bootstrap-token` mode
+  and provides the shared secret for bounded bootstrap tokens.
+- `TPP_BOOTSTRAP_TOKEN_TTL_SECONDS` is optional and defaults to `900` seconds.
 
 ## Blessed Local Path
 
@@ -133,7 +135,7 @@ tpp-planner-smoke --fixtures-dir path/to/planner-fixtures
 
 The same override also works through `TPP_PLANNER_FIXTURES_DIR`.
 
-## Preview Or Remote Base URLs
+## Preview or remote base URLs
 
 For preview or shared environments, point the same commands at the deployed base
 URL instead of localhost:

--- a/docs/policy-api.md
+++ b/docs/policy-api.md
@@ -4,8 +4,8 @@ This document describes the stable policy API surface in
 `src/travel_plan_permission/policy_api.py` for use by the LangGraph
 orchestration layer and planner-facing integrations.
 
-For the operator-facing live service path, environment bootstrap, and blessed
-smoke workflow, see the
+For the operator-facing live-test procedure for these endpoints, including
+environment bootstrap and the blessed smoke workflow, see the
 [`Planner Live-Test Runbook`](./planner-live-test-runbook.md).
 
 ## Data Models

--- a/docs/policy-api.md
+++ b/docs/policy-api.md
@@ -4,6 +4,10 @@ This document describes the stable policy API surface in
 `src/travel_plan_permission/policy_api.py` for use by the LangGraph
 orchestration layer and planner-facing integrations.
 
+For the operator-facing live service path, environment bootstrap, and blessed
+smoke workflow, see the
+[`Planner Live-Test Runbook`](./planner-live-test-runbook.md).
+
 ## Data Models
 
 ### TripPlan (input)
@@ -406,6 +410,8 @@ objects.
   when `versioning.compatible_with_planner_cache` is `false`.
 - The canonical request/response examples for this seam live in
   `tests/fixtures/planner_integration/`.
+- The source-of-truth live operator path for these endpoints lives in
+  [`docs/planner-live-test-runbook.md`](./planner-live-test-runbook.md).
 
 **Planner handshake**
 


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #786

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Even if the code and tests are ready, `Travel-Plan-Permission` is not actually
ready for live testing until a new operator can start the planner-facing
service, configure the required auth values, and run the smoke path without
reverse-engineering old PRs or scattered docs.

Parent epic: #782

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#782](https://github.com/stranske/Travel-Plan-Permission/issues/782)
- [#783](https://github.com/stranske/Travel-Plan-Permission/issues/783)
- [#785](https://github.com/stranske/Travel-Plan-Permission/issues/785)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Publish one source-of-truth runbook for starting the planner-facing service and exercising the live-test path.
- [ ] Document the required environment variables, auth/bootstrap steps, expected endpoint URLs, and blessed smoke command.
- [ ] Document the repo-native entrypoints for starting the service and running the smoke check.
- [ ] Add a troubleshooting section for the most likely live-test failures: auth, readiness, contract mismatch, and missing config.
- [ ] Cross-link the runbook from `README.md`, `docs/policy-api.md`, and `docs/contracts/planner-integration.md`.

#### Acceptance criteria
- [ ] A new operator can launch the planner-facing service and run the smoke path using repo docs only.
- [ ] The runbook identifies the required environment values, auth steps, and expected request/response surfaces.
- [ ] The README points to one clear source of truth for live testing.
- [ ] Troubleshooting guidance covers the main startup, auth, and smoke failure modes.

<!-- auto-status-summary:end -->