### PR TITLE
Issue #798: add workflow portal shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ the planner routes. The startup command now fails fast unless the planner auth
 contract is complete: base URL, supported OIDC provider, and an explicit auth
 mode with its matching token configuration must all be present.
 
+The same runtime now also exposes a minimal browser-facing workflow portal:
+
+- Open `http://127.0.0.1:8000/portal` for the portal home.
+- Use `http://127.0.0.1:8000/portal/requests/new` to draft and review a travel
+  request through the canonical form fields.
+- The review screen reuses the repo's canonical conversion, policy snapshot,
+  and spreadsheet/export seams before submitting through the existing proposal
+  contract.
+
 For bounded local or preview testing, mint a short-lived planner token with:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -86,6 +86,17 @@ Use the emitted value as `Authorization: Bearer <token>` when calling planner
 routes. `TPP_AUTH_MODE="static-token"` plus `TPP_ACCESS_TOKEN` remains
 available for simple fixed-token environments.
 
+For a browser-facing draft flow on top of the same runtime, open:
+
+```text
+http://127.0.0.1:8000/portal
+```
+
+The portal stays intentionally small and server-rendered. It lets a traveler
+capture draft trip details, see missing canonical inputs before submission,
+review policy-lite posture, and download the generated itinerary and summary
+artifacts before triggering the existing proposal submission seam.
+
 Run the repo-native live smoke command against a running service with:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,11 +29,11 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "httpx>=0.28.1",
-    "pytest>=9.0.2",
-    "pytest-cov>=7.0.0",
-    "ruff==0.15.1",
-    "black==26.1.0",
-    "mypy>=1.19.1",
+    "pytest==9.0.3",
+    "pytest-cov==7.1.0",
+    "ruff==0.15.10",
+    "black==26.3.1",
+    "mypy==1.20.1",
     "types-PyYAML>=6.0.12",
     "numpy>=1.24.0",
     "packaging>=23.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ where = ["src"]
 [tool.setuptools.package-data]
 travel_plan_permission = [
     "config/*.yaml",
+    "templates/*.html",
     "templates/*.xlsx",
     "fixtures/planner_integration/*.json",
 ]

--- a/requirements.lock
+++ b/requirements.lock
@@ -9,7 +9,7 @@ anyio==4.13.0
     #   httpx
     #   starlette
     #   watchfiles
-black==26.1.0
+black==26.3.1
     # via travel-plan-permission (pyproject.toml)
 certifi==2026.2.25
     # via
@@ -24,7 +24,7 @@ click==8.3.2
     # via
     #   black
     #   uvicorn
-coverage==7.13.4
+coverage==7.13.5
     # via pytest-cov
 et-xmlfile==2.0.0
     # via openpyxl
@@ -79,7 +79,7 @@ librt==0.9.0
     # via mypy
 markupsafe==3.0.3
     # via jinja2
-mypy==1.19.1
+mypy==1.20.1
     # via travel-plan-permission (pyproject.toml)
 mypy-extensions==1.1.0
     # via
@@ -137,11 +137,11 @@ pygments==2.20.0
     # via pytest
 pytesseract==0.3.13
     # via travel-plan-permission (pyproject.toml)
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   travel-plan-permission (pyproject.toml)
     #   pytest-cov
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via travel-plan-permission (pyproject.toml)
 python-dateutil==2.9.0.post0
     # via pandas
@@ -162,7 +162,7 @@ requests==2.33.1
     #   requests-toolbelt
 requests-toolbelt==1.0.0
     # via langsmith
-ruff==0.15.1
+ruff==0.15.10
     # via travel-plan-permission (pyproject.toml)
 six==1.17.0
     # via python-dateutil

--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -525,11 +525,13 @@ def _portal_artifacts(
 ) -> dict[str, PortalArtifact]:
     itinerary_excel = render_travel_spreadsheet_bytes(plan, canonical_plan=canonical)
     bundle = build_output_bundle(itinerary_excel=itinerary_excel, answers=answers)
+    itinerary_payload = bundle["itinerary_excel"]
     summary_payload = bundle["summary_pdf"]
