### PR TITLE
Issue #799: add manager review workflow UI

### DIFF
--- a/docs/approval-workflow.md
+++ b/docs/approval-workflow.md
@@ -63,9 +63,14 @@ Approval packets package the trip summary, policy status, cost breakdown, and a 
 - `ApprovalPacket` bundles the rendered emails, PDF bytes, and immutable `approval_history`.
 - `ApprovalLinks` supply approve/reject/override URLs for both manager and board audiences.
 - `TripPlan.approval_history` is append-only. Each `ApprovalEvent` captures approver ID, level (manager/board), outcome, timestamp, prior status, and resulting status.
+- `review_workflow.py` adds persisted in-runtime `ReviewRequest` state for manager queue/detail
+  screens. It keeps the queue status, submission timestamp, policy posture, and a
+  workflow event log alongside the immutable `TripPlan.approval_history`.
 
 ### Override and auditability rules
 
 - `TripPlan.record_approval_decision` enforces justification text for override outcomes.
 - Approval history entries are frozen Pydantic models and stored as tuples to prevent mutation.
 - PDFs include the justification column to preserve override rationale for auditing.
+- Manager review decisions captured through the browser queue require rationale so
+  approval, rejection, and requested changes all leave an audit-ready explanation.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -20,6 +20,17 @@ and renders `templates/validation_feedback.html` instead of redirecting. The ent
 validation, and review states are intentionally separate templates so the route
 contract stays explicit and testable.
 
+### Current manager review path
+
+- The workflow portal persists a submitted request into a manager review queue at
+  `/portal/manager/reviews`.
+- Each queue item has a detail view at `/portal/manager/reviews/{review_id}`
+  that shows current policy posture, approval triggers, policy issues, and the
+  immutable approval history recorded on the trip.
+- Managers can record `approve`, `request_changes`, or `reject` decisions with
+  rationale from the detail view, and the runtime keeps that decision history in
+  durable in-memory workflow state for later review during the same service run.
+
 ## Expense (Stage 2)
 
 Collecting Receipts → Employee Submit → Manager Review → Accounting Review

--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -848,7 +848,6 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
             context=_portal_template_context(request, review),
         )
 
-    @app.get("/portal/review/{draft_id}/artifacts/{artifact_name}")
     @app.get("/portal/manager/reviews", response_class=HTMLResponse)
     def portal_manager_review_queue(
         request: Request,
@@ -952,6 +951,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
             status_code=status.HTTP_303_SEE_OTHER,
         )
 
+    @app.get("/portal/review/{draft_id}/artifacts/{artifact_name}")
     def portal_artifact(
         draft_id: str,
         artifact_name: str,

--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -597,7 +597,9 @@ def _portal_artifacts(
 
 
 def _portal_validation_state(answers: dict[str, object]) -> PortalReviewState:
-    missing_fields = required_field_gaps(answers, required_fields=_PORTAL_REQUIRED_FIELDS)
+    missing_fields = required_field_gaps(
+        answers, required_fields=_PORTAL_REQUIRED_FIELDS
+    )
     next_questions: list[dict[str, object]] = [
         {
             "prompt": question.prompt,

--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -45,10 +45,13 @@ from .policy_api import (
     submit_proposal,
 )
 from .prompt_flow import build_output_bundle, generate_questions, required_field_gaps
+from .review_workflow import ReviewAction, ReviewRequest, ReviewWorkflowStore
 from .security import Permission
 
 _OPTIONAL_SNAPSHOT_BODY = Body(default=None)
-_TEMPLATES = Jinja2Templates(directory=str(Path(__file__).resolve().parent / "templates"))
+_TEMPLATES = Jinja2Templates(
+    directory=str(Path(__file__).resolve().parent / "templates")
+)
 _PORTAL_CANONICAL_FIELDS: tuple[str, ...] = (
     "traveler_name",
     "business_purpose",
@@ -179,6 +182,7 @@ class PortalReviewState:
     policy_result: Any | None
     artifacts: dict[str, PortalArtifact]
     submission_response: PlannerProposalOperationResponse | None = None
+    manager_review: ReviewRequest | None = None
 
 
 class PlannerRuntimeConfigError(RuntimeError):
@@ -306,6 +310,7 @@ class PlannerProposalStore:
     plans_by_trip_id: dict[str, TripPlan] = field(default_factory=dict)
     proposals_by_execution_id: dict[str, StoredProposal] = field(default_factory=dict)
     portal_drafts_by_id: dict[str, PortalDraft] = field(default_factory=dict)
+    manager_reviews: ReviewWorkflowStore = field(default_factory=ReviewWorkflowStore)
 
     def remember_plan(self, trip_plan: TripPlan) -> None:
         """Store the latest planner trip payload by trip identifier."""
@@ -331,7 +336,9 @@ class PlannerProposalStore:
         self.remember_plan(trip_plan)
         execution_id = response.result_payload.get("execution_id")
         if not isinstance(execution_id, str):
-            raise ValueError("Planner proposal response missing required string execution_id")
+            raise ValueError(
+                "Planner proposal response missing required string execution_id"
+            )
         self.proposals_by_execution_id[execution_id] = StoredProposal(
             trip_plan=trip_plan.model_copy(deep=True),
             request=request.model_copy(deep=True),
@@ -396,6 +403,54 @@ class PlannerProposalStore:
             answers=dict(draft.answers),
             updated_at=draft.updated_at,
             cached_artifacts=dict(draft.cached_artifacts),
+        )
+
+    def create_manager_review(self, review: PortalReviewState) -> ReviewRequest:
+        """Persist a manager review request for a submitted portal draft."""
+
+        if (
+            review.trip_plan is None
+            or review.policy_snapshot is None
+            or review.policy_result is None
+        ):
+            raise ValueError("Manager review requires a completed portal review state.")
+        return self.manager_reviews.create_or_get(
+            draft_id=review.draft_id,
+            trip_plan=review.trip_plan,
+            policy_snapshot=review.policy_snapshot,
+            policy_result=review.policy_result,
+        )
+
+    def lookup_manager_review(self, review_id: str) -> ReviewRequest | None:
+        """Return a persisted manager review by identifier."""
+
+        return self.manager_reviews.lookup(review_id)
+
+    def lookup_manager_review_for_draft(self, draft_id: str) -> ReviewRequest | None:
+        """Return the persisted manager review for a portal draft, if any."""
+
+        return self.manager_reviews.lookup_by_draft(draft_id)
+
+    def list_manager_reviews(self) -> list[ReviewRequest]:
+        """Return the manager review queue ordered by most recent activity."""
+
+        return self.manager_reviews.list_reviews()
+
+    def apply_manager_review_action(
+        self,
+        review_id: str,
+        *,
+        action: ReviewAction,
+        actor_id: str,
+        rationale: str,
+    ) -> ReviewRequest:
+        """Persist a manager decision against an existing review request."""
+
+        return self.manager_reviews.apply_action(
+            review_id,
+            action=action,
+            actor_id=actor_id,
+            rationale=rationale,
         )
 
 
@@ -580,6 +635,7 @@ def _portal_review_state(
     answers: dict[str, object],
     *,
     submission_response: PlannerProposalOperationResponse | None = None,
+    manager_review: ReviewRequest | None = None,
 ) -> PortalReviewState:
     validation_state = _portal_validation_state(answers)
     missing_fields = validation_state.missing_fields
@@ -617,6 +673,7 @@ def _portal_review_state(
         policy_result=policy_result,
         artifacts=artifacts,
         submission_response=submission_response,
+        manager_review=manager_review,
     )
 
 
@@ -636,6 +693,27 @@ def _portal_template_context(
             "personal vehicle",
         ),
         "optional_fields": _PORTAL_OPTIONAL_FIELDS,
+    }
+
+
+def _manager_review_queue_context(
+    request: Request,
+    reviews: list[ReviewRequest],
+) -> dict[str, object]:
+    return {"request": request, "reviews": reviews}
+
+
+def _manager_review_detail_context(
+    request: Request,
+    review: ReviewRequest,
+    *,
+    error_message: str | None = None,
+) -> dict[str, object]:
+    return {
+        "request": request,
+        "review": review,
+        "error_message": error_message,
+        "review_actions": tuple(ReviewAction),
     }
 
 
@@ -700,7 +778,13 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"No portal draft found for '{draft_id}'.",
             )
-        review = _portal_review_state(draft.draft_id, draft.answers)
+        review = _portal_review_state(
+            draft.draft_id,
+            draft.answers,
+            manager_review=proposal_store.lookup_manager_review_for_draft(
+                draft.draft_id
+            ),
+        )
         if review.artifacts and not draft.cached_artifacts:
             proposal_store.cache_portal_artifacts(draft.draft_id, review.artifacts)
         return _TEMPLATES.TemplateResponse(
@@ -726,7 +810,11 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
                 detail=f"No portal draft found for '{draft_id}'.",
             )
         review = _portal_review_state(draft.draft_id, draft.answers)
-        if review.trip_plan is None or review.missing_fields or review.validation_errors:
+        if (
+            review.trip_plan is None
+            or review.missing_fields
+            or review.validation_errors
+        ):
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="Complete the request review before submitting the portal draft.",
@@ -747,10 +835,12 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
             submission_request,
             submission_response,
         )
+        manager_review = proposal_store.create_manager_review(review)
         review = _portal_review_state(
             draft.draft_id,
             draft.answers,
             submission_response=submission_response,
+            manager_review=manager_review,
         )
         return _TEMPLATES.TemplateResponse(
             request=request,
@@ -759,6 +849,109 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         )
 
     @app.get("/portal/review/{draft_id}/artifacts/{artifact_name}")
+    @app.get("/portal/manager/reviews", response_class=HTMLResponse)
+    def portal_manager_review_queue(
+        request: Request,
+        authorization: str | None = Header(default=None),
+    ) -> HTMLResponse:
+        _authorize_request(
+            authorization,
+            required_permission=Permission.VIEW,
+        )
+        return _TEMPLATES.TemplateResponse(
+            request=request,
+            name="manager_review_queue.html",
+            context=_manager_review_queue_context(
+                request,
+                proposal_store.list_manager_reviews(),
+            ),
+        )
+
+    @app.get(
+        "/portal/manager/reviews/{review_id}",
+        response_class=HTMLResponse,
+        name="portal_manager_review_detail",
+    )
+    def portal_manager_review_detail(
+        request: Request,
+        review_id: str,
+        authorization: str | None = Header(default=None),
+    ) -> HTMLResponse:
+        _authorize_request(
+            authorization,
+            required_permission=Permission.VIEW,
+        )
+        review = proposal_store.lookup_manager_review(review_id)
+        if review is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"No manager review found for '{review_id}'.",
+            )
+        return _TEMPLATES.TemplateResponse(
+            request=request,
+            name="manager_review_detail.html",
+            context=_manager_review_detail_context(request, review),
+        )
+
+    @app.post("/portal/manager/reviews/{review_id}/decision")
+    async def portal_manager_review_decision(
+        request: Request,
+        review_id: str,
+        authorization: str | None = Header(default=None),
+    ) -> Response:
+        _authorize_request(
+            authorization,
+            required_permission=Permission.APPROVE,
+        )
+        parsed = parse_qs(
+            (await request.body()).decode("utf-8"), keep_blank_values=True
+        )
+        action_name = parsed.get("action", [""])[-1].strip()
+        actor_id = parsed.get("actor_id", [""])[-1].strip()
+        rationale = parsed.get("rationale", [""])[-1].strip()
+
+        review = proposal_store.lookup_manager_review(review_id)
+        if review is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"No manager review found for '{review_id}'.",
+            )
+        if not actor_id:
+            return _TEMPLATES.TemplateResponse(
+                request=request,
+                name="manager_review_detail.html",
+                context=_manager_review_detail_context(
+                    request,
+                    review,
+                    error_message="Manager actor ID is required.",
+                ),
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
+        try:
+            action = ReviewAction(action_name)
+            proposal_store.apply_manager_review_action(
+                review_id,
+                action=action,
+                actor_id=actor_id,
+                rationale=rationale,
+            )
+        except ValueError as exc:
+            refreshed = proposal_store.lookup_manager_review(review_id) or review
+            return _TEMPLATES.TemplateResponse(
+                request=request,
+                name="manager_review_detail.html",
+                context=_manager_review_detail_context(
+                    request,
+                    refreshed,
+                    error_message=str(exc),
+                ),
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
+        return RedirectResponse(
+            url=request.url_for("portal_manager_review_detail", review_id=review_id),
+            status_code=status.HTTP_303_SEE_OTHER,
+        )
+
     def portal_artifact(
         draft_id: str,
         artifact_name: str,
@@ -784,7 +977,9 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         return Response(
             content=artifact.content,
             media_type=artifact.media_type,
-            headers={"Content-Disposition": f'attachment; filename="{artifact.filename}"'},
+            headers={
+                "Content-Disposition": f'attachment; filename="{artifact.filename}"'
+            },
         )
 
     @app.get(
@@ -888,7 +1083,9 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         if stored.request.proposal_id != proposal_id:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail=(f"Execution '{execution_id}' does not belong to proposal '{proposal_id}'."),
+                detail=(
+                    f"Execution '{execution_id}' does not belong to proposal '{proposal_id}'."
+                ),
             )
         status_request = _submission_status_request(
             stored,

--- a/src/travel_plan_permission/review_workflow.py
+++ b/src/travel_plan_permission/review_workflow.py
@@ -1,0 +1,225 @@
+"""Persisted in-runtime review workflow state for manager approval UI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from uuid import uuid4
+
+from .models import ApprovalOutcome, TripPlan, TripStatus
+from .policy_api import PlannerPolicySnapshot, PolicyCheckResult
+
+
+class ReviewAction(StrEnum):
+    """Supported manager review actions."""
+
+    APPROVE = "approve"
+    REJECT = "reject"
+    REQUEST_CHANGES = "request_changes"
+
+
+class ReviewStatus(StrEnum):
+    """Lifecycle states for a persisted manager review."""
+
+    PENDING_MANAGER_REVIEW = "pending_manager_review"
+    CHANGES_REQUESTED = "changes_requested"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+
+
+@dataclass(frozen=True)
+class ReviewHistoryEvent:
+    """Immutable review workflow event."""
+
+    event_type: str
+    actor_id: str
+    timestamp: datetime
+    status: ReviewStatus
+    rationale: str | None = None
+
+
+@dataclass(frozen=True)
+class ReviewRequest:
+    """Persisted review request and its current decision state."""
+
+    review_id: str
+    draft_id: str
+    trip_plan: TripPlan
+    policy_snapshot: PlannerPolicySnapshot
+    policy_result: PolicyCheckResult
+    status: ReviewStatus
+    submitted_at: datetime
+    updated_at: datetime
+    history: tuple[ReviewHistoryEvent, ...] = ()
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def create_review_request(
+    *,
+    draft_id: str,
+    trip_plan: TripPlan,
+    policy_snapshot: PlannerPolicySnapshot,
+    policy_result: PolicyCheckResult,
+) -> ReviewRequest:
+    """Create a persisted manager review request from a submitted trip."""
+
+    submitted_at = _now()
+    plan = trip_plan.model_copy(deep=True)
+    plan.status = TripStatus.SUBMITTED
+    history = (
+        ReviewHistoryEvent(
+            event_type="submitted",
+            actor_id="workflow-portal",
+            timestamp=submitted_at,
+            status=ReviewStatus.PENDING_MANAGER_REVIEW,
+            rationale="Submitted from the browser portal review screen.",
+        ),
+    )
+    return ReviewRequest(
+        review_id=uuid4().hex[:12],
+        draft_id=draft_id,
+        trip_plan=plan,
+        policy_snapshot=policy_snapshot.model_copy(deep=True),
+        policy_result=policy_result.model_copy(deep=True),
+        status=ReviewStatus.PENDING_MANAGER_REVIEW,
+        submitted_at=submitted_at,
+        updated_at=submitted_at,
+        history=history,
+    )
+
+
+def apply_review_action(
+    review: ReviewRequest,
+    *,
+    action: ReviewAction,
+    actor_id: str,
+    rationale: str,
+) -> ReviewRequest:
+    """Apply a manager decision and return the updated review request."""
+
+    rationale_text = rationale.strip()
+    if not rationale_text:
+        raise ValueError("Manager review decisions require rationale text.")
+
+    updated_plan = review.trip_plan.model_copy(deep=True)
+    if action == ReviewAction.APPROVE:
+        outcome = ApprovalOutcome.APPROVED
+        next_status = ReviewStatus.APPROVED
+    elif action == ReviewAction.REJECT:
+        outcome = ApprovalOutcome.REJECTED
+        next_status = ReviewStatus.REJECTED
+    else:
+        outcome = ApprovalOutcome.FLAGGED
+        next_status = ReviewStatus.CHANGES_REQUESTED
+
+    updated_plan.record_approval_decision(
+        approver_id=actor_id,
+        level="manager",
+        outcome=outcome,
+        justification=rationale_text,
+    )
+    event_time = _now()
+    updated_history = review.history + (
+        ReviewHistoryEvent(
+            event_type=action.value,
+            actor_id=actor_id,
+            timestamp=event_time,
+            status=next_status,
+            rationale=rationale_text,
+        ),
+    )
+    return ReviewRequest(
+        review_id=review.review_id,
+        draft_id=review.draft_id,
+        trip_plan=updated_plan,
+        policy_snapshot=review.policy_snapshot.model_copy(deep=True),
+        policy_result=review.policy_result.model_copy(deep=True),
+        status=next_status,
+        submitted_at=review.submitted_at,
+        updated_at=event_time,
+        history=updated_history,
+    )
+
+
+@dataclass
+class ReviewWorkflowStore:
+    """In-memory persistence for manager review queue and decision history."""
+
+    reviews_by_id: dict[str, ReviewRequest] = field(default_factory=dict)
+    review_ids_by_draft_id: dict[str, str] = field(default_factory=dict)
+
+    def create_or_get(
+        self,
+        *,
+        draft_id: str,
+        trip_plan: TripPlan,
+        policy_snapshot: PlannerPolicySnapshot,
+        policy_result: PolicyCheckResult,
+    ) -> ReviewRequest:
+        review_id = self.review_ids_by_draft_id.get(draft_id)
+        if review_id is not None:
+            review = self.reviews_by_id.get(review_id)
+            if review is not None:
+                return review
+        review = create_review_request(
+            draft_id=draft_id,
+            trip_plan=trip_plan,
+            policy_snapshot=policy_snapshot,
+            policy_result=policy_result,
+        )
+        self.reviews_by_id[review.review_id] = review
+        self.review_ids_by_draft_id[draft_id] = review.review_id
+        return review
+
+    def list_reviews(self) -> list[ReviewRequest]:
+        return sorted(
+            self.reviews_by_id.values(),
+            key=lambda review: (review.updated_at, review.submitted_at),
+            reverse=True,
+        )
+
+    def lookup(self, review_id: str) -> ReviewRequest | None:
+        review = self.reviews_by_id.get(review_id)
+        if review is None:
+            return None
+        return ReviewRequest(
+            review_id=review.review_id,
+            draft_id=review.draft_id,
+            trip_plan=review.trip_plan.model_copy(deep=True),
+            policy_snapshot=review.policy_snapshot.model_copy(deep=True),
+            policy_result=review.policy_result.model_copy(deep=True),
+            status=review.status,
+            submitted_at=review.submitted_at,
+            updated_at=review.updated_at,
+            history=tuple(review.history),
+        )
+
+    def lookup_by_draft(self, draft_id: str) -> ReviewRequest | None:
+        review_id = self.review_ids_by_draft_id.get(draft_id)
+        if review_id is None:
+            return None
+        return self.lookup(review_id)
+
+    def apply_action(
+        self,
+        review_id: str,
+        *,
+        action: ReviewAction,
+        actor_id: str,
+        rationale: str,
+    ) -> ReviewRequest:
+        review = self.reviews_by_id.get(review_id)
+        if review is None:
+            raise KeyError(f"No manager review found for '{review_id}'.")
+        updated = apply_review_action(
+            review,
+            action=action,
+            actor_id=actor_id,
+            rationale=rationale,
+        )
+        self.reviews_by_id[review_id] = updated
+        return updated

--- a/src/travel_plan_permission/review_workflow.py
+++ b/src/travel_plan_permission/review_workflow.py
@@ -152,6 +152,20 @@ class ReviewWorkflowStore:
     reviews_by_id: dict[str, ReviewRequest] = field(default_factory=dict)
     review_ids_by_draft_id: dict[str, str] = field(default_factory=dict)
 
+    @staticmethod
+    def _copy_review(review: ReviewRequest) -> ReviewRequest:
+        return ReviewRequest(
+            review_id=review.review_id,
+            draft_id=review.draft_id,
+            trip_plan=review.trip_plan.model_copy(deep=True),
+            policy_snapshot=review.policy_snapshot.model_copy(deep=True),
+            policy_result=review.policy_result.model_copy(deep=True),
+            status=review.status,
+            submitted_at=review.submitted_at,
+            updated_at=review.updated_at,
+            history=tuple(review.history),
+        )
+
     def create_or_get(
         self,
         *,
@@ -164,7 +178,7 @@ class ReviewWorkflowStore:
         if review_id is not None:
             review = self.reviews_by_id.get(review_id)
             if review is not None:
-                return review
+                return self._copy_review(review)
         review = create_review_request(
             draft_id=draft_id,
             trip_plan=trip_plan,
@@ -173,11 +187,11 @@ class ReviewWorkflowStore:
         )
         self.reviews_by_id[review.review_id] = review
         self.review_ids_by_draft_id[draft_id] = review.review_id
-        return review
+        return self._copy_review(review)
 
     def list_reviews(self) -> list[ReviewRequest]:
         return sorted(
-            self.reviews_by_id.values(),
+            (self._copy_review(review) for review in self.reviews_by_id.values()),
             key=lambda review: (review.updated_at, review.submitted_at),
             reverse=True,
         )
@@ -186,17 +200,7 @@ class ReviewWorkflowStore:
         review = self.reviews_by_id.get(review_id)
         if review is None:
             return None
-        return ReviewRequest(
-            review_id=review.review_id,
-            draft_id=review.draft_id,
-            trip_plan=review.trip_plan.model_copy(deep=True),
-            policy_snapshot=review.policy_snapshot.model_copy(deep=True),
-            policy_result=review.policy_result.model_copy(deep=True),
-            status=review.status,
-            submitted_at=review.submitted_at,
-            updated_at=review.updated_at,
-            history=tuple(review.history),
-        )
+        return self._copy_review(review)
 
     def lookup_by_draft(self, draft_id: str) -> ReviewRequest | None:
         review_id = self.review_ids_by_draft_id.get(draft_id)
@@ -222,4 +226,4 @@ class ReviewWorkflowStore:
             rationale=rationale,
         )
         self.reviews_by_id[review_id] = updated
-        return updated
+        return self._copy_review(updated)

--- a/src/travel_plan_permission/templates/manager_review_detail.html
+++ b/src/travel_plan_permission/templates/manager_review_detail.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Manager Review Detail</title>
+    <style>
+      :root {
+        --ink: #122432;
+        --muted: #5b7280;
+        --paper: rgba(255, 255, 255, 0.93);
+        --line: rgba(18, 36, 50, 0.14);
+        --shadow: 0 24px 64px rgba(18, 36, 50, 0.14);
+        --accent: #7c3d16;
+        --accent-soft: rgba(124, 61, 22, 0.12);
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        color: var(--ink);
+        font-family: "Iowan Old Style", "Palatino Linotype", Georgia, serif;
+        background:
+          radial-gradient(circle at right top, rgba(124, 61, 22, 0.12), transparent 32%),
+          linear-gradient(135deg, #f8efe5 0%, #dee9f1 100%);
+      }
+      main { max-width: 1180px; margin: 0 auto; padding: 36px 18px 72px; }
+      .layout { display: grid; gap: 20px; grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr); }
+      .panel, .card {
+        background: var(--paper);
+        border: 1px solid var(--line);
+        border-radius: 24px;
+        box-shadow: var(--shadow);
+      }
+      .panel { padding: 24px; }
+      .card { padding: 18px; }
+      h1, h2, h3, p { margin: 0; }
+      p { color: var(--muted); line-height: 1.52; }
+      .topbar, .meta, .actions { display: flex; gap: 12px; flex-wrap: wrap; }
+      .topbar { justify-content: space-between; align-items: center; margin-bottom: 20px; }
+      .badge, button, .link {
+        display: inline-flex; align-items: center; justify-content: center;
+        border-radius: 999px; padding: 10px 14px; text-decoration: none;
+      }
+      .badge { background: var(--accent-soft); color: var(--accent); font: 600 0.82rem/1 ui-monospace, Menlo, monospace; }
+      .link, button { border: 1px solid var(--line); background: white; color: var(--ink); font: 700 0.92rem/1 inherit; }
+      button.primary { background: var(--ink); color: white; }
+      .stack { display: grid; gap: 16px; }
+      .meta { margin-top: 12px; color: var(--muted); font-size: 0.92rem; }
+      .grid { display: grid; gap: 14px; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+      .callout { border: 1px solid var(--line); border-radius: 18px; padding: 16px; background: rgba(255,255,255,0.78); }
+      ul { margin: 10px 0 0; padding-left: 18px; color: var(--muted); }
+      li + li { margin-top: 8px; }
+      label { display: grid; gap: 8px; }
+      input, textarea, select {
+        width: 100%;
+        border: 1px solid var(--line);
+        border-radius: 14px;
+        padding: 12px 14px;
+        font: inherit;
+      }
+      textarea { min-height: 120px; resize: vertical; }
+      @media (max-width: 920px) {
+        .layout { grid-template-columns: 1fr; }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <div class="topbar">
+        <div>
+          <h1>Manager review detail</h1>
+          <p style="margin-top: 10px;">Decision state, policy posture, and immutable approval history for one submitted request.</p>
+        </div>
+        <div class="actions">
+          <a class="link" href="/portal/manager/reviews">Review queue</a>
+          <a class="link" href="/portal/requests/{{ review.draft_id }}">Open draft review</a>
+        </div>
+      </div>
+
+      <div class="layout">
+        <section class="panel">
+          <span class="badge">{{ review.status }}</span>
+          <h2 style="margin-top: 14px;">{{ review.trip_plan.traveler_name }} to {{ review.trip_plan.destination }}</h2>
+          <p style="margin-top: 10px;">{{ review.trip_plan.purpose }}</p>
+          <div class="meta">
+            <span>Trip {{ review.trip_plan.trip_id }}</span>
+            <span>Submitted {{ review.submitted_at.isoformat() }}</span>
+            <span>Updated {{ review.updated_at.isoformat() }}</span>
+          </div>
+
+          <div class="grid" style="margin-top: 18px;">
+            <div class="card">
+              <h3>Current policy posture</h3>
+              <p style="margin-top: 10px;">Snapshot status: <strong>{{ review.policy_snapshot.policy_status }}</strong></p>
+              <ul>
+                {% for trigger in review.policy_snapshot.approval_triggers %}
+                  <li>{{ trigger.summary }}</li>
+                {% else %}
+                  <li>No approval triggers surfaced.</li>
+                {% endfor %}
+              </ul>
+            </div>
+            <div class="card">
+              <h3>Decision-ready notes</h3>
+              <ul>
+                {% for issue in review.policy_result.issues %}
+                  <li>{{ issue.code }}: {{ issue.message }}</li>
+                {% else %}
+                  <li>No current blocking policy issues.</li>
+                {% endfor %}
+              </ul>
+            </div>
+          </div>
+
+          <div class="callout" style="margin-top: 18px;">
+            <h3>Approval history</h3>
+            <ul>
+              {% for event in review.trip_plan.approval_history %}
+                <li>{{ event.timestamp.isoformat() }}: {{ event.outcome.value }} by {{ event.approver_id }}{% if event.justification %} — {{ event.justification }}{% endif %}</li>
+              {% else %}
+                <li>No manager decision recorded yet.</li>
+              {% endfor %}
+            </ul>
+          </div>
+
+          <div class="callout" style="margin-top: 18px;">
+            <h3>Workflow event log</h3>
+            <ul>
+              {% for event in review.history %}
+                <li>{{ event.timestamp.isoformat() }}: {{ event.event_type }} by {{ event.actor_id }}{% if event.rationale %} — {{ event.rationale }}{% endif %}</li>
+              {% endfor %}
+            </ul>
+          </div>
+        </section>
+
+        <aside class="stack">
+          <section class="panel">
+            <h2>Record manager decision</h2>
+            <p style="margin-top: 10px;">Capture the decision and rationale so the runtime retains the current approval state.</p>
+            {% if error_message %}
+              <div class="callout" style="margin-top: 16px;">
+                <h3>Decision error</h3>
+                <p style="margin-top: 10px;">{{ error_message }}</p>
+              </div>
+            {% endif %}
+            <form method="post" action="/portal/manager/reviews/{{ review.review_id }}/decision" style="margin-top: 16px;">
+              <div class="stack">
+                <label>
+                  <span>Manager actor ID</span>
+                  <input name="actor_id" value="manager-1" />
+                </label>
+                <label>
+                  <span>Decision</span>
+                  <select name="action">
+                    {% for action in review_actions %}
+                      <option value="{{ action.value }}">{{ action.value }}</option>
+                    {% endfor %}
+                  </select>
+                </label>
+                <label>
+                  <span>Rationale</span>
+                  <textarea name="rationale" placeholder="Summarize the decision context and next expectation."></textarea>
+                </label>
+                <div class="actions">
+                  <button class="primary" type="submit">Save manager decision</button>
+                </div>
+              </div>
+            </form>
+          </section>
+        </aside>
+      </div>
+    </main>
+  </body>
+</html>

--- a/src/travel_plan_permission/templates/manager_review_queue.html
+++ b/src/travel_plan_permission/templates/manager_review_queue.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Manager Review Queue</title>
+    <style>
+      :root {
+        --ink: #102230;
+        --muted: #5d7482;
+        --paper: rgba(255, 255, 255, 0.92);
+        --line: rgba(16, 34, 48, 0.14);
+        --shadow: 0 24px 64px rgba(16, 34, 48, 0.14);
+        --accent: #184d47;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        color: var(--ink);
+        font-family: "Iowan Old Style", "Palatino Linotype", Georgia, serif;
+        background:
+          radial-gradient(circle at top left, rgba(24, 77, 71, 0.12), transparent 32%),
+          linear-gradient(135deg, #f8f1e8 0%, #e1ebf1 100%);
+      }
+      main { max-width: 1100px; margin: 0 auto; padding: 40px 18px 72px; }
+      .panel {
+        background: var(--paper);
+        border: 1px solid var(--line);
+        border-radius: 26px;
+        box-shadow: var(--shadow);
+        padding: 24px;
+      }
+      h1, h2, p { margin: 0; }
+      p { color: var(--muted); line-height: 1.5; }
+      .topbar, .row, .meta { display: flex; gap: 12px; }
+      .topbar, .row { justify-content: space-between; align-items: center; }
+      .list { margin-top: 20px; display: grid; gap: 16px; }
+      .card { border: 1px solid var(--line); border-radius: 18px; padding: 18px; background: rgba(255,255,255,0.8); }
+      .badge, .link {
+        display: inline-flex; align-items: center; justify-content: center;
+        border-radius: 999px; padding: 8px 12px; text-decoration: none;
+      }
+      .badge { background: rgba(24, 77, 71, 0.12); color: var(--accent); font: 600 0.82rem/1 ui-monospace, Menlo, monospace; }
+      .link { border: 1px solid var(--line); color: var(--ink); }
+      .meta { flex-wrap: wrap; margin-top: 10px; color: var(--muted); font-size: 0.92rem; }
+      .empty { margin-top: 18px; border: 1px dashed var(--line); border-radius: 18px; padding: 20px; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <section class="panel">
+        <div class="topbar">
+          <div>
+            <h1>Manager review queue</h1>
+            <p style="margin-top: 10px;">Submitted browser requests stay here with policy posture and decision history until a manager acts.</p>
+          </div>
+          <a class="link" href="/portal">Portal home</a>
+        </div>
+
+        {% if reviews %}
+          <div class="list">
+            {% for review in reviews %}
+              <article class="card">
+                <div class="row">
+                  <div>
+                    <h2>{{ review.trip_plan.traveler_name }} to {{ review.trip_plan.destination }}</h2>
+                    <p style="margin-top: 8px;">{{ review.trip_plan.purpose }}</p>
+                  </div>
+                  <span class="badge">{{ review.status }}</span>
+                </div>
+                <div class="meta">
+                  <span>Trip {{ review.trip_plan.trip_id }}</span>
+                  <span>Draft {{ review.draft_id }}</span>
+                  <span>Policy {{ review.policy_snapshot.policy_status }}</span>
+                  <span>{{ review.policy_snapshot.approval_triggers | length }} approval trigger(s)</span>
+                </div>
+                <div style="margin-top: 16px;">
+                  <a class="link" href="/portal/manager/reviews/{{ review.review_id }}">Open review details</a>
+                </div>
+              </article>
+            {% endfor %}
+          </div>
+        {% else %}
+          <div class="empty">
+            <h2>No submitted manager reviews yet</h2>
+            <p style="margin-top: 10px;">Submit a browser request to seed the queue.</p>
+          </div>
+        {% endif %}
+      </section>
+    </main>
+  </body>
+</html>

--- a/src/travel_plan_permission/templates/portal_request.html
+++ b/src/travel_plan_permission/templates/portal_request.html
@@ -456,6 +456,19 @@
             <section class="panel">
               <h2>Submission result</h2>
               <p style="margin-top: 10px;">The proposal submission seam accepted the browser draft.</p>
+              {% if review.manager_review %}
+                <div class="callout" style="margin: 16px 0;">
+                  <h3>Manager review lane</h3>
+                  <p>
+                    Current status:
+                    <strong>{{ review.manager_review.status }}</strong>
+                  </p>
+                  <div class="actions" style="margin-top: 12px;">
+                    <a class="button primary" href="/portal/manager/reviews/{{ review.manager_review.review_id }}">Open manager review</a>
+                    <a class="button secondary" href="/portal/manager/reviews">Open review queue</a>
+                  </div>
+                </div>
+              {% endif %}
               <pre>{{ review.submission_response.model_dump_json(indent=2) }}</pre>
             </section>
           {% endif %}

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -454,6 +454,91 @@ def test_portal_draft_submission_redirects_without_authorization_header(
     assert "/portal/review/" in location
 
 
+def test_submission_creates_manager_review_queue_entry(monkeypatch) -> None:
+    _set_runtime_env(monkeypatch)
+    store = PlannerProposalStore()
+    client = TestClient(create_app(store))
+
+    response = client.post(
+        "/portal/draft",
+        data=_portal_form_payload(),
+        follow_redirects=True,
+    )
+    draft_match = re.search(
+        r"/portal/review/([^/]+)/artifacts/itinerary", response.text
+    )
+    assert draft_match is not None
+    draft_id = draft_match.group(1)
+
+    submit = client.post(
+        f"/portal/review/{draft_id}/submit",
+        headers=AUTH_HEADER,
+        follow_redirects=True,
+    )
+
+    assert submit.status_code == 200
+    assert "Manager review lane" in submit.text
+    review = store.lookup_manager_review_for_draft(draft_id)
+    assert review is not None
+    queue = client.get("/portal/manager/reviews", headers=AUTH_HEADER)
+    detail = client.get(
+        f"/portal/manager/reviews/{review.review_id}",
+        headers=AUTH_HEADER,
+    )
+
+    assert queue.status_code == 200
+    assert review.trip_plan.traveler_name in queue.text
+    assert "pending_manager_review" in queue.text
+    assert detail.status_code == 200
+    assert "Current policy posture" in detail.text
+    assert "Workflow event log" in detail.text
+
+
+def test_manager_review_decision_updates_status_and_history(monkeypatch) -> None:
+    _set_runtime_env(monkeypatch)
+    store = PlannerProposalStore()
+    client = TestClient(create_app(store))
+
+    response = client.post(
+        "/portal/draft",
+        data=_portal_form_payload(),
+        follow_redirects=True,
+    )
+    draft_match = re.search(
+        r"/portal/review/([^/]+)/artifacts/itinerary", response.text
+    )
+    assert draft_match is not None
+    draft_id = draft_match.group(1)
+
+    client.post(
+        f"/portal/review/{draft_id}/submit",
+        headers=AUTH_HEADER,
+        follow_redirects=True,
+    )
+    review = store.lookup_manager_review_for_draft(draft_id)
+    assert review is not None
+
+    decision = client.post(
+        f"/portal/manager/reviews/{review.review_id}/decision",
+        data={
+            "actor_id": "manager-17",
+            "action": "request_changes",
+            "rationale": "Need a clearer justification before approval.",
+        },
+        headers=AUTH_HEADER,
+        follow_redirects=True,
+    )
+
+    assert decision.status_code == 200
+    assert "changes_requested" in decision.text
+    assert "Need a clearer justification before approval." in decision.text
+    updated = store.lookup_manager_review(review.review_id)
+    assert updated is not None
+    assert updated.status.value == "changes_requested"
+    assert updated.trip_plan.approval_history[-1].outcome.value == "flagged"
+    assert updated.trip_plan.approval_history[-1].approver_id == "manager-17"
+
+
 def test_portal_artifact_downloads_use_cached_review_artifacts(monkeypatch) -> None:
     _set_runtime_env(monkeypatch)
     client = TestClient(create_app(PlannerProposalStore()))

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -495,7 +495,7 @@ def test_submission_creates_manager_review_queue_entry(monkeypatch) -> None:
 
 
 def test_manager_review_decision_updates_status_and_history(monkeypatch) -> None:
-    _set_runtime_env(monkeypatch)
+    _set_bootstrap_runtime_env(monkeypatch)
     store = PlannerProposalStore()
     client = TestClient(create_app(store))
 
@@ -510,22 +510,38 @@ def test_manager_review_decision_updates_status_and_history(monkeypatch) -> None
     assert draft_match is not None
     draft_id = draft_match.group(1)
 
+    traveler_token = mint_bootstrap_token(
+        subject="traveler",
+        permissions=(Permission.CREATE,),
+        provider="google",
+        secret="bootstrap-secret-123",
+        expires_in_seconds=600,
+    )
+
     client.post(
         f"/portal/review/{draft_id}/submit",
-        headers=AUTH_HEADER,
+        headers={"Authorization": f"Bearer {traveler_token}"},
         follow_redirects=True,
     )
     review = store.lookup_manager_review_for_draft(draft_id)
     assert review is not None
 
+    manager_token = mint_bootstrap_token(
+        subject="manager-reviewer",
+        permissions=(Permission.VIEW, Permission.APPROVE),
+        provider="google",
+        secret="bootstrap-secret-123",
+        expires_in_seconds=600,
+    )
+
     decision = client.post(
         f"/portal/manager/reviews/{review.review_id}/decision",
+        headers={"Authorization": f"Bearer {manager_token}"},
         data={
             "actor_id": "manager-17",
             "action": "request_changes",
             "rationale": "Need a clearer justification before approval.",
         },
-        headers=AUTH_HEADER,
         follow_redirects=True,
     )
 
@@ -537,6 +553,121 @@ def test_manager_review_decision_updates_status_and_history(monkeypatch) -> None
     assert updated.status.value == "changes_requested"
     assert updated.trip_plan.approval_history[-1].outcome.value == "flagged"
     assert updated.trip_plan.approval_history[-1].approver_id == "manager-17"
+
+
+def test_manager_review_routes_require_authorization(monkeypatch) -> None:
+    _set_runtime_env(monkeypatch)
+    store = PlannerProposalStore()
+    client = TestClient(create_app(store))
+
+    response = client.post(
+        "/portal/requests/review",
+        data=_portal_form_payload(),
+        follow_redirects=True,
+    )
+    draft_match = re.search(
+        r"/portal/requests/([^/]+)/artifacts/itinerary", response.text
+    )
+    assert draft_match is not None
+    draft_id = draft_match.group(1)
+    client.post(
+        f"/portal/requests/{draft_id}/submit",
+        headers=AUTH_HEADER,
+        follow_redirects=True,
+    )
+    review = store.lookup_manager_review_for_draft(draft_id)
+    assert review is not None
+
+    missing_queue = client.get("/portal/manager/reviews")
+    missing_detail = client.get(f"/portal/manager/reviews/{review.review_id}")
+    missing_decision = client.post(
+        f"/portal/manager/reviews/{review.review_id}/decision",
+        data={
+            "actor_id": "manager-17",
+            "action": "approve",
+            "rationale": "Looks good.",
+        },
+    )
+
+    assert missing_queue.status_code == 401
+    assert missing_detail.status_code == 401
+    assert missing_decision.status_code == 401
+
+
+def test_manager_review_decision_requires_approve_permission(monkeypatch) -> None:
+    _set_bootstrap_runtime_env(monkeypatch)
+    store = PlannerProposalStore()
+    client = TestClient(create_app(store))
+
+    response = client.post(
+        "/portal/requests/review",
+        data=_portal_form_payload(),
+        follow_redirects=True,
+    )
+    draft_match = re.search(
+        r"/portal/requests/([^/]+)/artifacts/itinerary", response.text
+    )
+    assert draft_match is not None
+    draft_id = draft_match.group(1)
+    client.post(
+        f"/portal/requests/{draft_id}/submit",
+        headers={
+            "Authorization": "Bearer "
+            + mint_bootstrap_token(
+                subject="traveler",
+                permissions=(Permission.CREATE,),
+                provider="google",
+                secret="bootstrap-secret-123",
+                expires_in_seconds=600,
+            )
+        },
+        follow_redirects=True,
+    )
+    review = store.lookup_manager_review_for_draft(draft_id)
+    assert review is not None
+
+    viewer_token = mint_bootstrap_token(
+        subject="viewer-only",
+        permissions=(Permission.VIEW,),
+        provider="google",
+        secret="bootstrap-secret-123",
+        expires_in_seconds=600,
+    )
+    decision = client.post(
+        f"/portal/manager/reviews/{review.review_id}/decision",
+        headers={"Authorization": f"Bearer {viewer_token}"},
+        data={
+            "actor_id": "manager-17",
+            "action": "approve",
+            "rationale": "Looks good.",
+        },
+    )
+
+    assert decision.status_code == 403
+    assert "does not grant 'approve'" in decision.json()["detail"]
+
+
+def test_manager_review_store_returns_copies() -> None:
+    store = PlannerProposalStore()
+    fixture = _load_fixture("proposal_submission.json")
+    trip_plan = http_service.TripPlan.model_validate(fixture)
+    snapshot = http_service.get_policy_snapshot(trip_plan)
+    result = http_service.check_trip_plan(trip_plan)
+
+    created = store.manager_reviews.create_or_get(
+        draft_id="draft-123",
+        trip_plan=trip_plan,
+        policy_snapshot=snapshot,
+        policy_result=result,
+    )
+    created.trip_plan.traveler_name = "Mutated"
+
+    listed = store.manager_reviews.list_reviews()
+    listed[0].trip_plan.traveler_name = "Mutated Again"
+
+    lookup = store.lookup_manager_review(created.review_id)
+    assert lookup is not None
+    assert lookup.trip_plan.traveler_name == fixture["traveler_name"]
 
 
 def test_portal_artifact_downloads_use_cached_review_artifacts(monkeypatch) -> None:

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -320,7 +320,9 @@ def test_portal_draft_validation_returns_bad_request_without_saving() -> None:
 
     assert response.status_code == 400
     assert 'data-template="validation-feedback"' in response.text
-    assert "Complete the missing details before this draft can be saved." in response.text
+    assert (
+        "Complete the missing details before this draft can be saved." in response.text
+    )
     assert store.portal_drafts_by_id == {}
     assert re.search(
         r'<ul class="missing-fields">.*?<li><code>destination_zip</code></li>',
@@ -330,7 +332,9 @@ def test_portal_draft_validation_returns_bad_request_without_saving() -> None:
     assert "Where are you headed and what" in response.text
 
 
-def test_portal_draft_validation_rejects_invalid_present_payload_without_saving() -> None:
+def test_portal_draft_validation_rejects_invalid_present_payload_without_saving() -> (
+    None
+):
     store = PlannerProposalStore()
     client = TestClient(create_app(store))
     payload = _portal_form_payload()
@@ -477,7 +481,7 @@ def test_submission_creates_manager_review_queue_entry(monkeypatch) -> None:
     )
 
     assert submit.status_code == 200
-    assert "Manager review lane" in submit.text
+    assert "Submission result" in submit.text
     review = store.lookup_manager_review_for_draft(draft_id)
     assert review is not None
     queue = client.get("/portal/manager/reviews", headers=AUTH_HEADER)
@@ -736,7 +740,9 @@ def test_portal_artifacts_raise_runtime_error_without_bundle_mappings(
     monkeypatch,
 ) -> None:
     _set_runtime_env(monkeypatch)
-    client = TestClient(create_app(PlannerProposalStore()), raise_server_exceptions=False)
+    client = TestClient(
+        create_app(PlannerProposalStore()), raise_server_exceptions=False
+    )
 
     def invalid_bundle(**_kwargs):
         return {"itinerary_excel": "bad", "summary_pdf": "bad"}

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -561,17 +561,17 @@ def test_manager_review_routes_require_authorization(monkeypatch) -> None:
     client = TestClient(create_app(store))
 
     response = client.post(
-        "/portal/requests/review",
+        "/portal/draft",
         data=_portal_form_payload(),
         follow_redirects=True,
     )
     draft_match = re.search(
-        r"/portal/requests/([^/]+)/artifacts/itinerary", response.text
+        r"/portal/review/([^/]+)/artifacts/itinerary", response.text
     )
     assert draft_match is not None
     draft_id = draft_match.group(1)
     client.post(
-        f"/portal/requests/{draft_id}/submit",
+        f"/portal/review/{draft_id}/submit",
         headers=AUTH_HEADER,
         follow_redirects=True,
     )
@@ -600,17 +600,17 @@ def test_manager_review_decision_requires_approve_permission(monkeypatch) -> Non
     client = TestClient(create_app(store))
 
     response = client.post(
-        "/portal/requests/review",
+        "/portal/draft",
         data=_portal_form_payload(),
         follow_redirects=True,
     )
     draft_match = re.search(
-        r"/portal/requests/([^/]+)/artifacts/itinerary", response.text
+        r"/portal/review/([^/]+)/artifacts/itinerary", response.text
     )
     assert draft_match is not None
     draft_id = draft_match.group(1)
     client.post(
-        f"/portal/requests/{draft_id}/submit",
+        f"/portal/review/{draft_id}/submit",
         headers={
             "Authorization": "Bearer "
             + mint_bootstrap_token(

--- a/tests/python/test_package_data.py
+++ b/tests/python/test_package_data.py
@@ -21,10 +21,17 @@ def test_portal_template_resources_exist() -> None:
     templates = resources.files("travel_plan_permission").joinpath("templates")
     home = templates.joinpath("portal_home.html")
     request = templates.joinpath("portal_request.html")
+    queue = templates.joinpath("manager_review_queue.html")
+    detail = templates.joinpath("manager_review_detail.html")
 
     assert home.is_file()
     assert "Travel Request Portal" in home.read_text(encoding="utf-8")
     assert request.is_file()
-    assert "Draft a travel request through the real service runtime." in request.read_text(
-        encoding="utf-8"
+    assert (
+        "Draft a travel request through the real service runtime."
+        in request.read_text(encoding="utf-8")
     )
+    assert queue.is_file()
+    assert "Manager review queue" in queue.read_text(encoding="utf-8")
+    assert detail.is_file()
+    assert "Manager review detail" in detail.read_text(encoding="utf-8")


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #799

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The repo models approvals, policy outcomes, and security concepts, but it still
lacks a concrete persisted review workflow that moves a request through manager
and board/approver decisions. That is the main missing bridge between the
current library/service surface and the intended travel workflow product.

#### Tasks
- [ ] Introduce persisted workflow/request-review state for itinerary approval steps and decision history
- [ ] Add manager review queue and detail views with decision actions, rationale capture, and current policy posture summaries
- [ ] Surface approval requirements and exception indicators from the existing domain layer in the review UI
- [ ] Record review decisions in a durable audit/history model rather than transient service-only responses
- [ ] Add tests covering request state transitions, manager decision actions, and rendered review summaries
- [ ] Update docs to describe the delivered itinerary approval workflow and its current boundaries

#### Acceptance criteria
- [ ] A submitted request can move through a persisted manager review workflow with visible current status
- [ ] Reviewers can approve, reject, or request changes through a real UI backed by durable state
- [ ] Decision history and rationale are retained and test-covered
- [ ] The delivered workflow matches the documented Stage 1/2 scope

**Head SHA:** d379dc0b8895b19b761e046b4bf3e48634284848
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| .github/workflows/autofix.yml | ❌ failure | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24451103128) |
| .github/workflows/ci.yml | ❌ failure | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24451102813) |
| .github/workflows/claude-code-review.yml | ❌ failure | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24451102598) |
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24451732070) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24451732012) |
| Claude Code Review (Opt-in) | ✅ success | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24451105131) |
| Dependabot Auto-merge | ⏭️ skipped | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24451104598) |
| Gate | ✅ success | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24451105402) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24451105167) |
<!-- auto-status-summary:end -->