+    assert isinstance(itinerary_payload, dict)
     assert isinstance(summary_payload, dict)
     return {
         "itinerary": PortalArtifact(
-            filename=str(bundle["itinerary_excel"]["filename"]),
+            filename=str(itinerary_payload["filename"]),
             content=itinerary_excel,
             media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         ),
@@ -548,7 +550,7 @@ def _portal_review_state(
     submission_response: PlannerProposalOperationResponse | None = None,
 ) -> PortalReviewState:
     missing_fields = required_field_gaps(answers, required_fields=_PORTAL_REQUIRED_FIELDS)
-    next_questions = [
+    next_questions: list[dict[str, object]] = [
         {
             "prompt": question.prompt,
             "fields": ", ".join(question.fields),

--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 import sys
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -39,10 +39,8 @@ from .prompt_flow import build_output_bundle, generate_questions, required_field
 from .security import Permission
 
 _OPTIONAL_SNAPSHOT_BODY = Body(default=None)
-_TEMPLATES = Jinja2Templates(
-    directory=str(Path(__file__).resolve().parent / "templates")
-)
-_PORTAL_FIELDS: tuple[str, ...] = (
+_TEMPLATES = Jinja2Templates(directory=str(Path(__file__).resolve().parent / "templates"))
+_PORTAL_CANONICAL_FIELDS: tuple[str, ...] = (
     "traveler_name",
     "business_purpose",
     "cost_center",
@@ -72,6 +70,21 @@ _PORTAL_FIELDS: tuple[str, ...] = (
     "ground_transport_pref",
     "notes",
 )
+_PORTAL_POLICY_FIELDS: tuple[str, ...] = (
+    "booking_date",
+    "selected_fare",
+    "lowest_fare",
+    "cabin_class",
+    "flight_duration_hours",
+    "fare_evidence_attached",
+    "driving_cost",
+    "flight_cost",
+    "distance_from_office_miles",
+    "overnight_stay",
+    "meals_provided",
+    "meal_per_diem_requested",
+)
+_PORTAL_FIELDS: tuple[str, ...] = _PORTAL_CANONICAL_FIELDS + _PORTAL_POLICY_FIELDS
 _PORTAL_OPTIONAL_FIELDS = {
     "cost_center",
     "event_registration_cost",
@@ -95,8 +108,32 @@ _PORTAL_OPTIONAL_FIELDS = {
     "comparable_hotels[0].nightly_rate",
     "ground_transport_pref",
     "notes",
+    "booking_date",
+    "selected_fare",
+    "lowest_fare",
+    "cabin_class",
+    "flight_duration_hours",
+    "fare_evidence_attached",
+    "driving_cost",
+    "flight_cost",
+    "distance_from_office_miles",
+    "overnight_stay",
+    "meals_provided",
+    "meal_per_diem_requested",
 }
-_PORTAL_BOOLEAN_FIELDS = {"hotel.conference_hotel"}
+_PORTAL_REQUIRED_FIELDS: tuple[str, ...] = tuple(
+    field_name
+    for field_name in _PORTAL_CANONICAL_FIELDS
+    if field_name not in _PORTAL_OPTIONAL_FIELDS
+)
+_PORTAL_BOOLEAN_FIELDS = {
+    "hotel.conference_hotel",
+    "fare_evidence_attached",
+    "overnight_stay",
+    "meals_provided",
+    "meal_per_diem_requested",
+}
+_PORTAL_MAX_DRAFTS = 64
 
 
 @dataclass(frozen=True)
@@ -106,6 +143,7 @@ class PortalDraft:
     draft_id: str
     answers: dict[str, object]
     updated_at: datetime
+    cached_artifacts: dict[str, PortalArtifact] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -284,9 +322,7 @@ class PlannerProposalStore:
         self.remember_plan(trip_plan)
         execution_id = response.result_payload.get("execution_id")
         if not isinstance(execution_id, str):
-            raise ValueError(
-                "Planner proposal response missing required string execution_id"
-            )
+            raise ValueError("Planner proposal response missing required string execution_id")
         self.proposals_by_execution_id[execution_id] = StoredProposal(
             trip_plan=trip_plan.model_copy(deep=True),
             request=request.model_copy(deep=True),
@@ -308,6 +344,12 @@ class PlannerProposalStore:
     def save_portal_draft(self, answers: dict[str, object]) -> PortalDraft:
         """Persist portal answers so a review route can be revisited."""
 
+        if len(self.portal_drafts_by_id) >= _PORTAL_MAX_DRAFTS:
+            oldest_draft_id = min(
+                self.portal_drafts_by_id.items(),
+                key=lambda item: item[1].updated_at,
+            )[0]
+            del self.portal_drafts_by_id[oldest_draft_id]
         draft = PortalDraft(
             draft_id=uuid4().hex[:12],
             answers=dict(answers),
@@ -315,6 +357,24 @@ class PlannerProposalStore:
         )
         self.portal_drafts_by_id[draft.draft_id] = draft
         return draft
+
+    def cache_portal_artifacts(
+        self,
+        draft_id: str,
+        artifacts: dict[str, PortalArtifact],
+    ) -> PortalDraft | None:
+        """Persist generated portal artifacts for repeated downloads."""
+
+        draft = self.portal_drafts_by_id.get(draft_id)
+        if draft is None:
+            return None
+        updated = replace(
+            draft,
+            updated_at=datetime.now(UTC),
+            cached_artifacts=dict(artifacts),
+        )
+        self.portal_drafts_by_id[draft_id] = updated
+        return updated
 
     def lookup_portal_draft(self, draft_id: str) -> PortalDraft | None:
         """Return a previously stored portal draft by identifier."""
@@ -326,6 +386,7 @@ class PlannerProposalStore:
             draft_id=draft.draft_id,
             answers=dict(draft.answers),
             updated_at=draft.updated_at,
+            cached_artifacts=dict(draft.cached_artifacts),
         )
 
 
@@ -411,7 +472,7 @@ def _portal_answers_from_encoded_body(body: bytes) -> dict[str, object]:
 
 def _canonical_payload_from_answers(answers: dict[str, object]) -> dict[str, object]:
     payload: dict[str, object] = {"type": "trip"}
-    for field_name in _PORTAL_FIELDS:
+    for field_name in _PORTAL_CANONICAL_FIELDS:
         value = answers.get(field_name)
         if value is None:
             continue
@@ -486,7 +547,7 @@ def _portal_review_state(
     *,
     submission_response: PlannerProposalOperationResponse | None = None,
 ) -> PortalReviewState:
-    missing_fields = required_field_gaps(answers)
+    missing_fields = required_field_gaps(answers, required_fields=_PORTAL_REQUIRED_FIELDS)
     next_questions = [
         {
             "prompt": question.prompt,
@@ -579,14 +640,10 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
 
     @app.get("/portal/requests/new", response_class=HTMLResponse)
     def portal_request_form(request: Request) -> HTMLResponse:
-        answers = _portal_answers_from_form(request)
-        review = (
-            _portal_review_state(draft_id="preview", answers=answers) if answers else None
-        )
         return _TEMPLATES.TemplateResponse(
             request=request,
             name="portal_request.html",
-            context=_portal_template_context(request, review),
+            context=_portal_template_context(request, None),
         )
 
     @app.post("/portal/requests/review")
@@ -598,7 +655,9 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
             status_code=status.HTTP_303_SEE_OTHER,
         )
 
-    @app.get("/portal/requests/{draft_id}", response_class=HTMLResponse, name="portal_request_detail")
+    @app.get(
+        "/portal/requests/{draft_id}", response_class=HTMLResponse, name="portal_request_detail"
+    )
     def portal_request_detail(request: Request, draft_id: str) -> HTMLResponse:
         draft = proposal_store.lookup_portal_draft(draft_id)
         if draft is None:
@@ -607,6 +666,8 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
                 detail=f"No portal draft found for '{draft_id}'.",
             )
         review = _portal_review_state(draft.draft_id, draft.answers)
+        if review.artifacts and not draft.cached_artifacts:
+            proposal_store.cache_portal_artifacts(draft.draft_id, review.artifacts)
         return _TEMPLATES.TemplateResponse(
             request=request,
             name="portal_request.html",
@@ -614,7 +675,15 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         )
 
     @app.post("/portal/requests/{draft_id}/submit", response_class=HTMLResponse)
-    def portal_submit_request(request: Request, draft_id: str) -> HTMLResponse:
+    def portal_submit_request(
+        request: Request,
+        draft_id: str,
+        authorization: str | None = Header(default=None),
+    ) -> HTMLResponse:
+        _authorize_request(
+            authorization,
+            required_permission=Permission.CREATE,
+        )
         draft = proposal_store.lookup_portal_draft(draft_id)
         if draft is None:
             raise HTTPException(
@@ -622,11 +691,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
                 detail=f"No portal draft found for '{draft_id}'.",
             )
         review = _portal_review_state(draft.draft_id, draft.answers)
-        if (
-            review.trip_plan is None
-            or review.missing_fields
-            or review.validation_errors
-        ):
+        if review.trip_plan is None or review.missing_fields or review.validation_errors:
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="Complete the request review before submitting the portal draft.",
@@ -669,8 +734,13 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"No portal draft found for '{draft_id}'.",
             )
-        review = _portal_review_state(draft.draft_id, draft.answers)
-        artifact = review.artifacts.get(artifact_name)
+        artifacts = draft.cached_artifacts
+        if not artifacts:
+            review = _portal_review_state(draft.draft_id, draft.answers)
+            artifacts = review.artifacts
+            if artifacts:
+                proposal_store.cache_portal_artifacts(draft.draft_id, artifacts)
+        artifact = artifacts.get(artifact_name)
         if artifact is None:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
@@ -679,9 +749,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         return Response(
             content=artifact.content,
             media_type=artifact.media_type,
-            headers={
-                "Content-Disposition": f'attachment; filename="{artifact.filename}"'
-            },
+            headers={"Content-Disposition": f'attachment; filename="{artifact.filename}"'},
         )
 
     @app.get(
@@ -785,9 +853,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         if stored.request.proposal_id != proposal_id:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail=(
-                    f"Execution '{execution_id}' does not belong to proposal '{proposal_id}'."
-                ),
+                detail=(f"Execution '{execution_id}' does not belong to proposal '{proposal_id}'."),
             )
         status_request = _submission_status_request(
             stored,

--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -6,11 +6,18 @@ import argparse
 import sys
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs
+from uuid import uuid4
 
 import uvicorn
-from fastapi import Body, FastAPI, Header, HTTPException, Query, Response, status
-from pydantic import BaseModel, Field
+from fastapi import Body, FastAPI, Header, HTTPException, Query, Request, Response, status
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+from pydantic import BaseModel, Field, ValidationError
 
+from .canonical import CanonicalTripPlan, canonical_trip_plan_to_model
 from .models import TripPlan
 from .planner_auth import PlannerAuthConfig, authenticate_request
 from .policy_api import (
@@ -21,14 +28,110 @@ from .policy_api import (
     PlannerProposalOperationResponse,
     PlannerProposalStatusRequest,
     PlannerProposalSubmissionRequest,
+    check_trip_plan,
     get_evaluation_result,
     get_policy_snapshot,
     poll_execution_status,
+    render_travel_spreadsheet_bytes,
     submit_proposal,
 )
+from .prompt_flow import build_output_bundle, generate_questions, required_field_gaps
 from .security import Permission
 
 _OPTIONAL_SNAPSHOT_BODY = Body(default=None)
+_TEMPLATES = Jinja2Templates(
+    directory=str(Path(__file__).resolve().parent / "templates")
+)
+_PORTAL_FIELDS: tuple[str, ...] = (
+    "traveler_name",
+    "business_purpose",
+    "cost_center",
+    "destination_zip",
+    "city_state",
+    "depart_date",
+    "return_date",
+    "event_registration_cost",
+    "flight_pref_outbound.carrier_flight",
+    "flight_pref_outbound.depart_time",
+    "flight_pref_outbound.arrive_time",
+    "flight_pref_outbound.roundtrip_cost",
+    "flight_pref_return.carrier_flight",
+    "flight_pref_return.depart_time",
+    "flight_pref_return.arrive_time",
+    "lowest_cost_roundtrip",
+    "parking_estimate",
+    "hotel.name",
+    "hotel.address",
+    "hotel.city_state",
+    "hotel.nightly_rate",
+    "hotel.nights",
+    "hotel.conference_hotel",
+    "hotel.price_compare_notes",
+    "comparable_hotels[0].name",
+    "comparable_hotels[0].nightly_rate",
+    "ground_transport_pref",
+    "notes",
+)
+_PORTAL_OPTIONAL_FIELDS = {
+    "cost_center",
+    "event_registration_cost",
+    "flight_pref_outbound.carrier_flight",
+    "flight_pref_outbound.depart_time",
+    "flight_pref_outbound.arrive_time",
+    "flight_pref_outbound.roundtrip_cost",
+    "flight_pref_return.carrier_flight",
+    "flight_pref_return.depart_time",
+    "flight_pref_return.arrive_time",
+    "lowest_cost_roundtrip",
+    "parking_estimate",
+    "hotel.name",
+    "hotel.address",
+    "hotel.city_state",
+    "hotel.nightly_rate",
+    "hotel.nights",
+    "hotel.conference_hotel",
+    "hotel.price_compare_notes",
+    "comparable_hotels[0].name",
+    "comparable_hotels[0].nightly_rate",
+    "ground_transport_pref",
+    "notes",
+}
+_PORTAL_BOOLEAN_FIELDS = {"hotel.conference_hotel"}
+
+
+@dataclass(frozen=True)
+class PortalDraft:
+    """Stored portal draft answers for request review and submission."""
+
+    draft_id: str
+    answers: dict[str, object]
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
+class PortalArtifact:
+    """Generated portal artifact metadata and payload."""
+
+    filename: str
+    content: bytes
+    media_type: str
+
+
+@dataclass(frozen=True)
+class PortalReviewState:
+    """Computed portal review context derived from a draft."""
+
+    draft_id: str
+    answers: dict[str, object]
+    missing_fields: list[str]
+    next_questions: list[dict[str, object]]
+    validation_errors: list[str]
+    canonical_payload: dict[str, object] | None
+    trip_plan: TripPlan | None
+    policy_snapshot: PlannerPolicySnapshot | None
+    policy_result: Any | None
+    artifacts: dict[str, PortalArtifact]
+    submission_response: PlannerProposalOperationResponse | None = None
 
 
 class PlannerRuntimeConfigError(RuntimeError):
@@ -155,6 +258,7 @@ class PlannerProposalStore:
 
     plans_by_trip_id: dict[str, TripPlan] = field(default_factory=dict)
     proposals_by_execution_id: dict[str, StoredProposal] = field(default_factory=dict)
+    portal_drafts_by_id: dict[str, PortalDraft] = field(default_factory=dict)
 
     def remember_plan(self, trip_plan: TripPlan) -> None:
         """Store the latest planner trip payload by trip identifier."""
@@ -201,6 +305,29 @@ class PlannerProposalStore:
             response=stored.response.model_copy(deep=True),
         )
 
+    def save_portal_draft(self, answers: dict[str, object]) -> PortalDraft:
+        """Persist portal answers so a review route can be revisited."""
+
+        draft = PortalDraft(
+            draft_id=uuid4().hex[:12],
+            answers=dict(answers),
+            updated_at=datetime.now(UTC),
+        )
+        self.portal_drafts_by_id[draft.draft_id] = draft
+        return draft
+
+    def lookup_portal_draft(self, draft_id: str) -> PortalDraft | None:
+        """Return a previously stored portal draft by identifier."""
+
+        draft = self.portal_drafts_by_id.get(draft_id)
+        if draft is None:
+            return None
+        return PortalDraft(
+            draft_id=draft.draft_id,
+            answers=dict(draft.answers),
+            updated_at=draft.updated_at,
+        )
+
 
 def _readiness_response() -> PlannerReadinessResponse:
     config = PlannerRuntimeConfig.from_env()
@@ -242,6 +369,192 @@ def _evaluation_request(
     )
 
 
+def _normalize_portal_value(field_name: str, raw_value: str) -> object | None:
+    value = raw_value.strip()
+    if not value:
+        return None
+    if field_name in _PORTAL_BOOLEAN_FIELDS:
+        normalized = value.casefold()
+        if normalized in {"true", "yes", "on", "1"}:
+            return True
+        if normalized in {"false", "no", "off", "0"}:
+            return False
+    return value
+
+
+def _portal_answers_from_form(request: Request) -> dict[str, object]:
+    answers: dict[str, object] = {}
+    for field_name in _PORTAL_FIELDS:
+        raw_value = request.query_params.get(field_name)
+        if raw_value is None:
+            continue
+        normalized = _normalize_portal_value(field_name, raw_value)
+        if normalized is None:
+            continue
+        answers[field_name] = normalized
+    return answers
+
+
+def _portal_answers_from_encoded_body(body: bytes) -> dict[str, object]:
+    answers: dict[str, object] = {}
+    parsed = parse_qs(body.decode("utf-8"), keep_blank_values=False)
+    for field_name in _PORTAL_FIELDS:
+        values = parsed.get(field_name)
+        if not values:
+            continue
+        normalized = _normalize_portal_value(field_name, values[-1])
+        if normalized is None:
+            continue
+        answers[field_name] = normalized
+    return answers
+
+
+def _canonical_payload_from_answers(answers: dict[str, object]) -> dict[str, object]:
+    payload: dict[str, object] = {"type": "trip"}
+    for field_name in _PORTAL_FIELDS:
+        value = answers.get(field_name)
+        if value is None:
+            continue
+        segments = field_name.split(".")
+        current: dict[str, object] = payload
+        for index, segment in enumerate(segments):
+            is_last = index == len(segments) - 1
+            if "[" in segment and segment.endswith("]"):
+                container_name, item_index_text = segment[:-1].split("[", 1)
+                item_index = int(item_index_text)
+                existing = current.get(container_name)
+                if not isinstance(existing, list):
+                    existing = []
+                    current[container_name] = existing
+                while len(existing) <= item_index:
+                    existing.append({})
+                if is_last:
+                    existing[item_index] = value
+                    continue
+                next_value = existing[item_index]
+                if not isinstance(next_value, dict):
+                    next_value = {}
+                    existing[item_index] = next_value
+                current = next_value
+                continue
+            if is_last:
+                current[segment] = value
+            else:
+                next_value = current.get(segment)
+                if not isinstance(next_value, dict):
+                    next_value = {}
+                    current[segment] = next_value
+                current = next_value
+    return payload
+
+
+def _review_validation_errors(exc: ValidationError) -> list[str]:
+    errors: list[str] = []
+    for error in exc.errors():
+        location = ".".join(str(part) for part in error["loc"])
+        errors.append(f"{location}: {error['msg']}")
+    return errors
+
+
+def _portal_artifacts(
+    *,
+    canonical: CanonicalTripPlan,
+    plan: TripPlan,
+    answers: dict[str, object],
+) -> dict[str, PortalArtifact]:
+    itinerary_excel = render_travel_spreadsheet_bytes(plan, canonical_plan=canonical)
+    bundle = build_output_bundle(itinerary_excel=itinerary_excel, answers=answers)
+    summary_payload = bundle["summary_pdf"]
+    assert isinstance(summary_payload, dict)
+    return {
+        "itinerary": PortalArtifact(
+            filename=str(bundle["itinerary_excel"]["filename"]),
+            content=itinerary_excel,
+            media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        ),
+        "summary": PortalArtifact(
+            filename=str(summary_payload["filename"]),
+            content=bytes(summary_payload["content"]),
+            media_type=str(summary_payload["mime_type"]),
+        ),
+    }
+
+
+def _portal_review_state(
+    draft_id: str,
+    answers: dict[str, object],
+    *,
+    submission_response: PlannerProposalOperationResponse | None = None,
+) -> PortalReviewState:
+    missing_fields = required_field_gaps(answers)
+    next_questions = [
+        {
+            "prompt": question.prompt,
+            "fields": ", ".join(question.fields),
+            "kind": question.kind,
+        }
+        for question in generate_questions(answers, max_questions=4)
+    ]
+    validation_errors: list[str] = []
+    canonical_payload: dict[str, object] | None = None
+    trip_plan: TripPlan | None = None
+    policy_snapshot: PlannerPolicySnapshot | None = None
+    policy_result: Any | None = None
+    artifacts: dict[str, PortalArtifact] = {}
+
+    if not missing_fields:
+        canonical_payload = _canonical_payload_from_answers(answers)
+        try:
+            canonical = CanonicalTripPlan.model_validate(canonical_payload)
+        except ValidationError as exc:
+            validation_errors = _review_validation_errors(exc)
+        else:
+            trip_plan = canonical_trip_plan_to_model(canonical)
+            policy_snapshot = get_policy_snapshot(
+                trip_plan,
+                PlannerPolicySnapshotRequest(trip_id=trip_plan.trip_id),
+            )
+            policy_result = check_trip_plan(trip_plan)
+            artifacts = _portal_artifacts(
+                canonical=canonical,
+                plan=trip_plan,
+                answers=answers,
+            )
+
+    return PortalReviewState(
+        draft_id=draft_id,
+        answers=answers,
+        missing_fields=missing_fields,
+        next_questions=next_questions,
+        validation_errors=validation_errors,
+        canonical_payload=canonical_payload,
+        trip_plan=trip_plan,
+        policy_snapshot=policy_snapshot,
+        policy_result=policy_result,
+        artifacts=artifacts,
+        submission_response=submission_response,
+    )
+
+
+def _portal_template_context(
+    request: Request,
+    review: PortalReviewState | None = None,
+) -> dict[str, object]:
+    answers = review.answers if review is not None else {}
+    return {
+        "request": request,
+        "answers": answers,
+        "review": review,
+        "ground_transport_options": (
+            "rideshare/taxi",
+            "rental car",
+            "public transit",
+            "personal vehicle",
+        ),
+        "optional_fields": _PORTAL_OPTIONAL_FIELDS,
+    }
+
+
 def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
     """Create the planner-facing ASGI application."""
 
@@ -255,6 +568,121 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
     @app.get("/healthz")
     def healthz() -> dict[str, str]:
         return {"status": "ok"}
+
+    @app.get("/portal", response_class=HTMLResponse)
+    def portal_home(request: Request) -> HTMLResponse:
+        return _TEMPLATES.TemplateResponse(
+            request=request,
+            name="portal_home.html",
+            context={"service_ready": _readiness_response().status == "ready"},
+        )
+
+    @app.get("/portal/requests/new", response_class=HTMLResponse)
+    def portal_request_form(request: Request) -> HTMLResponse:
+        answers = _portal_answers_from_form(request)
+        review = (
+            _portal_review_state(draft_id="preview", answers=answers) if answers else None
+        )
+        return _TEMPLATES.TemplateResponse(
+            request=request,
+            name="portal_request.html",
+            context=_portal_template_context(request, review),
+        )
+
+    @app.post("/portal/requests/review")
+    async def portal_request_review(request: Request) -> RedirectResponse:
+        answers = _portal_answers_from_encoded_body(await request.body())
+        draft = proposal_store.save_portal_draft(answers)
+        return RedirectResponse(
+            url=request.url_for("portal_request_detail", draft_id=draft.draft_id),
+            status_code=status.HTTP_303_SEE_OTHER,
+        )
+
+    @app.get("/portal/requests/{draft_id}", response_class=HTMLResponse, name="portal_request_detail")
+    def portal_request_detail(request: Request, draft_id: str) -> HTMLResponse:
+        draft = proposal_store.lookup_portal_draft(draft_id)
+        if draft is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"No portal draft found for '{draft_id}'.",
+            )
+        review = _portal_review_state(draft.draft_id, draft.answers)
+        return _TEMPLATES.TemplateResponse(
+            request=request,
+            name="portal_request.html",
+            context=_portal_template_context(request, review),
+        )
+
+    @app.post("/portal/requests/{draft_id}/submit", response_class=HTMLResponse)
+    def portal_submit_request(request: Request, draft_id: str) -> HTMLResponse:
+        draft = proposal_store.lookup_portal_draft(draft_id)
+        if draft is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"No portal draft found for '{draft_id}'.",
+            )
+        review = _portal_review_state(draft.draft_id, draft.answers)
+        if (
+            review.trip_plan is None
+            or review.missing_fields
+            or review.validation_errors
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Complete the request review before submitting the portal draft.",
+            )
+        submission_request = PlannerProposalSubmissionRequest(
+            trip_id=review.trip_plan.trip_id,
+            proposal_id=f"{review.trip_plan.trip_id.lower()}-portal-request",
+            proposal_version="portal-v1",
+            payload={
+                "channel": "workflow-portal",
+                "draft_id": draft_id,
+                "review_surface": "browser",
+            },
+        )
+        submission_response = submit_proposal(review.trip_plan, submission_request)
+        proposal_store.record_submission(
+            review.trip_plan,
+            submission_request,
+            submission_response,
+        )
+        review = _portal_review_state(
+            draft.draft_id,
+            draft.answers,
+            submission_response=submission_response,
+        )
+        return _TEMPLATES.TemplateResponse(
+            request=request,
+            name="portal_request.html",
+            context=_portal_template_context(request, review),
+        )
+
+    @app.get("/portal/requests/{draft_id}/artifacts/{artifact_name}")
+    def portal_artifact(
+        draft_id: str,
+        artifact_name: str,
+    ) -> Response:
+        draft = proposal_store.lookup_portal_draft(draft_id)
+        if draft is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"No portal draft found for '{draft_id}'.",
+            )
+        review = _portal_review_state(draft.draft_id, draft.answers)
+        artifact = review.artifacts.get(artifact_name)
+        if artifact is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"No artifact named '{artifact_name}' for draft '{draft_id}'.",
+            )
+        return Response(
+            content=artifact.content,
+            media_type=artifact.media_type,
+            headers={
+                "Content-Disposition": f'attachment; filename="{artifact.filename}"'
+            },
+        )
 
     @app.get(
         "/readyz",

--- a/src/travel_plan_permission/templates/portal_home.html
+++ b/src/travel_plan_permission/templates/portal_home.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Travel Request Portal</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #f4efe6;
+        --card: #fffdf9;
+        --ink: #1e1d1a;
+        --muted: #625c52;
+        --accent: #a2461a;
+        --accent-soft: #f8d5c5;
+        --border: #d7c8b9;
+      }
+      body {
+        margin: 0;
+        font-family: Georgia, "Times New Roman", serif;
+        background: linear-gradient(180deg, #f8f2ea 0%, var(--bg) 100%);
+        color: var(--ink);
+      }
+      main {
+        max-width: 860px;
+        margin: 0 auto;
+        padding: 3rem 1.5rem 4rem;
+      }
+      .hero,
+      .card {
+        background: var(--card);
+        border: 1px solid var(--border);
+        border-radius: 20px;
+        box-shadow: 0 16px 40px rgba(37, 27, 15, 0.08);
+      }
+      .hero {
+        padding: 2rem;
+        margin-bottom: 1.5rem;
+      }
+      .card {
+        padding: 1.5rem;
+      }
+      h1,
+      h2 {
+        margin-top: 0;
+      }
+      .badge {
+        display: inline-block;
+        padding: 0.3rem 0.65rem;
+        border-radius: 999px;
+        background: var(--accent-soft);
+        color: var(--accent);
+        font-size: 0.9rem;
+        margin-bottom: 0.75rem;
+      }
+      a.button {
+        display: inline-block;
+        margin-top: 1rem;
+        padding: 0.85rem 1.2rem;
+        border-radius: 999px;
+        background: var(--accent);
+        color: white;
+        text-decoration: none;
+        font-weight: 600;
+      }
+      ul {
+        padding-left: 1.2rem;
+      }
+      code {
+        font-size: 0.95em;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <section class="hero">
+        <div class="badge">Workflow Lite Portal</div>
+        <h1>Travel request intake without fixtures</h1>
+        <p>
+          Start a request in the browser, inspect policy readiness, and submit
+          it through the same runtime seams the planner adapter already uses.
+        </p>
+        <a class="button" href="{{ request.url_for('portal_request_form') }}">
+          Start a new request
+        </a>
+      </section>
+      <section class="card">
+        <h2>What this shell does</h2>
+        <ul>
+          <li>Captures canonical trip inputs in a lightweight server-rendered form.</li>
+          <li>Surfaces missing required fields and next intake questions.</li>
+          <li>Shows policy-lite readiness plus generated spreadsheet and summary artifacts.</li>
+          <li>Submits the reviewed request through the existing proposal seam.</li>
+        </ul>
+        <p>
+          Planner runtime ready:
+          <strong>{{ "yes" if service_ready else "no" }}</strong>
+        </p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/src/travel_plan_permission/templates/portal_home.html
+++ b/src/travel_plan_permission/templates/portal_home.html
@@ -6,96 +6,147 @@
     <title>Travel Request Portal</title>
     <style>
       :root {
-        color-scheme: light;
-        --bg: #f4efe6;
-        --card: #fffdf9;
-        --ink: #1e1d1a;
-        --muted: #625c52;
-        --accent: #a2461a;
-        --accent-soft: #f8d5c5;
-        --border: #d7c8b9;
+        --ink: #102230;
+        --muted: #4f6776;
+        --card: rgba(255, 255, 255, 0.88);
+        --accent: #c65d2e;
+        --accent-soft: #f6d8ca;
+        --line: rgba(16, 34, 48, 0.14);
+        --shadow: 0 24px 64px rgba(16, 34, 48, 0.16);
       }
+      * { box-sizing: border-box; }
       body {
         margin: 0;
-        font-family: Georgia, "Times New Roman", serif;
-        background: linear-gradient(180deg, #f8f2ea 0%, var(--bg) 100%);
         color: var(--ink);
+        font-family: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, serif;
+        background:
+          radial-gradient(circle at top left, rgba(246, 216, 202, 0.95), transparent 34%),
+          linear-gradient(135deg, #f7f2ea 0%, #dce8ef 100%);
       }
       main {
-        max-width: 860px;
+        max-width: 1080px;
         margin: 0 auto;
-        padding: 3rem 1.5rem 4rem;
+        padding: 48px 20px 72px;
       }
-      .hero,
-      .card {
+      .hero, .panel {
         background: var(--card);
-        border: 1px solid var(--border);
-        border-radius: 20px;
-        box-shadow: 0 16px 40px rgba(37, 27, 15, 0.08);
+        border: 1px solid var(--line);
+        border-radius: 28px;
+        box-shadow: var(--shadow);
       }
       .hero {
-        padding: 2rem;
-        margin-bottom: 1.5rem;
+        padding: 36px;
+        display: grid;
+        gap: 20px;
       }
-      .card {
-        padding: 1.5rem;
+      h1, h2 {
+        margin: 0;
+        letter-spacing: -0.03em;
       }
-      h1,
-      h2 {
-        margin-top: 0;
+      h1 {
+        font-size: clamp(2.5rem, 4vw, 4.6rem);
+        line-height: 0.96;
+        max-width: 10ch;
       }
-      .badge {
-        display: inline-block;
-        padding: 0.3rem 0.65rem;
+      p {
+        margin: 0;
+        line-height: 1.55;
+        color: var(--muted);
+        max-width: 68ch;
+      }
+      .actions {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+      .button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 14px 18px;
+        border-radius: 999px;
+        text-decoration: none;
+        font-weight: 700;
+        border: 1px solid var(--line);
+      }
+      .button.primary {
+        background: var(--ink);
+        color: white;
+      }
+      .button.secondary {
+        background: white;
+        color: var(--ink);
+      }
+      .grid {
+        margin-top: 28px;
+        display: grid;
+        gap: 20px;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      }
+      .panel {
+        padding: 24px;
+      }
+      .eyebrow {
+        text-transform: uppercase;
+        font: 600 0.78rem/1.2 ui-monospace, "SFMono-Regular", "SF Mono", Menlo, monospace;
+        letter-spacing: 0.14em;
+        color: var(--accent);
+      }
+      .status {
+        display: inline-flex;
+        padding: 6px 10px;
         border-radius: 999px;
         background: var(--accent-soft);
-        color: var(--accent);
-        font-size: 0.9rem;
-        margin-bottom: 0.75rem;
-      }
-      a.button {
-        display: inline-block;
-        margin-top: 1rem;
-        padding: 0.85rem 1.2rem;
-        border-radius: 999px;
-        background: var(--accent);
-        color: white;
-        text-decoration: none;
-        font-weight: 600;
+        font: 600 0.8rem/1.1 ui-monospace, "SFMono-Regular", Menlo, monospace;
       }
       ul {
-        padding-left: 1.2rem;
+        margin: 14px 0 0;
+        padding-left: 18px;
+        color: var(--muted);
       }
-      code {
-        font-size: 0.95em;
+      li + li {
+        margin-top: 8px;
       }
     </style>
   </head>
   <body>
     <main>
       <section class="hero">
-        <div class="badge">Workflow Lite Portal</div>
-        <h1>Travel request intake without fixtures</h1>
+        <div class="eyebrow">Workflow Lite Portal</div>
+        <h1>Travel request drafting without fixture gymnastics.</h1>
         <p>
-          Start a request in the browser, inspect policy readiness, and submit
-          it through the same runtime seams the planner adapter already uses.
+          Start a browser-facing request, review canonical readiness, and generate the
+          spreadsheet and summary artifacts from the repo’s real travel-plan seams.
         </p>
-        <a class="button" href="{{ request.url_for('portal_request_form') }}">
-          Start a new request
-        </a>
+        <div class="actions">
+          <a class="button primary" href="/portal/requests/new">Start a new request</a>
+          <a class="button secondary" href="/readyz">Check runtime readiness</a>
+        </div>
       </section>
-      <section class="card">
-        <h2>What this shell does</h2>
-        <ul>
-          <li>Captures canonical trip inputs in a lightweight server-rendered form.</li>
-          <li>Surfaces missing required fields and next intake questions.</li>
-          <li>Shows policy-lite readiness plus generated spreadsheet and summary artifacts.</li>
-          <li>Submits the reviewed request through the existing proposal seam.</li>
-        </ul>
-        <p>
-          Planner runtime ready:
-          <strong>{{ "yes" if service_ready else "no" }}</strong>
-        </p>
+
+      <section class="grid">
+        <article class="panel">
+          <div class="eyebrow">What It Uses</div>
+          <h2>Real repo logic</h2>
+          <ul>
+            <li>Canonical trip fields and missing-input guidance.</li>
+            <li>Planner policy snapshot and policy-lite posture.</li>
+            <li>Spreadsheet and summary artifact generation.</li>
+          </ul>
+        </article>
+        <article class="panel">
+          <div class="eyebrow">Runtime</div>
+          <h2>Service status</h2>
+          <p>
+            <span class="status">
+              {% if service_ready %}Planner auth configured{% else %}Planner auth incomplete{% endif %}
+            </span>
+          </p>
+          <p style="margin-top: 12px;">
+            The portal shell is available without planner credentials; the lower-level planner
+            API still follows the normal token requirements.
+          </p>
+        </article>
       </section>
     </main>
   </body>

--- a/src/travel_plan_permission/templates/portal_request.html
+++ b/src/travel_plan_permission/templates/portal_request.html
@@ -3,179 +3,202 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Travel Request Portal</title>
+    <title>Travel Request Draft</title>
     <style>
       :root {
-        color-scheme: light;
-        --bg: #f3efe8;
-        --panel: #fffdf9;
-        --panel-alt: #f8f4ee;
-        --ink: #22211f;
-        --muted: #6b6258;
-        --accent: #0c5c57;
-        --accent-soft: #dff1ef;
-        --warning: #7d4e00;
-        --warning-soft: #ffefcf;
-        --danger: #a2271b;
-        --danger-soft: #f8dad6;
-        --border: #d8cbbd;
+        --ink: #0f2230;
+        --muted: #587080;
+        --paper: rgba(255, 255, 255, 0.9);
+        --line: rgba(15, 34, 48, 0.12);
+        --accent: #146356;
+        --accent-soft: rgba(20, 99, 86, 0.14);
+        --warn: #a74e1c;
+        --warn-soft: rgba(167, 78, 28, 0.13);
+        --shadow: 0 22px 58px rgba(15, 34, 48, 0.14);
       }
+      * { box-sizing: border-box; }
       body {
         margin: 0;
-        background: radial-gradient(circle at top, #ffffff 0%, var(--bg) 55%);
         color: var(--ink);
-        font-family: Georgia, "Times New Roman", serif;
+        font-family: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, serif;
+        background:
+          radial-gradient(circle at right top, rgba(20, 99, 86, 0.13), transparent 30%),
+          linear-gradient(135deg, #f6f0e8 0%, #dfe9ef 100%);
       }
       main {
-        max-width: 1180px;
+        max-width: 1240px;
         margin: 0 auto;
-        padding: 2rem 1rem 3rem;
+        padding: 32px 18px 72px;
       }
-      .masthead {
+      a { color: inherit; }
+      .topbar {
         display: flex;
         justify-content: space-between;
-        gap: 1rem;
-        align-items: end;
-        margin-bottom: 1rem;
+        align-items: center;
+        gap: 12px;
+        margin-bottom: 24px;
       }
-      .masthead a {
-        color: var(--accent);
+      .home-link {
+        text-decoration: none;
+        font: 600 0.85rem/1.1 ui-monospace, "SFMono-Regular", Menlo, monospace;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
       }
       .layout {
         display: grid;
-        grid-template-columns: minmax(0, 1.4fr) minmax(320px, 0.9fr);
-        gap: 1rem;
+        gap: 20px;
+        grid-template-columns: minmax(0, 1.2fr) minmax(320px, 0.8fr);
       }
       .panel {
-        background: var(--panel);
-        border: 1px solid var(--border);
+        background: var(--paper);
+        border: 1px solid var(--line);
+        border-radius: 26px;
+        box-shadow: var(--shadow);
+        padding: 24px;
+      }
+      h1, h2, h3 {
+        margin: 0;
+        letter-spacing: -0.03em;
+      }
+      h1 { font-size: clamp(2rem, 3vw, 3.6rem); line-height: 0.98; }
+      h2 { font-size: 1.3rem; }
+      h3 { font-size: 1rem; text-transform: uppercase; letter-spacing: 0.08em; }
+      p {
+        margin: 0;
+        color: var(--muted);
+        line-height: 1.55;
+      }
+      .intro {
+        display: grid;
+        gap: 14px;
+        margin-bottom: 24px;
+      }
+      .section-grid {
+        display: grid;
+        gap: 18px;
+      }
+      .section-card {
+        border: 1px solid var(--line);
         border-radius: 20px;
-        box-shadow: 0 12px 32px rgba(35, 29, 18, 0.08);
-        padding: 1.25rem;
+        padding: 18px;
+        background: rgba(255, 255, 255, 0.74);
       }
-      .panel.alt {
-        background: var(--panel-alt);
-      }
-      .stack {
+      .fields {
+        margin-top: 14px;
         display: grid;
-        gap: 1rem;
-      }
-      .field-grid {
-        display: grid;
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-        gap: 0.9rem;
-      }
-      .field {
-        display: grid;
-        gap: 0.35rem;
-      }
-      .field.full {
-        grid-column: 1 / -1;
+        gap: 14px;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
       }
       label {
+        display: grid;
+        gap: 6px;
         font-size: 0.95rem;
-        font-weight: 700;
       }
-      input,
-      textarea,
-      select {
+      .label-row {
+        display: flex;
+        justify-content: space-between;
+        gap: 10px;
+        align-items: baseline;
+      }
+      .optional {
+        font: 600 0.7rem/1 ui-monospace, "SFMono-Regular", Menlo, monospace;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--muted);
+      }
+      input, textarea, select {
         width: 100%;
-        box-sizing: border-box;
-        border: 1px solid var(--border);
-        border-radius: 12px;
-        padding: 0.7rem 0.8rem;
+        border: 1px solid var(--line);
+        border-radius: 14px;
+        padding: 12px 14px;
         font: inherit;
-        background: white;
+        color: var(--ink);
+        background: rgba(255, 255, 255, 0.94);
       }
       textarea {
-        min-height: 5rem;
+        min-height: 110px;
         resize: vertical;
       }
-      .hint {
-        color: var(--muted);
-        font-size: 0.9rem;
-      }
       .actions {
+        margin-top: 22px;
         display: flex;
-        gap: 0.75rem;
-        align-items: center;
+        gap: 12px;
         flex-wrap: wrap;
-        margin-top: 1rem;
       }
-      button,
-      .button-link {
-        appearance: none;
+      button, .button {
         border: 0;
         border-radius: 999px;
-        padding: 0.8rem 1.15rem;
-        font: inherit;
-        font-weight: 700;
+        padding: 14px 18px;
+        font: 700 0.95rem/1 inherit;
         cursor: pointer;
         text-decoration: none;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
       }
-      button.primary,
-      .button-link.primary {
-        background: var(--accent);
+      button.primary, .button.primary {
+        background: var(--ink);
         color: white;
       }
-      .button-link.secondary {
+      button.secondary, .button.secondary {
+        background: white;
+        color: var(--ink);
+        border: 1px solid var(--line);
+      }
+      .stack { display: grid; gap: 16px; }
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 7px 12px;
+        border-radius: 999px;
         background: var(--accent-soft);
         color: var(--accent);
+        font: 600 0.8rem/1 ui-monospace, "SFMono-Regular", Menlo, monospace;
+      }
+      .badge.warn {
+        background: var(--warn-soft);
+        color: var(--warn);
       }
       .callout {
-        border-radius: 16px;
-        padding: 0.95rem 1rem;
-      }
-      .callout.warning {
-        background: var(--warning-soft);
-        color: var(--warning);
-      }
-      .callout.danger {
-        background: var(--danger-soft);
-        color: var(--danger);
-      }
-      .callout.success {
-        background: var(--accent-soft);
-        color: var(--accent);
+        border-radius: 18px;
+        padding: 16px 18px;
+        background: rgba(255, 255, 255, 0.76);
+        border: 1px solid var(--line);
       }
       ul {
-        margin: 0.6rem 0 0;
-        padding-left: 1.2rem;
+        margin: 10px 0 0;
+        padding-left: 18px;
+        color: var(--muted);
+      }
+      li + li {
+        margin-top: 8px;
+      }
+      pre {
+        margin: 0;
+        padding: 14px;
+        border-radius: 16px;
+        background: #102230;
+        color: #edf4f7;
+        overflow: auto;
+        font: 0.84rem/1.45 ui-monospace, "SFMono-Regular", Menlo, monospace;
       }
       dl {
         margin: 0;
         display: grid;
-        grid-template-columns: max-content 1fr;
-        gap: 0.4rem 0.75rem;
+        gap: 10px;
       }
       dt {
-        font-weight: 700;
+        font: 600 0.78rem/1 ui-monospace, "SFMono-Regular", Menlo, monospace;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--muted);
       }
-      .artifact-list,
-      .question-list,
-      .issue-list {
-        display: grid;
-        gap: 0.8rem;
+      dd {
+        margin: 2px 0 0;
       }
-      .artifact,
-      .question,
-      .issue {
-        border: 1px solid var(--border);
-        border-radius: 14px;
-        padding: 0.8rem;
-        background: white;
-      }
-      .status-pill {
-        display: inline-block;
-        padding: 0.2rem 0.55rem;
-        border-radius: 999px;
-        background: var(--accent-soft);
-        color: var(--accent);
-        font-size: 0.9rem;
-      }
-      @media (max-width: 900px) {
-        .layout,
-        .field-grid {
+      @media (max-width: 920px) {
+        .layout {
           grid-template-columns: 1fr;
         }
       }
@@ -183,268 +206,265 @@
   </head>
   <body>
     <main>
-      <div class="masthead">
-        <div>
-          <p class="hint">Workflow Lite Portal</p>
-          <h1>Travel request submission shell</h1>
-        </div>
-        <a href="{{ request.url_for('portal_home') }}">Portal home</a>
+      <div class="topbar">
+        <a class="home-link" href="/portal">Travel Request Portal</a>
+        {% if review %}
+          <span class="badge">Draft {{ review.draft_id }}</span>
+        {% endif %}
       </div>
 
       <div class="layout">
         <section class="panel">
-          <h2>Request draft</h2>
-          <p class="hint">
-            Complete the canonical travel fields that already back the package,
-            then review policy readiness before submit.
-          </p>
+          <div class="intro">
+            <h1>Draft a travel request through the real service runtime.</h1>
+            <p>
+              This shell keeps the interaction small and server-rendered while still routing
+              review through canonical trip construction, prompt-flow gaps, policy snapshot
+              generation, and artifact creation.
+            </p>
+          </div>
 
-          <form method="post" action="{{ request.url_for('portal_request_review') }}">
-            <div class="field-grid">
-              <div class="field">
-                <label for="traveler_name">Traveler name</label>
-                <input id="traveler_name" name="traveler_name" value="{{ answers.get('traveler_name', '') }}" required />
-              </div>
-              <div class="field">
-                <label for="cost_center">Cost center</label>
-                <input id="cost_center" name="cost_center" value="{{ answers.get('cost_center', '') }}" />
-              </div>
-              <div class="field full">
-                <label for="business_purpose">Business purpose</label>
-                <textarea id="business_purpose" name="business_purpose" required>{{ answers.get('business_purpose', '') }}</textarea>
-              </div>
-              <div class="field">
-                <label for="city_state">Destination city/state</label>
-                <input id="city_state" name="city_state" value="{{ answers.get('city_state', '') }}" required />
-              </div>
-              <div class="field">
-                <label for="destination_zip">Destination ZIP</label>
-                <input id="destination_zip" name="destination_zip" value="{{ answers.get('destination_zip', '') }}" required />
-              </div>
-              <div class="field">
-                <label for="depart_date">Departure date</label>
-                <input id="depart_date" type="date" name="depart_date" value="{{ answers.get('depart_date', '') }}" required />
-              </div>
-              <div class="field">
-                <label for="return_date">Return date</label>
-                <input id="return_date" type="date" name="return_date" value="{{ answers.get('return_date', '') }}" required />
-              </div>
-              <div class="field">
-                <label for="event_registration_cost">Registration cost</label>
-                <input id="event_registration_cost" name="event_registration_cost" value="{{ answers.get('event_registration_cost', '') }}" />
-              </div>
-              <div class="field">
-                <label for="parking_estimate">Parking estimate</label>
-                <input id="parking_estimate" name="parking_estimate" value="{{ answers.get('parking_estimate', '') }}" />
-              </div>
-              <div class="field">
-                <label for="ground_transport_pref">Ground transport</label>
-                <select id="ground_transport_pref" name="ground_transport_pref">
-                  <option value="">Select one</option>
-                  {% for option in ground_transport_options %}
-                  <option value="{{ option }}" {% if answers.get('ground_transport_pref') == option %}selected{% endif %}>{{ option }}</option>
-                  {% endfor %}
-                </select>
-              </div>
-              <div class="field">
-                <label for="lowest_cost_roundtrip">Lowest roundtrip fare</label>
-                <input id="lowest_cost_roundtrip" name="lowest_cost_roundtrip" value="{{ answers.get('lowest_cost_roundtrip', '') }}" />
-              </div>
-              <div class="field">
-                <label for="flight_pref_outbound.carrier_flight">Outbound flight</label>
-                <input id="flight_pref_outbound.carrier_flight" name="flight_pref_outbound.carrier_flight" value="{{ answers.get('flight_pref_outbound.carrier_flight', '') }}" />
-              </div>
-              <div class="field">
-                <label for="flight_pref_outbound.roundtrip_cost">Chosen fare</label>
-                <input id="flight_pref_outbound.roundtrip_cost" name="flight_pref_outbound.roundtrip_cost" value="{{ answers.get('flight_pref_outbound.roundtrip_cost', '') }}" />
-              </div>
-              <div class="field">
-                <label for="flight_pref_outbound.depart_time">Outbound depart</label>
-                <input id="flight_pref_outbound.depart_time" name="flight_pref_outbound.depart_time" value="{{ answers.get('flight_pref_outbound.depart_time', '') }}" />
-              </div>
-              <div class="field">
-                <label for="flight_pref_outbound.arrive_time">Outbound arrive</label>
-                <input id="flight_pref_outbound.arrive_time" name="flight_pref_outbound.arrive_time" value="{{ answers.get('flight_pref_outbound.arrive_time', '') }}" />
-              </div>
-              <div class="field">
-                <label for="flight_pref_return.carrier_flight">Return flight</label>
-                <input id="flight_pref_return.carrier_flight" name="flight_pref_return.carrier_flight" value="{{ answers.get('flight_pref_return.carrier_flight', '') }}" />
-              </div>
-              <div class="field">
-                <label for="flight_pref_return.depart_time">Return depart</label>
-                <input id="flight_pref_return.depart_time" name="flight_pref_return.depart_time" value="{{ answers.get('flight_pref_return.depart_time', '') }}" />
-              </div>
-              <div class="field">
-                <label for="flight_pref_return.arrive_time">Return arrive</label>
-                <input id="flight_pref_return.arrive_time" name="flight_pref_return.arrive_time" value="{{ answers.get('flight_pref_return.arrive_time', '') }}" />
-              </div>
-              <div class="field">
-                <label for="hotel.name">Hotel name</label>
-                <input id="hotel.name" name="hotel.name" value="{{ answers.get('hotel.name', '') }}" />
-              </div>
-              <div class="field">
-                <label for="hotel.address">Hotel address</label>
-                <input id="hotel.address" name="hotel.address" value="{{ answers.get('hotel.address', '') }}" />
-              </div>
-              <div class="field">
-                <label for="hotel.city_state">Hotel city/state</label>
-                <input id="hotel.city_state" name="hotel.city_state" value="{{ answers.get('hotel.city_state', '') }}" />
-              </div>
-              <div class="field">
-                <label for="hotel.nightly_rate">Nightly rate</label>
-                <input id="hotel.nightly_rate" name="hotel.nightly_rate" value="{{ answers.get('hotel.nightly_rate', '') }}" />
-              </div>
-              <div class="field">
-                <label for="hotel.nights">Nights</label>
-                <input id="hotel.nights" name="hotel.nights" value="{{ answers.get('hotel.nights', '') }}" />
-              </div>
-              <div class="field">
-                <label for="hotel.conference_hotel">Conference hotel</label>
-                <select id="hotel.conference_hotel" name="hotel.conference_hotel">
-                  <option value="">Select one</option>
-                  <option value="true" {% if answers.get('hotel.conference_hotel') is sameas true %}selected{% endif %}>Yes</option>
-                  <option value="false" {% if answers.get('hotel.conference_hotel') is sameas false %}selected{% endif %}>No</option>
-                </select>
-              </div>
-              <div class="field full">
-                <label for="hotel.price_compare_notes">Hotel comparison notes</label>
-                <textarea id="hotel.price_compare_notes" name="hotel.price_compare_notes">{{ answers.get('hotel.price_compare_notes', '') }}</textarea>
-              </div>
-              <div class="field">
-                <label for="comparable_hotels[0].name">Comparable hotel</label>
-                <input id="comparable_hotels[0].name" name="comparable_hotels[0].name" value="{{ answers.get('comparable_hotels[0].name', '') }}" />
-              </div>
-              <div class="field">
-                <label for="comparable_hotels[0].nightly_rate">Comparable rate</label>
-                <input id="comparable_hotels[0].nightly_rate" name="comparable_hotels[0].nightly_rate" value="{{ answers.get('comparable_hotels[0].nightly_rate', '') }}" />
-              </div>
-              <div class="field full">
-                <label for="notes">Notes</label>
-                <textarea id="notes" name="notes">{{ answers.get('notes', '') }}</textarea>
-              </div>
+          <form method="post" action="/portal/requests/review">
+            <div class="section-grid">
+              <section class="section-card">
+                <h2>Trip brief</h2>
+                <div class="fields">
+                  <label>
+                    <div class="label-row"><span>Traveler name</span></div>
+                    <input name="traveler_name" value="{{ answers.get('traveler_name', '') }}" />
+                  </label>
+                  <label>
+                    <div class="label-row"><span>Business purpose</span></div>
+                    <textarea name="business_purpose">{{ answers.get('business_purpose', '') }}</textarea>
+                  </label>
+                  <label>
+                    <div class="label-row"><span>Cost center</span><span class="optional">Optional</span></div>
+                    <input name="cost_center" value="{{ answers.get('cost_center', '') }}" />
+                  </label>
+                  <label>
+                    <div class="label-row"><span>Destination city and state</span></div>
+                    <input name="city_state" value="{{ answers.get('city_state', '') }}" />
+                  </label>
+                  <label>
+                    <div class="label-row"><span>Destination ZIP</span></div>
+                    <input name="destination_zip" value="{{ answers.get('destination_zip', '') }}" />
+                  </label>
+                  <label>
+                    <div class="label-row"><span>Departure date</span></div>
+                    <input type="date" name="depart_date" value="{{ answers.get('depart_date', '') }}" />
+                  </label>
+                  <label>
+                    <div class="label-row"><span>Return date</span></div>
+                    <input type="date" name="return_date" value="{{ answers.get('return_date', '') }}" />
+                  </label>
+                  <label>
+                    <div class="label-row"><span>Traveler notes</span><span class="optional">Optional</span></div>
+                    <textarea name="notes">{{ answers.get('notes', '') }}</textarea>
+                  </label>
+                </div>
+              </section>
+
+              <section class="section-card">
+                <h2>Air and lodging</h2>
+                <div class="fields">
+                  <label><div class="label-row"><span>Outbound flight</span></div><input name="flight_pref_outbound.carrier_flight" value="{{ answers.get('flight_pref_outbound.carrier_flight', '') }}" /></label>
+                  <label><div class="label-row"><span>Outbound departure</span></div><input name="flight_pref_outbound.depart_time" value="{{ answers.get('flight_pref_outbound.depart_time', '') }}" /></label>
+                  <label><div class="label-row"><span>Outbound arrival</span></div><input name="flight_pref_outbound.arrive_time" value="{{ answers.get('flight_pref_outbound.arrive_time', '') }}" /></label>
+                  <label><div class="label-row"><span>Chosen roundtrip fare</span><span class="optional">Optional</span></div><input type="number" step="0.01" name="flight_pref_outbound.roundtrip_cost" value="{{ answers.get('flight_pref_outbound.roundtrip_cost', '') }}" /></label>
+                  <label><div class="label-row"><span>Return flight</span></div><input name="flight_pref_return.carrier_flight" value="{{ answers.get('flight_pref_return.carrier_flight', '') }}" /></label>
+                  <label><div class="label-row"><span>Return departure</span></div><input name="flight_pref_return.depart_time" value="{{ answers.get('flight_pref_return.depart_time', '') }}" /></label>
+                  <label><div class="label-row"><span>Return arrival</span></div><input name="flight_pref_return.arrive_time" value="{{ answers.get('flight_pref_return.arrive_time', '') }}" /></label>
+                  <label><div class="label-row"><span>Lowest available roundtrip fare</span><span class="optional">Optional</span></div><input type="number" step="0.01" name="lowest_cost_roundtrip" value="{{ answers.get('lowest_cost_roundtrip', '') }}" /></label>
+                  <label><div class="label-row"><span>Hotel name</span><span class="optional">Optional</span></div><input name="hotel.name" value="{{ answers.get('hotel.name', '') }}" /></label>
+                  <label><div class="label-row"><span>Hotel address</span><span class="optional">Optional</span></div><input name="hotel.address" value="{{ answers.get('hotel.address', '') }}" /></label>
+                  <label><div class="label-row"><span>Hotel city and state</span><span class="optional">Optional</span></div><input name="hotel.city_state" value="{{ answers.get('hotel.city_state', '') }}" /></label>
+                  <label><div class="label-row"><span>Nightly rate</span><span class="optional">Optional</span></div><input type="number" step="0.01" name="hotel.nightly_rate" value="{{ answers.get('hotel.nightly_rate', '') }}" /></label>
+                  <label><div class="label-row"><span>Nights</span><span class="optional">Optional</span></div><input type="number" step="1" name="hotel.nights" value="{{ answers.get('hotel.nights', '') }}" /></label>
+                  <label>
+                    <div class="label-row"><span>Conference hotel</span><span class="optional">Optional</span></div>
+                    <select name="hotel.conference_hotel">
+                      <option value="">Select</option>
+                      <option value="true" {% if answers.get('hotel.conference_hotel') in [True, 'true'] %}selected{% endif %}>Yes</option>
+                      <option value="false" {% if answers.get('hotel.conference_hotel') in [False, 'false'] %}selected{% endif %}>No</option>
+                    </select>
+                  </label>
+                  <label><div class="label-row"><span>Hotel comparison notes</span><span class="optional">Optional</span></div><textarea name="hotel.price_compare_notes">{{ answers.get('hotel.price_compare_notes', '') }}</textarea></label>
+                  <label><div class="label-row"><span>Comparable hotel</span><span class="optional">Optional</span></div><input name="comparable_hotels[0].name" value="{{ answers.get('comparable_hotels[0].name', '') }}" /></label>
+                  <label><div class="label-row"><span>Comparable nightly rate</span><span class="optional">Optional</span></div><input type="number" step="0.01" name="comparable_hotels[0].nightly_rate" value="{{ answers.get('comparable_hotels[0].nightly_rate', '') }}" /></label>
+                  <label>
+                    <div class="label-row"><span>Ground transport</span><span class="optional">Optional</span></div>
+                    <select name="ground_transport_pref">
+                      <option value="">Select</option>
+                      {% for option in ground_transport_options %}
+                        <option value="{{ option }}" {% if answers.get('ground_transport_pref') == option %}selected{% endif %}>{{ option }}</option>
+                      {% endfor %}
+                    </select>
+                  </label>
+                  <label><div class="label-row"><span>Parking estimate</span><span class="optional">Optional</span></div><input type="number" step="0.01" name="parking_estimate" value="{{ answers.get('parking_estimate', '') }}" /></label>
+                  <label><div class="label-row"><span>Registration cost</span><span class="optional">Optional</span></div><input type="number" step="0.01" name="event_registration_cost" value="{{ answers.get('event_registration_cost', '') }}" /></label>
+                </div>
+              </section>
+
+              <section class="section-card">
+                <h2>Policy readiness</h2>
+                <div class="fields">
+                  <label><div class="label-row"><span>Booking date</span><span class="optional">Optional</span></div><input type="date" name="booking_date" value="{{ answers.get('booking_date', '') }}" /></label>
+                  <label><div class="label-row"><span>Selected fare</span><span class="optional">Optional</span></div><input type="number" step="0.01" name="selected_fare" value="{{ answers.get('selected_fare', '') }}" /></label>
+                  <label><div class="label-row"><span>Lowest comparable fare</span><span class="optional">Optional</span></div><input type="number" step="0.01" name="lowest_fare" value="{{ answers.get('lowest_fare', '') }}" /></label>
+                  <label><div class="label-row"><span>Cabin class</span><span class="optional">Optional</span></div><input name="cabin_class" value="{{ answers.get('cabin_class', '') }}" /></label>
+                  <label><div class="label-row"><span>Flight duration hours</span><span class="optional">Optional</span></div><input type="number" step="0.1" name="flight_duration_hours" value="{{ answers.get('flight_duration_hours', '') }}" /></label>
+                  <label>
+                    <div class="label-row"><span>Fare evidence attached</span><span class="optional">Optional</span></div>
+                    <select name="fare_evidence_attached">
+                      <option value="">Select</option>
+                      <option value="true" {% if answers.get('fare_evidence_attached') in [True, 'true'] %}selected{% endif %}>Yes</option>
+                      <option value="false" {% if answers.get('fare_evidence_attached') in [False, 'false'] %}selected{% endif %}>No</option>
+                    </select>
+                  </label>
+                  <label><div class="label-row"><span>Driving cost</span><span class="optional">Optional</span></div><input type="number" step="0.01" name="driving_cost" value="{{ answers.get('driving_cost', '') }}" /></label>
+                  <label><div class="label-row"><span>Flight cost</span><span class="optional">Optional</span></div><input type="number" step="0.01" name="flight_cost" value="{{ answers.get('flight_cost', '') }}" /></label>
+                  <label><div class="label-row"><span>Distance from office miles</span><span class="optional">Optional</span></div><input type="number" step="0.1" name="distance_from_office_miles" value="{{ answers.get('distance_from_office_miles', '') }}" /></label>
+                  <label>
+                    <div class="label-row"><span>Overnight stay requested</span><span class="optional">Optional</span></div>
+                    <select name="overnight_stay">
+                      <option value="">Select</option>
+                      <option value="true" {% if answers.get('overnight_stay') in [True, 'true'] %}selected{% endif %}>Yes</option>
+                      <option value="false" {% if answers.get('overnight_stay') in [False, 'false'] %}selected{% endif %}>No</option>
+                    </select>
+                  </label>
+                  <label>
+                    <div class="label-row"><span>Meals provided</span><span class="optional">Optional</span></div>
+                    <select name="meals_provided">
+                      <option value="">Select</option>
+                      <option value="true" {% if answers.get('meals_provided') in [True, 'true'] %}selected{% endif %}>Yes</option>
+                      <option value="false" {% if answers.get('meals_provided') in [False, 'false'] %}selected{% endif %}>No</option>
+                    </select>
+                  </label>
+                  <label>
+                    <div class="label-row"><span>Meal per diem requested</span><span class="optional">Optional</span></div>
+                    <select name="meal_per_diem_requested">
+                      <option value="">Select</option>
+                      <option value="true" {% if answers.get('meal_per_diem_requested') in [True, 'true'] %}selected{% endif %}>Yes</option>
+                      <option value="false" {% if answers.get('meal_per_diem_requested') in [False, 'false'] %}selected{% endif %}>No</option>
+                    </select>
+                  </label>
+                </div>
+              </section>
             </div>
+
             <div class="actions">
-              <button class="primary" type="submit">Review request</button>
-              {% if review %}
-              <a class="button-link secondary" href="{{ request.url_for('portal_request_detail', draft_id=review.draft_id) }}">Permalink to this draft</a>
-              {% endif %}
+              <button class="primary" type="submit">Save draft and review</button>
+              <a class="button secondary" href="/portal">Back to portal home</a>
             </div>
           </form>
         </section>
 
         <aside class="stack">
-          <section class="panel alt">
-            <h2>Review</h2>
-            {% if review is none %}
-            <p class="hint">Draft a request to see readiness, artifacts, and submit controls.</p>
-            {% else %}
-            <dl>
-              <dt>Draft</dt>
-              <dd>{{ review.draft_id }}</dd>
-              <dt>Status</dt>
-              <dd>
-                {% if review.missing_fields %}
-                <span class="status-pill">Needs input</span>
-                {% elif review.validation_errors %}
-                <span class="status-pill">Fix field formats</span>
-                {% elif review.trip_plan %}
-                <span class="status-pill">Ready for submit</span>
-                {% endif %}
-              </dd>
-              {% if review.trip_plan %}
-              <dt>Trip ID</dt>
-              <dd>{{ review.trip_plan.trip_id }}</dd>
+          <section class="panel">
+            <h2>Review status</h2>
+            {% if review %}
+              {% if review.missing_fields %}
+                <p style="margin-top: 10px;"><span class="badge warn">Missing required inputs</span></p>
+                <ul>
+                  {% for field in review.missing_fields %}
+                    <li><code>{{ field }}</code></li>
+                  {% endfor %}
+                </ul>
+              {% else %}
+                <p style="margin-top: 10px;"><span class="badge">Canonical payload complete</span></p>
               {% endif %}
-            </dl>
+
+              {% if review.validation_errors %}
+                <div class="callout" style="margin-top: 16px;">
+                  <h3>Validation notes</h3>
+                  <ul>
+                    {% for error in review.validation_errors %}
+                      <li>{{ error }}</li>
+                    {% endfor %}
+                  </ul>
+                </div>
+              {% endif %}
+
+              {% if review.next_questions %}
+                <div class="callout" style="margin-top: 16px;">
+                  <h3>Next intake questions</h3>
+                  <ul>
+                    {% for question in review.next_questions %}
+                      <li>{{ question.prompt }}{% if question.fields %} <code>{{ question.fields }}</code>{% endif %}</li>
+                    {% endfor %}
+                  </ul>
+                </div>
+              {% endif %}
+            {% else %}
+              <p style="margin-top: 10px;">Save a draft to see canonical gaps, review posture, and generated artifacts.</p>
             {% endif %}
           </section>
-
-          {% if review and review.missing_fields %}
-          <section class="panel callout warning">
-            <strong>Missing required inputs</strong>
-            <ul>
-              {% for field_name in review.missing_fields %}
-              <li>{{ field_name }}</li>
-              {% endfor %}
-            </ul>
-          </section>
-          {% endif %}
-
-          {% if review and review.validation_errors %}
-          <section class="panel callout danger">
-            <strong>Canonical validation errors</strong>
-            <ul>
-              {% for error in review.validation_errors %}
-              <li>{{ error }}</li>
-              {% endfor %}
-            </ul>
-          </section>
-          {% endif %}
-
-          {% if review and review.next_questions %}
-          <section class="panel">
-            <h2>Next intake questions</h2>
-            <div class="question-list">
-              {% for question in review.next_questions %}
-              <div class="question">
-                <strong>{{ question.prompt }}</strong>
-                <div class="hint">Fields: {{ question.fields }}</div>
-              </div>
-              {% endfor %}
-            </div>
-          </section>
-          {% endif %}
 
           {% if review and review.policy_snapshot %}
-          <section class="panel">
-            <h2>Policy readiness</h2>
-            <p>
-              <strong>Status:</strong> {{ review.policy_snapshot.policy_status }}
-            </p>
-            <p>
-              <strong>Policy version:</strong>
-              {{ review.policy_snapshot.versioning.policy_version[:12] }}
-            </p>
-            {% if review.policy_result and review.policy_result.issues %}
-            <div class="issue-list">
-              {% for issue in review.policy_result.issues %}
-              <div class="issue">
-                <strong>{{ issue.code }}</strong>
-                <div>{{ issue.message }}</div>
+            <section class="panel">
+              <h2>Policy-lite posture</h2>
+              <p style="margin-top: 10px;">
+                <span class="badge {% if review.policy_snapshot.policy_status == 'fail' %}warn{% endif %}">
+                  {{ review.policy_snapshot.policy_status }}
+                </span>
+              </p>
+              <div class="callout" style="margin-top: 16px;">
+                <h3>Approval triggers</h3>
+                <ul>
+                  {% for trigger in review.policy_snapshot.approval_triggers %}
+                    <li>{{ trigger.summary }}</li>
+                  {% else %}
+                    <li>No approval triggers surfaced.</li>
+                  {% endfor %}
+                </ul>
               </div>
-              {% endfor %}
-            </div>
-            {% else %}
-            <p class="hint">No blocking or advisory issues from the current policy snapshot.</p>
-            {% endif %}
-          </section>
-
-          <section class="panel">
-            <h2>Generated artifacts</h2>
-            <div class="artifact-list">
-              {% for artifact_name, artifact in review.artifacts.items() %}
-              <div class="artifact">
-                <strong>{{ artifact.filename }}</strong>
-                <div class="hint">{{ artifact.media_type }} · {{ artifact.content|length }} bytes</div>
-                <a href="{{ request.url_for('portal_artifact', draft_id=review.draft_id, artifact_name=artifact_name) }}">Download</a>
+              <div class="callout" style="margin-top: 16px;">
+                <h3>Policy issues</h3>
+                <ul>
+                  {% for issue in review.policy_result.issues %}
+                    <li>{{ issue.code }}: {{ issue.message }}</li>
+                  {% else %}
+                    <li>No current policy issues.</li>
+                  {% endfor %}
+                </ul>
               </div>
-              {% endfor %}
-            </div>
-          </section>
+            </section>
+          {% endif %}
 
-          <section class="panel">
-            <h2>Submit request</h2>
-            <form method="post" action="{{ request.url_for('portal_submit_request', draft_id=review.draft_id) }}">
-              <button class="primary" type="submit">Submit through proposal seam</button>
-            </form>
-            {% if review.submission_response %}
-            <div class="callout success" style="margin-top: 1rem;">
-              <strong>Submitted.</strong>
-              Request {{ review.submission_response.request_id }} is now
-              {{ review.submission_response.submission_status }}.
-            </div>
-            {% endif %}
-          </section>
+          {% if review and review.artifacts %}
+            <section class="panel">
+              <h2>Generated artifacts</h2>
+              <p style="margin-top: 10px;">Download the current spreadsheet and summary generated from the saved draft.</p>
+              <div class="actions">
+                <a class="button primary" href="/portal/requests/{{ review.draft_id }}/artifacts/itinerary">Download itinerary</a>
+                <a class="button secondary" href="/portal/requests/{{ review.draft_id }}/artifacts/summary">Download summary</a>
+              </div>
+              <div class="callout" style="margin-top: 16px;">
+                <h3>Ready for submit</h3>
+                <p>
+                  Submission reuses the existing proposal submission seam and records the resulting
+                  execution contract alongside the draft.
+                </p>
+                <form method="post" action="/portal/requests/{{ review.draft_id }}/submit" style="margin-top: 14px;">
+                  <button class="primary" type="submit">Submit request</button>
+                </form>
+              </div>
+            </section>
+          {% endif %}
+
+          {% if review and review.submission_response %}
+            <section class="panel">
+              <h2>Submission result</h2>
+              <p style="margin-top: 10px;">The proposal submission seam accepted the browser draft.</p>
+              <pre>{{ review.submission_response.model_dump_json(indent=2) }}</pre>
+            </section>
+          {% endif %}
+
+          {% if review and review.canonical_payload %}
+            <section class="panel">
+              <h2>Canonical payload preview</h2>
+              <pre>{{ review.canonical_payload | tojson(indent=2) }}</pre>
+            </section>
           {% endif %}
         </aside>
       </div>

--- a/src/travel_plan_permission/templates/portal_request.html
+++ b/src/travel_plan_permission/templates/portal_request.html
@@ -1,0 +1,453 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Travel Request Portal</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #f3efe8;
+        --panel: #fffdf9;
+        --panel-alt: #f8f4ee;
+        --ink: #22211f;
+        --muted: #6b6258;
+        --accent: #0c5c57;
+        --accent-soft: #dff1ef;
+        --warning: #7d4e00;
+        --warning-soft: #ffefcf;
+        --danger: #a2271b;
+        --danger-soft: #f8dad6;
+        --border: #d8cbbd;
+      }
+      body {
+        margin: 0;
+        background: radial-gradient(circle at top, #ffffff 0%, var(--bg) 55%);
+        color: var(--ink);
+        font-family: Georgia, "Times New Roman", serif;
+      }
+      main {
+        max-width: 1180px;
+        margin: 0 auto;
+        padding: 2rem 1rem 3rem;
+      }
+      .masthead {
+        display: flex;
+        justify-content: space-between;
+        gap: 1rem;
+        align-items: end;
+        margin-bottom: 1rem;
+      }
+      .masthead a {
+        color: var(--accent);
+      }
+      .layout {
+        display: grid;
+        grid-template-columns: minmax(0, 1.4fr) minmax(320px, 0.9fr);
+        gap: 1rem;
+      }
+      .panel {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 20px;
+        box-shadow: 0 12px 32px rgba(35, 29, 18, 0.08);
+        padding: 1.25rem;
+      }
+      .panel.alt {
+        background: var(--panel-alt);
+      }
+      .stack {
+        display: grid;
+        gap: 1rem;
+      }
+      .field-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 0.9rem;
+      }
+      .field {
+        display: grid;
+        gap: 0.35rem;
+      }
+      .field.full {
+        grid-column: 1 / -1;
+      }
+      label {
+        font-size: 0.95rem;
+        font-weight: 700;
+      }
+      input,
+      textarea,
+      select {
+        width: 100%;
+        box-sizing: border-box;
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 0.7rem 0.8rem;
+        font: inherit;
+        background: white;
+      }
+      textarea {
+        min-height: 5rem;
+        resize: vertical;
+      }
+      .hint {
+        color: var(--muted);
+        font-size: 0.9rem;
+      }
+      .actions {
+        display: flex;
+        gap: 0.75rem;
+        align-items: center;
+        flex-wrap: wrap;
+        margin-top: 1rem;
+      }
+      button,
+      .button-link {
+        appearance: none;
+        border: 0;
+        border-radius: 999px;
+        padding: 0.8rem 1.15rem;
+        font: inherit;
+        font-weight: 700;
+        cursor: pointer;
+        text-decoration: none;
+      }
+      button.primary,
+      .button-link.primary {
+        background: var(--accent);
+        color: white;
+      }
+      .button-link.secondary {
+        background: var(--accent-soft);
+        color: var(--accent);
+      }
+      .callout {
+        border-radius: 16px;
+        padding: 0.95rem 1rem;
+      }
+      .callout.warning {
+        background: var(--warning-soft);
+        color: var(--warning);
+      }
+      .callout.danger {
+        background: var(--danger-soft);
+        color: var(--danger);
+      }
+      .callout.success {
+        background: var(--accent-soft);
+        color: var(--accent);
+      }
+      ul {
+        margin: 0.6rem 0 0;
+        padding-left: 1.2rem;
+      }
+      dl {
+        margin: 0;
+        display: grid;
+        grid-template-columns: max-content 1fr;
+        gap: 0.4rem 0.75rem;
+      }
+      dt {
+        font-weight: 700;
+      }
+      .artifact-list,
+      .question-list,
+      .issue-list {
+        display: grid;
+        gap: 0.8rem;
+      }
+      .artifact,
+      .question,
+      .issue {
+        border: 1px solid var(--border);
+        border-radius: 14px;
+        padding: 0.8rem;
+        background: white;
+      }
+      .status-pill {
+        display: inline-block;
+        padding: 0.2rem 0.55rem;
+        border-radius: 999px;
+        background: var(--accent-soft);
+        color: var(--accent);
+        font-size: 0.9rem;
+      }
+      @media (max-width: 900px) {
+        .layout,
+        .field-grid {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <div class="masthead">
+        <div>
+          <p class="hint">Workflow Lite Portal</p>
+          <h1>Travel request submission shell</h1>
+        </div>
+        <a href="{{ request.url_for('portal_home') }}">Portal home</a>
+      </div>
+
+      <div class="layout">
+        <section class="panel">
+          <h2>Request draft</h2>
+          <p class="hint">
+            Complete the canonical travel fields that already back the package,
+            then review policy readiness before submit.
+          </p>
+
+          <form method="post" action="{{ request.url_for('portal_request_review') }}">
+            <div class="field-grid">
+              <div class="field">
+                <label for="traveler_name">Traveler name</label>
+                <input id="traveler_name" name="traveler_name" value="{{ answers.get('traveler_name', '') }}" required />
+              </div>
+              <div class="field">
+                <label for="cost_center">Cost center</label>
+                <input id="cost_center" name="cost_center" value="{{ answers.get('cost_center', '') }}" />
+              </div>
+              <div class="field full">
+                <label for="business_purpose">Business purpose</label>
+                <textarea id="business_purpose" name="business_purpose" required>{{ answers.get('business_purpose', '') }}</textarea>
+              </div>
+              <div class="field">
+                <label for="city_state">Destination city/state</label>
+                <input id="city_state" name="city_state" value="{{ answers.get('city_state', '') }}" required />
+              </div>
+              <div class="field">
+                <label for="destination_zip">Destination ZIP</label>
+                <input id="destination_zip" name="destination_zip" value="{{ answers.get('destination_zip', '') }}" required />
+              </div>
+              <div class="field">
+                <label for="depart_date">Departure date</label>
+                <input id="depart_date" type="date" name="depart_date" value="{{ answers.get('depart_date', '') }}" required />
+              </div>
+              <div class="field">
+                <label for="return_date">Return date</label>
+                <input id="return_date" type="date" name="return_date" value="{{ answers.get('return_date', '') }}" required />
+              </div>
+              <div class="field">
+                <label for="event_registration_cost">Registration cost</label>
+                <input id="event_registration_cost" name="event_registration_cost" value="{{ answers.get('event_registration_cost', '') }}" />
+              </div>
+              <div class="field">
+                <label for="parking_estimate">Parking estimate</label>
+                <input id="parking_estimate" name="parking_estimate" value="{{ answers.get('parking_estimate', '') }}" />
+              </div>
+              <div class="field">
+                <label for="ground_transport_pref">Ground transport</label>
+                <select id="ground_transport_pref" name="ground_transport_pref">
+                  <option value="">Select one</option>
+                  {% for option in ground_transport_options %}
+                  <option value="{{ option }}" {% if answers.get('ground_transport_pref') == option %}selected{% endif %}>{{ option }}</option>
+                  {% endfor %}
+                </select>
+              </div>
+              <div class="field">
+                <label for="lowest_cost_roundtrip">Lowest roundtrip fare</label>
+                <input id="lowest_cost_roundtrip" name="lowest_cost_roundtrip" value="{{ answers.get('lowest_cost_roundtrip', '') }}" />
+              </div>
+              <div class="field">
+                <label for="flight_pref_outbound.carrier_flight">Outbound flight</label>
+                <input id="flight_pref_outbound.carrier_flight" name="flight_pref_outbound.carrier_flight" value="{{ answers.get('flight_pref_outbound.carrier_flight', '') }}" />
+              </div>
+              <div class="field">
+                <label for="flight_pref_outbound.roundtrip_cost">Chosen fare</label>
+                <input id="flight_pref_outbound.roundtrip_cost" name="flight_pref_outbound.roundtrip_cost" value="{{ answers.get('flight_pref_outbound.roundtrip_cost', '') }}" />
+              </div>
+              <div class="field">
+                <label for="flight_pref_outbound.depart_time">Outbound depart</label>
+                <input id="flight_pref_outbound.depart_time" name="flight_pref_outbound.depart_time" value="{{ answers.get('flight_pref_outbound.depart_time', '') }}" />
+              </div>
+              <div class="field">
+                <label for="flight_pref_outbound.arrive_time">Outbound arrive</label>
+                <input id="flight_pref_outbound.arrive_time" name="flight_pref_outbound.arrive_time" value="{{ answers.get('flight_pref_outbound.arrive_time', '') }}" />
+              </div>
+              <div class="field">
+                <label for="flight_pref_return.carrier_flight">Return flight</label>
+                <input id="flight_pref_return.carrier_flight" name="flight_pref_return.carrier_flight" value="{{ answers.get('flight_pref_return.carrier_flight', '') }}" />
+              </div>
+              <div class="field">
+                <label for="flight_pref_return.depart_time">Return depart</label>
+                <input id="flight_pref_return.depart_time" name="flight_pref_return.depart_time" value="{{ answers.get('flight_pref_return.depart_time', '') }}" />
+              </div>
+              <div class="field">
+                <label for="flight_pref_return.arrive_time">Return arrive</label>
+                <input id="flight_pref_return.arrive_time" name="flight_pref_return.arrive_time" value="{{ answers.get('flight_pref_return.arrive_time', '') }}" />
+              </div>
+              <div class="field">
+                <label for="hotel.name">Hotel name</label>
+                <input id="hotel.name" name="hotel.name" value="{{ answers.get('hotel.name', '') }}" />
+              </div>
+              <div class="field">
+                <label for="hotel.address">Hotel address</label>
+                <input id="hotel.address" name="hotel.address" value="{{ answers.get('hotel.address', '') }}" />
+              </div>
+              <div class="field">
+                <label for="hotel.city_state">Hotel city/state</label>
+                <input id="hotel.city_state" name="hotel.city_state" value="{{ answers.get('hotel.city_state', '') }}" />
+              </div>
+              <div class="field">
+                <label for="hotel.nightly_rate">Nightly rate</label>
+                <input id="hotel.nightly_rate" name="hotel.nightly_rate" value="{{ answers.get('hotel.nightly_rate', '') }}" />
+              </div>
+              <div class="field">
+                <label for="hotel.nights">Nights</label>
+                <input id="hotel.nights" name="hotel.nights" value="{{ answers.get('hotel.nights', '') }}" />
+              </div>
+              <div class="field">
+                <label for="hotel.conference_hotel">Conference hotel</label>
+                <select id="hotel.conference_hotel" name="hotel.conference_hotel">
+                  <option value="">Select one</option>
+                  <option value="true" {% if answers.get('hotel.conference_hotel') is sameas true %}selected{% endif %}>Yes</option>
+                  <option value="false" {% if answers.get('hotel.conference_hotel') is sameas false %}selected{% endif %}>No</option>
+                </select>
+              </div>
+              <div class="field full">
+                <label for="hotel.price_compare_notes">Hotel comparison notes</label>
+                <textarea id="hotel.price_compare_notes" name="hotel.price_compare_notes">{{ answers.get('hotel.price_compare_notes', '') }}</textarea>
+              </div>
+              <div class="field">
+                <label for="comparable_hotels[0].name">Comparable hotel</label>
+                <input id="comparable_hotels[0].name" name="comparable_hotels[0].name" value="{{ answers.get('comparable_hotels[0].name', '') }}" />
+              </div>
+              <div class="field">
+                <label for="comparable_hotels[0].nightly_rate">Comparable rate</label>
+                <input id="comparable_hotels[0].nightly_rate" name="comparable_hotels[0].nightly_rate" value="{{ answers.get('comparable_hotels[0].nightly_rate', '') }}" />
+              </div>
+              <div class="field full">
+                <label for="notes">Notes</label>
+                <textarea id="notes" name="notes">{{ answers.get('notes', '') }}</textarea>
+              </div>
+            </div>
+            <div class="actions">
+              <button class="primary" type="submit">Review request</button>
+              {% if review %}
+              <a class="button-link secondary" href="{{ request.url_for('portal_request_detail', draft_id=review.draft_id) }}">Permalink to this draft</a>
+              {% endif %}
+            </div>
+          </form>
+        </section>
+
+        <aside class="stack">
+          <section class="panel alt">
+            <h2>Review</h2>
+            {% if review is none %}
+            <p class="hint">Draft a request to see readiness, artifacts, and submit controls.</p>
+            {% else %}
+            <dl>
+              <dt>Draft</dt>
+              <dd>{{ review.draft_id }}</dd>
+              <dt>Status</dt>
+              <dd>
+                {% if review.missing_fields %}
+                <span class="status-pill">Needs input</span>
+                {% elif review.validation_errors %}
+                <span class="status-pill">Fix field formats</span>
+                {% elif review.trip_plan %}
+                <span class="status-pill">Ready for submit</span>
+                {% endif %}
+              </dd>
+              {% if review.trip_plan %}
+              <dt>Trip ID</dt>
+              <dd>{{ review.trip_plan.trip_id }}</dd>
+              {% endif %}
+            </dl>
+            {% endif %}
+          </section>
+
+          {% if review and review.missing_fields %}
+          <section class="panel callout warning">
+            <strong>Missing required inputs</strong>
+            <ul>
+              {% for field_name in review.missing_fields %}
+              <li>{{ field_name }}</li>
+              {% endfor %}
+            </ul>
+          </section>
+          {% endif %}
+
+          {% if review and review.validation_errors %}
+          <section class="panel callout danger">
+            <strong>Canonical validation errors</strong>
+            <ul>
+              {% for error in review.validation_errors %}
+              <li>{{ error }}</li>
+              {% endfor %}
+            </ul>
+          </section>
+          {% endif %}
+
+          {% if review and review.next_questions %}
+          <section class="panel">
+            <h2>Next intake questions</h2>
+            <div class="question-list">
+              {% for question in review.next_questions %}
+              <div class="question">
+                <strong>{{ question.prompt }}</strong>
+                <div class="hint">Fields: {{ question.fields }}</div>
+              </div>
+              {% endfor %}
+            </div>
+          </section>
+          {% endif %}
+
+          {% if review and review.policy_snapshot %}
+          <section class="panel">
+            <h2>Policy readiness</h2>
+            <p>
+              <strong>Status:</strong> {{ review.policy_snapshot.policy_status }}
+            </p>
+            <p>
+              <strong>Policy version:</strong>
+              {{ review.policy_snapshot.versioning.policy_version[:12] }}
+            </p>
+            {% if review.policy_result and review.policy_result.issues %}
+            <div class="issue-list">
+              {% for issue in review.policy_result.issues %}
+              <div class="issue">
+                <strong>{{ issue.code }}</strong>
+                <div>{{ issue.message }}</div>
+              </div>
+              {% endfor %}
+            </div>
+            {% else %}
+            <p class="hint">No blocking or advisory issues from the current policy snapshot.</p>
+            {% endif %}
+          </section>
+
+          <section class="panel">
+            <h2>Generated artifacts</h2>
+            <div class="artifact-list">
+              {% for artifact_name, artifact in review.artifacts.items() %}
+              <div class="artifact">
+                <strong>{{ artifact.filename }}</strong>
+                <div class="hint">{{ artifact.media_type }} · {{ artifact.content|length }} bytes</div>
+                <a href="{{ request.url_for('portal_artifact', draft_id=review.draft_id, artifact_name=artifact_name) }}">Download</a>
+              </div>
+              {% endfor %}
+            </div>
+          </section>
+
+          <section class="panel">
+            <h2>Submit request</h2>
+            <form method="post" action="{{ request.url_for('portal_submit_request', draft_id=review.draft_id) }}">
+              <button class="primary" type="submit">Submit through proposal seam</button>
+            </form>
+            {% if review.submission_response %}
+            <div class="callout success" style="margin-top: 1rem;">
+              <strong>Submitted.</strong>
+              Request {{ review.submission_response.request_id }} is now
+              {{ review.submission_response.submission_status }}.
+            </div>
+            {% endif %}
+          </section>
+          {% endif %}
+        </aside>
+      </div>
+    </main>
+  </body>
+</html>

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -6,12 +6,8 @@ from pathlib import Path
 
 from fastapi.testclient import TestClient
 
-from travel_plan_permission.http_service import (
-    PlannerProposalStore,
-    create_app,
-    main,
-)
 from travel_plan_permission import http_service
+from travel_plan_permission.http_service import PlannerProposalStore, create_app, main
 from travel_plan_permission.planner_auth import mint_bootstrap_token
 from travel_plan_permission.policy_api import PlannerProposalOperationResponse
 from travel_plan_permission.security import Permission
@@ -429,7 +425,7 @@ def test_portal_artifact_downloads_use_cached_review_artifacts(monkeypatch) -> N
     assert match is not None
     draft_id = match.group(1)
 
-    def fail_render(*args, **kwargs):
+    def fail_render(*_args, **_kwargs):
         raise AssertionError("artifact download should use cached payloads")
 
     monkeypatch.setattr(http_service, "render_travel_spreadsheet_bytes", fail_render)

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 from fastapi.testclient import TestClient
@@ -15,52 +16,11 @@ from travel_plan_permission.policy_api import PlannerProposalOperationResponse
 from travel_plan_permission.security import Permission
 
 FIXTURE_ROOT = Path(__file__).resolve().parents[1] / "fixtures" / "planner_integration"
-CANONICAL_FIXTURE = (
-    Path(__file__).resolve().parents[1] / "fixtures" / "canonical_trip_plan_realistic.json"
-)
 AUTH_HEADER = {"Authorization": "Bearer dev-token"}
 
 
 def _load_fixture(name: str) -> dict[str, object]:
     return json.loads((FIXTURE_ROOT / name).read_text(encoding="utf-8"))
-
-
-def _portal_form_data() -> dict[str, str]:
-    payload = json.loads(CANONICAL_FIXTURE.read_text(encoding="utf-8"))
-    hotel = payload["hotel"]
-    outbound = payload["flight_pref_outbound"]
-    inbound = payload["flight_pref_return"]
-    comparable = payload["comparable_hotels"][0]
-    return {
-        "traveler_name": payload["traveler_name"],
-        "business_purpose": payload["business_purpose"],
-        "cost_center": payload["cost_center"],
-        "destination_zip": payload["destination_zip"],
-        "city_state": payload["city_state"],
-        "depart_date": payload["depart_date"],
-        "return_date": payload["return_date"],
-        "event_registration_cost": str(payload["event_registration_cost"]),
-        "flight_pref_outbound.carrier_flight": outbound["carrier_flight"],
-        "flight_pref_outbound.depart_time": outbound["depart_time"],
-        "flight_pref_outbound.arrive_time": outbound["arrive_time"],
-        "flight_pref_outbound.roundtrip_cost": str(outbound["roundtrip_cost"]),
-        "flight_pref_return.carrier_flight": inbound["carrier_flight"],
-        "flight_pref_return.depart_time": inbound["depart_time"],
-        "flight_pref_return.arrive_time": inbound["arrive_time"],
-        "lowest_cost_roundtrip": str(payload["lowest_cost_roundtrip"]),
-        "parking_estimate": str(payload["parking_estimate"]),
-        "hotel.name": hotel["name"],
-        "hotel.address": hotel["address"],
-        "hotel.city_state": hotel["city_state"],
-        "hotel.nightly_rate": str(hotel["nightly_rate"]),
-        "hotel.nights": str(hotel["nights"]),
-        "hotel.conference_hotel": "true",
-        "hotel.price_compare_notes": hotel["price_compare_notes"],
-        "comparable_hotels[0].name": comparable["name"],
-        "comparable_hotels[0].nightly_rate": str(comparable["nightly_rate"]),
-        "ground_transport_pref": payload["ground_transport_pref"],
-        "notes": payload["notes"],
-    }
 
 
 def _set_runtime_env(monkeypatch, *, provider: str = "google") -> None:
@@ -75,6 +35,51 @@ def _set_bootstrap_runtime_env(monkeypatch, *, provider: str = "google") -> None
     monkeypatch.setenv("TPP_OIDC_PROVIDER", provider)
     monkeypatch.setenv("TPP_AUTH_MODE", "bootstrap-token")
     monkeypatch.setenv("TPP_BOOTSTRAP_SIGNING_SECRET", "bootstrap-secret-123")
+
+
+def _portal_form_payload() -> dict[str, str]:
+    return {
+        "traveler_name": "Alex Rivera",
+        "business_purpose": "Regional partner summit",
+        "cost_center": "OPS-410",
+        "city_state": "Seattle, WA",
+        "destination_zip": "98101",
+        "depart_date": "2025-10-05",
+        "return_date": "2025-10-09",
+        "notes": "Request airport pickup and late checkout.",
+        "flight_pref_outbound.carrier_flight": "AS120",
+        "flight_pref_outbound.depart_time": "2025-10-05T07:15",
+        "flight_pref_outbound.arrive_time": "2025-10-05T09:40",
+        "flight_pref_outbound.roundtrip_cost": "455.25",
+        "flight_pref_return.carrier_flight": "AS221",
+        "flight_pref_return.depart_time": "2025-10-09T18:10",
+        "flight_pref_return.arrive_time": "2025-10-09T20:30",
+        "lowest_cost_roundtrip": "430.00",
+        "hotel.name": "Pine Street Suites",
+        "hotel.address": "120 Pine St",
+        "hotel.city_state": "Seattle, WA",
+        "hotel.nightly_rate": "210.00",
+        "hotel.nights": "4",
+        "hotel.conference_hotel": "true",
+        "hotel.price_compare_notes": "Conference hotel is $20 more per night.",
+        "comparable_hotels[0].name": "Marketview Hotel",
+        "comparable_hotels[0].nightly_rate": "190.00",
+        "ground_transport_pref": "rideshare/taxi",
+        "parking_estimate": "35.00",
+        "event_registration_cost": "320.00",
+        "booking_date": "2025-09-20",
+        "selected_fare": "455.25",
+        "lowest_fare": "430.00",
+        "cabin_class": "economy",
+        "flight_duration_hours": "2.5",
+        "fare_evidence_attached": "true",
+        "driving_cost": "120.00",
+        "flight_cost": "200.00",
+        "distance_from_office_miles": "12.5",
+        "overnight_stay": "true",
+        "meals_provided": "false",
+        "meal_per_diem_requested": "true",
+    }
 
 
 def test_readyz_reports_missing_runtime_config(monkeypatch) -> None:
@@ -283,64 +288,62 @@ def test_snapshot_route_returns_bad_request_for_contract_mismatch(monkeypatch) -
     assert "trip_id" in response.json()["detail"]
 
 
-def test_portal_home_and_form_routes_render() -> None:
+def test_portal_home_and_request_form_render() -> None:
     client = TestClient(create_app())
 
     home = client.get("/portal")
     form = client.get("/portal/requests/new")
 
     assert home.status_code == 200
-    assert "Workflow Lite Portal" in home.text
+    assert "Travel Request Portal" in home.text
     assert form.status_code == 200
-    assert "Travel request submission shell" in form.text
-    assert "Review request" in form.text
+    assert "Draft a travel request through the real service runtime." in form.text
 
 
-def test_portal_review_surfaces_missing_required_inputs() -> None:
+def test_portal_review_shows_missing_inputs() -> None:
     client = TestClient(create_app())
 
     response = client.post(
         "/portal/requests/review",
-        data={
-            "traveler_name": "Ada Lovelace",
-            "city_state": "Boston, MA",
-        },
+        data={"traveler_name": "Alex Rivera", "business_purpose": "Partner summit"},
         follow_redirects=True,
     )
 
     assert response.status_code == 200
     assert "Missing required inputs" in response.text
-    assert "business_purpose" in response.text
-    assert "Next intake questions" in response.text
+    assert "destination_zip" in response.text
+    assert "Where are you headed and what" in response.text
 
 
-def test_portal_review_generates_artifacts_and_submission(monkeypatch) -> None:
+def test_portal_generates_review_artifacts_and_submission(monkeypatch) -> None:
     _set_runtime_env(monkeypatch)
     client = TestClient(create_app(PlannerProposalStore()))
 
-    review = client.post(
+    response = client.post(
         "/portal/requests/review",
-        data=_portal_form_data(),
+        data=_portal_form_payload(),
         follow_redirects=True,
     )
 
-    assert review.status_code == 200
-    assert "Ready for submit" in review.text
-    assert "Policy readiness" in review.text
-    assert "itinerary.xlsx" in review.text
-    assert "summary.pdf" in review.text
-    assert "TRIP-20251005-ALEX-RIVERA" in review.text
+    assert response.status_code == 200
+    assert "Policy-lite posture" in response.text
+    assert "Generated artifacts" in response.text
 
-    draft_id = str(review.url).rstrip("/").split("/")[-1]
-    submit = client.post(f"/portal/requests/{draft_id}/submit")
+    match = re.search(r"/portal/requests/([^/]+)/artifacts/itinerary", response.text)
+    assert match is not None
+    draft_id = match.group(1)
 
-    assert submit.status_code == 200
-    assert "Submitted." in submit.text
-    assert "pending" in submit.text
-
-    artifact = client.get(f"/portal/requests/{draft_id}/artifacts/itinerary")
-    assert artifact.status_code == 200
-    assert (
-        artifact.headers["content-type"]
-        == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    itinerary = client.get(f"/portal/requests/{draft_id}/artifacts/itinerary")
+    summary = client.get(f"/portal/requests/{draft_id}/artifacts/summary")
+    submit = client.post(
+        f"/portal/requests/{draft_id}/submit",
+        follow_redirects=True,
     )
+
+    assert itinerary.status_code == 200
+    assert itinerary.content.startswith(b"PK")
+    assert summary.status_code == 200
+    assert summary.content
+    assert summary.headers["content-type"].startswith(("application/pdf", "text/plain"))
+    assert submit.status_code == 200
+    assert "Submission result" in submit.text

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -11,6 +11,7 @@ from travel_plan_permission.http_service import (
     create_app,
     main,
 )
+from travel_plan_permission import http_service
 from travel_plan_permission.planner_auth import mint_bootstrap_token
 from travel_plan_permission.policy_api import PlannerProposalOperationResponse
 from travel_plan_permission.security import Permission
@@ -300,6 +301,17 @@ def test_portal_home_and_request_form_render() -> None:
     assert "Draft a travel request through the real service runtime." in form.text
 
 
+def test_portal_request_form_get_stays_lightweight() -> None:
+    client = TestClient(create_app())
+
+    response = client.get("/portal/requests/new?traveler_name=Alex+Rivera")
+
+    assert response.status_code == 200
+    assert 'value="Alex Rivera"' not in response.text
+    assert "Generated artifacts" not in response.text
+    assert "Policy-lite posture" not in response.text
+
+
 def test_portal_review_shows_missing_inputs() -> None:
     client = TestClient(create_app())
 
@@ -313,6 +325,58 @@ def test_portal_review_shows_missing_inputs() -> None:
     assert "Missing required inputs" in response.text
     assert "destination_zip" in response.text
     assert "Where are you headed and what" in response.text
+
+
+def test_portal_review_allows_optional_fields_to_remain_blank(monkeypatch) -> None:
+    _set_runtime_env(monkeypatch)
+    client = TestClient(create_app(PlannerProposalStore()))
+    payload = _portal_form_payload()
+    for field_name in (
+        "cost_center",
+        "event_registration_cost",
+        "flight_pref_outbound.carrier_flight",
+        "flight_pref_return.carrier_flight",
+        "lowest_cost_roundtrip",
+        "parking_estimate",
+        "hotel.name",
+        "hotel.address",
+        "hotel.city_state",
+        "hotel.nightly_rate",
+        "hotel.nights",
+        "hotel.conference_hotel",
+        "hotel.price_compare_notes",
+        "comparable_hotels[0].name",
+        "comparable_hotels[0].nightly_rate",
+        "ground_transport_pref",
+        "notes",
+    ):
+        payload.pop(field_name)
+
+    response = client.post(
+        "/portal/requests/review",
+        data=payload,
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert "Generated artifacts" in response.text
+    assert "Missing required inputs" not in response.text
+
+
+def test_portal_review_persists_policy_readiness_answers(monkeypatch) -> None:
+    _set_runtime_env(monkeypatch)
+    client = TestClient(create_app(PlannerProposalStore()))
+
+    response = client.post(
+        "/portal/requests/review",
+        data=_portal_form_payload(),
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert 'value="2025-09-20"' in response.text
+    assert 'value="economy"' in response.text
+    assert 'value="120.00"' in response.text
 
 
 def test_portal_generates_review_artifacts_and_submission(monkeypatch) -> None:
@@ -337,6 +401,7 @@ def test_portal_generates_review_artifacts_and_submission(monkeypatch) -> None:
     summary = client.get(f"/portal/requests/{draft_id}/artifacts/summary")
     submit = client.post(
         f"/portal/requests/{draft_id}/submit",
+        headers=AUTH_HEADER,
         follow_redirects=True,
     )
 
@@ -347,3 +412,55 @@ def test_portal_generates_review_artifacts_and_submission(monkeypatch) -> None:
     assert summary.headers["content-type"].startswith(("application/pdf", "text/plain"))
     assert submit.status_code == 200
     assert "Submission result" in submit.text
+
+
+def test_portal_artifact_downloads_use_cached_review_artifacts(monkeypatch) -> None:
+    _set_runtime_env(monkeypatch)
+    client = TestClient(create_app(PlannerProposalStore()))
+
+    response = client.post(
+        "/portal/requests/review",
+        data=_portal_form_payload(),
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    match = re.search(r"/portal/requests/([^/]+)/artifacts/itinerary", response.text)
+    assert match is not None
+    draft_id = match.group(1)
+
+    def fail_render(*args, **kwargs):
+        raise AssertionError("artifact download should use cached payloads")
+
+    monkeypatch.setattr(http_service, "render_travel_spreadsheet_bytes", fail_render)
+    monkeypatch.setattr(http_service, "build_output_bundle", fail_render)
+
+    itinerary = client.get(f"/portal/requests/{draft_id}/artifacts/itinerary")
+    summary = client.get(f"/portal/requests/{draft_id}/artifacts/summary")
+
+    assert itinerary.status_code == 200
+    assert itinerary.content.startswith(b"PK")
+    assert summary.status_code == 200
+    assert summary.content
+
+
+def test_portal_submit_requires_bearer_token(monkeypatch) -> None:
+    _set_runtime_env(monkeypatch)
+    client = TestClient(create_app(PlannerProposalStore()))
+
+    response = client.post(
+        "/portal/requests/review",
+        data=_portal_form_payload(),
+        follow_redirects=True,
+    )
+    match = re.search(r"/portal/requests/([^/]+)/artifacts/itinerary", response.text)
+    assert match is not None
+    draft_id = match.group(1)
+
+    submit = client.post(
+        f"/portal/requests/{draft_id}/submit",
+        follow_redirects=True,
+    )
+
+    assert submit.status_code == 401
+    assert submit.json()["detail"] == "Missing bearer token."

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -15,11 +15,52 @@ from travel_plan_permission.policy_api import PlannerProposalOperationResponse
 from travel_plan_permission.security import Permission
 
 FIXTURE_ROOT = Path(__file__).resolve().parents[1] / "fixtures" / "planner_integration"
+CANONICAL_FIXTURE = (
+    Path(__file__).resolve().parents[1] / "fixtures" / "canonical_trip_plan_realistic.json"
+)
 AUTH_HEADER = {"Authorization": "Bearer dev-token"}
 
 
 def _load_fixture(name: str) -> dict[str, object]:
     return json.loads((FIXTURE_ROOT / name).read_text(encoding="utf-8"))
+
+
+def _portal_form_data() -> dict[str, str]:
+    payload = json.loads(CANONICAL_FIXTURE.read_text(encoding="utf-8"))
+    hotel = payload["hotel"]
+    outbound = payload["flight_pref_outbound"]
+    inbound = payload["flight_pref_return"]
+    comparable = payload["comparable_hotels"][0]
+    return {
+        "traveler_name": payload["traveler_name"],
+        "business_purpose": payload["business_purpose"],
+        "cost_center": payload["cost_center"],
+        "destination_zip": payload["destination_zip"],
+        "city_state": payload["city_state"],
+        "depart_date": payload["depart_date"],
+        "return_date": payload["return_date"],
+        "event_registration_cost": str(payload["event_registration_cost"]),
+        "flight_pref_outbound.carrier_flight": outbound["carrier_flight"],
+        "flight_pref_outbound.depart_time": outbound["depart_time"],
+        "flight_pref_outbound.arrive_time": outbound["arrive_time"],
+        "flight_pref_outbound.roundtrip_cost": str(outbound["roundtrip_cost"]),
+        "flight_pref_return.carrier_flight": inbound["carrier_flight"],
+        "flight_pref_return.depart_time": inbound["depart_time"],
+        "flight_pref_return.arrive_time": inbound["arrive_time"],
+        "lowest_cost_roundtrip": str(payload["lowest_cost_roundtrip"]),
+        "parking_estimate": str(payload["parking_estimate"]),
+        "hotel.name": hotel["name"],
+        "hotel.address": hotel["address"],
+        "hotel.city_state": hotel["city_state"],
+        "hotel.nightly_rate": str(hotel["nightly_rate"]),
+        "hotel.nights": str(hotel["nights"]),
+        "hotel.conference_hotel": "true",
+        "hotel.price_compare_notes": hotel["price_compare_notes"],
+        "comparable_hotels[0].name": comparable["name"],
+        "comparable_hotels[0].nightly_rate": str(comparable["nightly_rate"]),
+        "ground_transport_pref": payload["ground_transport_pref"],
+        "notes": payload["notes"],
+    }
 
 
 def _set_runtime_env(monkeypatch, *, provider: str = "google") -> None:
@@ -240,3 +281,66 @@ def test_snapshot_route_returns_bad_request_for_contract_mismatch(monkeypatch) -
 
     assert response.status_code == 400
     assert "trip_id" in response.json()["detail"]
+
+
+def test_portal_home_and_form_routes_render() -> None:
+    client = TestClient(create_app())
+
+    home = client.get("/portal")
+    form = client.get("/portal/requests/new")
+
+    assert home.status_code == 200
+    assert "Workflow Lite Portal" in home.text
+    assert form.status_code == 200
+    assert "Travel request submission shell" in form.text
+    assert "Review request" in form.text
+
+
+def test_portal_review_surfaces_missing_required_inputs() -> None:
+    client = TestClient(create_app())
+
+    response = client.post(
+        "/portal/requests/review",
+        data={
+            "traveler_name": "Ada Lovelace",
+            "city_state": "Boston, MA",
+        },
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert "Missing required inputs" in response.text
+    assert "business_purpose" in response.text
+    assert "Next intake questions" in response.text
+
+
+def test_portal_review_generates_artifacts_and_submission(monkeypatch) -> None:
+    _set_runtime_env(monkeypatch)
+    client = TestClient(create_app(PlannerProposalStore()))
+
+    review = client.post(
+        "/portal/requests/review",
+        data=_portal_form_data(),
+        follow_redirects=True,
+    )
+
+    assert review.status_code == 200
+    assert "Ready for submit" in review.text
+    assert "Policy readiness" in review.text
+    assert "itinerary.xlsx" in review.text
+    assert "summary.pdf" in review.text
+    assert "TRIP-20251005-ALEX-RIVERA" in review.text
+
+    draft_id = str(review.url).rstrip("/").split("/")[-1]
+    submit = client.post(f"/portal/requests/{draft_id}/submit")
+
+    assert submit.status_code == 200
+    assert "Submitted." in submit.text
+    assert "pending" in submit.text
+
+    artifact = client.get(f"/portal/requests/{draft_id}/artifacts/itinerary")
+    assert artifact.status_code == 200
+    assert (
+        artifact.headers["content-type"]
+        == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    )

--- a/tests/python/test_package_data.py
+++ b/tests/python/test_package_data.py
@@ -15,3 +15,16 @@ def test_template_resource_exists() -> None:
     )
     assert template.is_file()
     assert template.read_bytes().startswith(b"PK")
+
+
+def test_portal_template_resources_exist() -> None:
+    templates = resources.files("travel_plan_permission").joinpath("templates")
+    home = templates.joinpath("portal_home.html")
+    request = templates.joinpath("portal_request.html")
+
+    assert home.is_file()
+    assert "Travel Request Portal" in home.read_text(encoding="utf-8")
+    assert request.is_file()
+    assert "Draft a travel request through the real service runtime." in request.read_text(
+        encoding="utf-8"
+    )


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #798

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The repository has strong domain logic, planner-facing APIs, spreadsheet export, and policy evaluation, but it still does not provide the lightweight end-user workflow portal implied by the Stage 2 plan. That leaves the repo usable as a backend package, but not yet as a complete travel request product.

#### Tasks
### Portal Routes
- [ ] Create GET route for displaying the draft creation form in `src/travel_plan_permission/http_service.py`
- [ ] Create POST route for handling draft submission in `src/travel_plan_permission/http_service.py`
- [ ] Create GET route for displaying the review screen in `src/travel_plan_permission/http_service.py`
- [ ] Mount all new portal routes on the existing FastAPI app instance

### HTML Templates
- [ ] Create HTML template for the draft entry form with all required input fields under `src/travel_plan_permission/templates/`
- [ ] Create HTML template for displaying validation feedback and missing field errors under `src/travel_plan_permission/templates/`
- [ ] Create HTML template for the request review and summary screen under `src/travel_plan_permission/templates/`

### Draft Handling Logic
- [ ] Implement draft data model to capture trip details, travel purpose, and cost context
- [ ] Integrate `src/travel_plan_permission/canonical.py` seams to validate and normalize draft input data
- [ ] Integrate `src/travel_plan_permission/prompt_flow.py` to identify missing required fields in draft submissions
- [ ] Add error handling and user-friendly error messages for validation failures

### Policy Integration
- [ ] Update the portal review route to display policy-readiness diagnostics by reusing `src/travel_plan_permission/policy_api.py` instead of duplicating policy logic

### Tests
- [ ] Add test for successful draft creation POST request with valid inputs under `tests/python/`
- [ ] Add test for draft creation POST with missing required fields returns validation errors under `tests/python/`
- [ ] Add test for validation error rendering displays correct missing field messages under `tests/python/`
- [ ] Add test for review page rendering displays draft data and policy readiness status under `tests/python/`

### Documentation
- [ ] Update `docs/workflows.md` with steps to run the portal locally via the standard service workflow
- [ ] Update `docs/plan.md` with portal architecture and integration points

#### Acceptance criteria
- [ ] The portal serves a draft creation form at `/portal/draft/new`, accepts POST submissions to `/portal/draft`, and displays a review screen at `/portal/review/{draft_id}` with data from `canonical.py` and `policy_api.py`
- [ ] When required inputs are missing, the portal returns HTTP 400 with an HTML response containing a list element for each missing field identified by `prompt_flow.py`, and the form is not submitted to the backend
- [ ] The portal's policy-readiness and canonical evaluation paths call into `src/travel_plan_permission/canonical.py`, `src/travel_plan_permission/prompt_flow.py`, and `src/travel_plan_permission/policy_api.py` (no duplicated policy/canonical logic in route handlers)
- [ ] All tests under `tests/python/` pass, covering draft creation, validation feedback rendering, and review-state rendering

**Head SHA:** f977b1d34b34c6d81232b5aff71e7bd7290f5c5b
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| .github/workflows/autofix.yml | ❌ failure | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24441384598) |
| .github/workflows/ci.yml | ❌ failure | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24441384121) |
| .github/workflows/claude-code-review.yml | ❌ failure | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24441384357) |
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24441785199) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24441785247) |
| Claude Code Review (Opt-in) | ✅ success | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24441386439) |
| Dependabot Auto-merge | ⏭️ skipped | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24441385418) |
| Gate | ✅ success | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24441386615) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24441386446) |
<!-- auto-status-summary:end -->