### PR TITLE
Issue #799: persist manager review workflow state

### DIFF
--- a/docs/approval-workflow.md
+++ b/docs/approval-workflow.md
@@ -69,3 +69,14 @@ Approval packets package the trip summary, policy status, cost breakdown, and a 
 - `TripPlan.record_approval_decision` enforces justification text for override outcomes.
 - Approval history entries are frozen Pydantic models and stored as tuples to prevent mutation.
 - PDFs include the justification column to preserve override rationale for auditing.
+
+## Manager review portal workflow
+
+The browser portal now promotes submitted drafts into a durable manager review queue:
+
+- Portal submit creates a persisted review record keyed by the planner execution id.
+- Review records keep the trip summary, policy snapshot, evaluation result, and decision history.
+- Managers work from `/portal/manager/reviews` and record `approve`, `request_changes`, or
+  `reject` decisions with rationale text.
+- Approved and rejected decisions also append immutable `TripPlan.approval_history` entries so
+  the queue state and trip audit trail stay aligned.

--- a/docs/audit-trail.md
+++ b/docs/audit-trail.md
@@ -18,6 +18,9 @@ Each snapshot is stored as a compact JSON document (`<trip_id>/<timestamp>.json`
 
 - Snapshots are written whenever an approval decision is recorded (approved, rejected, flagged, or overridden) when a `ValidationSnapshotStore` is provided.
 - Captures include the exact validation results used for the decision; if they are missing, the policy validator is run automatically before writing the snapshot.
+- Manager queue decisions also persist a separate file-backed review record containing the
+  manager rationale, queue status, and latest planner evaluation context so request review can be
+  resumed outside transient service memory.
 
 ## Storage and integrity
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -7,6 +7,10 @@ Draft → Employee Submit → Manager Review → Board Secretary Review → Appr
 
 Branches: Request Changes, Reject. No delegation/escalation in Stage 1–2.
 
+Current local portal/runtime support now persists the submitted manager-review queue to a
+file-backed workflow store, exposes a manager queue/detail surface under `/portal/manager/reviews`,
+and records rationale-backed approve/request-changes/reject decisions against the request.
+
 ## Expense (Stage 2)
 
 Collecting Receipts → Employee Submit → Manager Review → Accounting Review

--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -36,6 +36,11 @@ from .policy_api import (
     submit_proposal,
 )
 from .prompt_flow import build_output_bundle, generate_questions, required_field_gaps
+from .review_workflow import (
+    ManagerReviewDecision,
+    ManagerReviewRecord,
+    ReviewWorkflowStore,
+)
 from .security import Permission
 
 _OPTIONAL_SNAPSHOT_BODY = Body(default=None)
@@ -170,6 +175,7 @@ class PortalReviewState:
     policy_result: Any | None
     artifacts: dict[str, PortalArtifact]
     submission_response: PlannerProposalOperationResponse | None = None
+    manager_review: ManagerReviewRecord | None = None
 
 
 class PlannerRuntimeConfigError(RuntimeError):
@@ -297,6 +303,7 @@ class PlannerProposalStore:
     plans_by_trip_id: dict[str, TripPlan] = field(default_factory=dict)
     proposals_by_execution_id: dict[str, StoredProposal] = field(default_factory=dict)
     portal_drafts_by_id: dict[str, PortalDraft] = field(default_factory=dict)
+    review_store: ReviewWorkflowStore = field(default_factory=ReviewWorkflowStore)
 
     def remember_plan(self, trip_plan: TripPlan) -> None:
         """Store the latest planner trip payload by trip identifier."""
@@ -387,6 +394,54 @@ class PlannerProposalStore:
             answers=dict(draft.answers),
             updated_at=draft.updated_at,
             cached_artifacts=dict(draft.cached_artifacts),
+        )
+
+    def create_manager_review(
+        self,
+        *,
+        draft_id: str,
+        portal_answers: dict[str, object],
+        trip_plan: TripPlan,
+        policy_snapshot: PlannerPolicySnapshot,
+        evaluation_result: PlannerProposalEvaluationResult,
+        submission_response: PlannerProposalOperationResponse,
+    ) -> ManagerReviewRecord:
+        """Persist a durable manager-review record for a submitted request."""
+
+        return self.review_store.create_record(
+            draft_id=draft_id,
+            portal_answers=portal_answers,
+            trip_plan=trip_plan,
+            policy_snapshot=policy_snapshot,
+            evaluation_result=evaluation_result,
+            submission_response=submission_response,
+        )
+
+    def lookup_manager_review(self, request_id: str) -> ManagerReviewRecord | None:
+        """Return a persisted manager-review record by identifier."""
+
+        return self.review_store.get_record(request_id)
+
+    def list_manager_reviews(self) -> list[ManagerReviewRecord]:
+        """Return the durable manager-review queue."""
+
+        return self.review_store.list_records()
+
+    def record_manager_review_decision(
+        self,
+        request_id: str,
+        *,
+        decision: ManagerReviewDecision,
+        reviewer_id: str,
+        rationale: str,
+    ) -> ManagerReviewRecord:
+        """Apply a manager decision to a persisted review record."""
+
+        return self.review_store.record_manager_decision(
+            request_id,
+            decision=decision,
+            reviewer_id=reviewer_id,
+            rationale=rationale,
         )
 
 
@@ -548,6 +603,7 @@ def _portal_review_state(
     answers: dict[str, object],
     *,
     submission_response: PlannerProposalOperationResponse | None = None,
+    manager_review: ManagerReviewRecord | None = None,
 ) -> PortalReviewState:
     missing_fields = required_field_gaps(answers, required_fields=_PORTAL_REQUIRED_FIELDS)
     next_questions: list[dict[str, object]] = [
@@ -596,6 +652,7 @@ def _portal_review_state(
         policy_result=policy_result,
         artifacts=artifacts,
         submission_response=submission_response,
+        manager_review=manager_review,
     )
 
 
@@ -637,7 +694,11 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         return _TEMPLATES.TemplateResponse(
             request=request,
             name="portal_home.html",
-            context={"service_ready": _readiness_response().status == "ready"},
+            context={
+                "request": request,
+                "service_ready": _readiness_response().status == "ready",
+                "manager_review_count": len(proposal_store.list_manager_reviews()),
+            },
         )
 
     @app.get("/portal/requests/new", response_class=HTMLResponse)
@@ -714,15 +775,108 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
             submission_request,
             submission_response,
         )
+        execution_id = str(submission_response.result_payload["execution_id"])
+        stored_submission = proposal_store.lookup_submission(execution_id)
+        assert stored_submission is not None
+        evaluation_result = get_evaluation_result(
+            stored_submission.trip_plan,
+            _evaluation_request(stored_submission, execution_id=execution_id),
+        )
+        manager_review = proposal_store.create_manager_review(
+            draft_id=draft_id,
+            portal_answers=draft.answers,
+            trip_plan=stored_submission.trip_plan,
+            policy_snapshot=review.policy_snapshot,
+            evaluation_result=evaluation_result,
+            submission_response=submission_response,
+        )
         review = _portal_review_state(
             draft.draft_id,
             draft.answers,
             submission_response=submission_response,
+            manager_review=manager_review,
         )
         return _TEMPLATES.TemplateResponse(
             request=request,
             name="portal_request.html",
             context=_portal_template_context(request, review),
+        )
+
+    @app.get("/portal/manager/reviews", response_class=HTMLResponse)
+    def portal_manager_review_queue(request: Request) -> HTMLResponse:
+        return _TEMPLATES.TemplateResponse(
+            request=request,
+            name="portal_manager_queue.html",
+            context={
+                "request": request,
+                "reviews": proposal_store.list_manager_reviews(),
+            },
+        )
+
+    @app.get(
+        "/portal/manager/reviews/{request_id}",
+        response_class=HTMLResponse,
+        name="portal_manager_review_detail",
+    )
+    def portal_manager_review_detail(request: Request, request_id: str) -> HTMLResponse:
+        review_record = proposal_store.lookup_manager_review(request_id)
+        if review_record is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"No manager review found for '{request_id}'.",
+            )
+        return _TEMPLATES.TemplateResponse(
+            request=request,
+            name="portal_manager_review.html",
+            context={"request": request, "review_record": review_record},
+        )
+
+    @app.post("/portal/manager/reviews/{request_id}/decision")
+    async def portal_manager_review_decision(
+        request: Request,
+        request_id: str,
+        authorization: str | None = Header(default=None),
+    ) -> RedirectResponse:
+        _authorize_request(
+            authorization,
+            required_permission=Permission.APPROVE,
+        )
+        parsed = parse_qs((await request.body()).decode("utf-8"), keep_blank_values=True)
+        reviewer_id = parsed.get("reviewer_id", [""])[-1].strip()
+        rationale = parsed.get("rationale", [""])[-1].strip()
+        decision_raw = parsed.get("decision", [""])[-1].strip()
+        if not reviewer_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Manager reviewer_id is required.",
+            )
+        try:
+            decision = ManagerReviewDecision(decision_raw)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Unsupported manager decision '{decision_raw}'.",
+            ) from exc
+        try:
+            proposal_store.record_manager_review_decision(
+                request_id,
+                decision=decision,
+                reviewer_id=reviewer_id,
+                rationale=rationale,
+            )
+        except KeyError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"No manager review found for '{request_id}'.",
+            ) from exc
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=str(exc),
+            ) from exc
+        return RedirectResponse(
+            url=request.url_for("portal_manager_review_detail", request_id=request_id),
+            status_code=status.HTTP_303_SEE_OTHER,
         )
 
     @app.get("/portal/requests/{draft_id}/artifacts/{artifact_name}")

--- a/src/travel_plan_permission/review_workflow.py
+++ b/src/travel_plan_permission/review_workflow.py
@@ -1,0 +1,209 @@
+"""Durable manager-review workflow records for portal-submitted requests."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime
+from enum import StrEnum
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+from .models import ApprovalOutcome, TripPlan
+from .policy_api import (
+    PlannerBlockingIssue,
+    PlannerExceptionRequirement,
+    PlannerPolicySnapshot,
+    PlannerProposalEvaluationResult,
+    PlannerProposalOperationResponse,
+)
+
+
+class ManagerReviewStatus(StrEnum):
+    """Lifecycle states for the persisted manager review workflow."""
+
+    PENDING = "pending_manager_review"
+    CHANGES_REQUESTED = "changes_requested"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+
+
+class ManagerReviewDecision(StrEnum):
+    """Manager actions supported by the review workflow."""
+
+    APPROVE = "approve"
+    REQUEST_CHANGES = "request_changes"
+    REJECT = "reject"
+
+
+class ManagerReviewHistoryEntry(BaseModel):
+    """Immutable audit entry for a manager decision."""
+
+    decision: ManagerReviewDecision
+    reviewer_id: str = Field(..., min_length=1)
+    rationale: str = Field(..., min_length=5)
+    decided_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    resulting_status: ManagerReviewStatus
+
+
+class ManagerReviewRecord(BaseModel):
+    """Persisted request-review state for manager queue and detail views."""
+
+    request_id: str
+    draft_id: str
+    trip_id: str
+    traveler_name: str
+    business_purpose: str
+    destination: str
+    submitted_at: datetime
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    status: ManagerReviewStatus = ManagerReviewStatus.PENDING
+    current_reviewer: str = "manager"
+    portal_answers: dict[str, object] = Field(default_factory=dict)
+    trip_plan: TripPlan
+    policy_snapshot: PlannerPolicySnapshot
+    evaluation_result: PlannerProposalEvaluationResult
+    submission_response: PlannerProposalOperationResponse
+    history: list[ManagerReviewHistoryEntry] = Field(default_factory=list)
+
+
+class ReviewWorkflowStore:
+    """File-backed store for portal-submitted manager review records."""
+
+    def __init__(self, base_path: Path | None = None) -> None:
+        default_root = Path(
+            os.getenv("TPP_REVIEW_STORE_PATH", Path.cwd() / ".data" / "review-workflow")
+        )
+        self.base_path = Path(base_path) if base_path is not None else default_root
+        self.base_path.mkdir(parents=True, exist_ok=True)
+
+    def _record_path(self, request_id: str) -> Path:
+        return self.base_path / f"{request_id}.json"
+
+    def _write_record(self, record: ManagerReviewRecord) -> None:
+        path = self._record_path(record.request_id)
+        payload = json.dumps(record.model_dump(mode="json"), indent=2, sort_keys=True)
+        tmp_path = path.with_suffix(".tmp")
+        tmp_path.write_text(payload, encoding="utf-8")
+        tmp_path.replace(path)
+
+    def save_record(self, record: ManagerReviewRecord) -> ManagerReviewRecord:
+        """Persist a manager review record to disk."""
+
+        saved = record.model_copy(update={"updated_at": datetime.now(UTC)}, deep=True)
+        self._write_record(saved)
+        return saved
+
+    def create_record(
+        self,
+        *,
+        draft_id: str,
+        portal_answers: dict[str, object],
+        trip_plan: TripPlan,
+        policy_snapshot: PlannerPolicySnapshot,
+        evaluation_result: PlannerProposalEvaluationResult,
+        submission_response: PlannerProposalOperationResponse,
+    ) -> ManagerReviewRecord:
+        """Create and persist a new manager review record for a submitted draft."""
+
+        destination = trip_plan.destination_city or trip_plan.destination
+        record = ManagerReviewRecord(
+            request_id=evaluation_result.execution_id,
+            draft_id=draft_id,
+            trip_id=trip_plan.trip_id,
+            traveler_name=trip_plan.traveler_name,
+            business_purpose=trip_plan.purpose,
+            destination=destination,
+            submitted_at=datetime.now(UTC),
+            portal_answers=dict(portal_answers),
+            trip_plan=trip_plan.model_copy(deep=True),
+            policy_snapshot=policy_snapshot.model_copy(deep=True),
+            evaluation_result=evaluation_result.model_copy(deep=True),
+            submission_response=submission_response.model_copy(deep=True),
+        )
+        return self.save_record(record)
+
+    def get_record(self, request_id: str) -> ManagerReviewRecord | None:
+        """Load a persisted manager review record by identifier."""
+
+        path = self._record_path(request_id)
+        if not path.exists():
+            return None
+        return ManagerReviewRecord.model_validate_json(path.read_text(encoding="utf-8"))
+
+    def list_records(self) -> list[ManagerReviewRecord]:
+        """Return persisted manager review records sorted by update time descending."""
+
+        records = [
+            ManagerReviewRecord.model_validate_json(path.read_text(encoding="utf-8"))
+            for path in sorted(self.base_path.glob("*.json"))
+        ]
+        return sorted(records, key=lambda record: record.updated_at, reverse=True)
+
+    def record_manager_decision(
+        self,
+        request_id: str,
+        *,
+        decision: ManagerReviewDecision,
+        reviewer_id: str,
+        rationale: str,
+    ) -> ManagerReviewRecord:
+        """Apply a manager decision, update trip approval history, and persist it."""
+
+        record = self.get_record(request_id)
+        if record is None:
+            raise KeyError(request_id)
+
+        rationale_text = rationale.strip()
+        if len(rationale_text) < 5:
+            raise ValueError("Manager decisions require rationale text.")
+
+        if decision == ManagerReviewDecision.APPROVE:
+            status = ManagerReviewStatus.APPROVED
+            record.trip_plan.record_approval_decision(
+                approver_id=reviewer_id,
+                level="manager",
+                outcome=ApprovalOutcome.APPROVED,
+                justification=rationale_text,
+            )
+        elif decision == ManagerReviewDecision.REJECT:
+            status = ManagerReviewStatus.REJECTED
+            record.trip_plan.record_approval_decision(
+                approver_id=reviewer_id,
+                level="manager",
+                outcome=ApprovalOutcome.REJECTED,
+                justification=rationale_text,
+            )
+        else:
+            status = ManagerReviewStatus.CHANGES_REQUESTED
+            record.trip_plan.record_approval_decision(
+                approver_id=reviewer_id,
+                level="manager",
+                outcome=ApprovalOutcome.FLAGGED,
+            )
+
+        history_entry = ManagerReviewHistoryEntry(
+            decision=decision,
+            reviewer_id=reviewer_id.strip(),
+            rationale=rationale_text,
+            resulting_status=status,
+        )
+        updated = record.model_copy(
+            update={
+                "status": status,
+                "history": [*record.history, history_entry],
+                "trip_plan": record.trip_plan,
+            },
+            deep=True,
+        )
+        return self.save_record(updated)
+
+
+__all__ = [
+    "ManagerReviewDecision",
+    "ManagerReviewHistoryEntry",
+    "ManagerReviewRecord",
+    "ManagerReviewStatus",
+    "ReviewWorkflowStore",
+]

--- a/src/travel_plan_permission/templates/portal_home.html
+++ b/src/travel_plan_permission/templates/portal_home.html
@@ -120,6 +120,7 @@
         </p>
         <div class="actions">
           <a class="button primary" href="/portal/requests/new">Start a new request</a>
+          <a class="button secondary" href="/portal/manager/reviews">Open manager queue</a>
           <a class="button secondary" href="/readyz">Check runtime readiness</a>
         </div>
       </section>
@@ -145,6 +146,17 @@
           <p style="margin-top: 12px;">
             The portal shell is available without planner credentials; the lower-level planner
             API still follows the normal token requirements.
+          </p>
+        </article>
+        <article class="panel">
+          <div class="eyebrow">Manager Workflow</div>
+          <h2>Durable review queue</h2>
+          <p>
+            <span class="status">{{ manager_review_count }} request{% if manager_review_count != 1 %}s{% endif %} tracked</span>
+          </p>
+          <p style="margin-top: 12px;">
+            Submitted portal requests now land in a persisted manager queue with rationale-backed
+            approve, request-changes, and reject actions.
           </p>
         </article>
       </section>

--- a/src/travel_plan_permission/templates/portal_manager_queue.html
+++ b/src/travel_plan_permission/templates/portal_manager_queue.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Manager Review Queue</title>
+    <style>
+      :root {
+        --ink: #132532;
+        --muted: #5d7280;
+        --paper: rgba(255, 255, 255, 0.9);
+        --line: rgba(19, 37, 50, 0.12);
+        --accent: #0c6b5d;
+        --warn: #b25a24;
+        --bg: linear-gradient(140deg, #edf2ec 0%, #dce7ef 100%);
+        --shadow: 0 24px 58px rgba(19, 37, 50, 0.12);
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        font-family: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, serif;
+        color: var(--ink);
+        background: var(--bg);
+      }
+      main { max-width: 1100px; margin: 0 auto; padding: 36px 18px 72px; }
+      a { color: inherit; }
+      .topbar, .card, table {
+        background: var(--paper);
+        border: 1px solid var(--line);
+        border-radius: 24px;
+        box-shadow: var(--shadow);
+      }
+      .topbar { padding: 24px; display: grid; gap: 12px; margin-bottom: 22px; }
+      .actions { display: flex; gap: 12px; flex-wrap: wrap; }
+      .button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 12px 16px;
+        border-radius: 999px;
+        border: 1px solid var(--line);
+        background: white;
+        text-decoration: none;
+        font-weight: 700;
+      }
+      .button.primary { background: var(--ink); color: white; }
+      .card { padding: 0; overflow: hidden; }
+      table { width: 100%; border-collapse: collapse; overflow: hidden; }
+      th, td { padding: 16px 18px; text-align: left; vertical-align: top; }
+      th {
+        font: 600 0.78rem/1 ui-monospace, "SFMono-Regular", Menlo, monospace;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--muted);
+        border-bottom: 1px solid var(--line);
+      }
+      tr + tr td { border-top: 1px solid var(--line); }
+      .badge {
+        display: inline-flex;
+        padding: 6px 10px;
+        border-radius: 999px;
+        background: rgba(12, 107, 93, 0.12);
+        color: var(--accent);
+        font: 600 0.78rem/1 ui-monospace, "SFMono-Regular", Menlo, monospace;
+      }
+      .badge.warn {
+        background: rgba(178, 90, 36, 0.14);
+        color: var(--warn);
+      }
+      .muted { color: var(--muted); }
+      h1, p { margin: 0; }
+      h1 { font-size: clamp(2rem, 3.5vw, 3.5rem); letter-spacing: -0.03em; }
+      p { line-height: 1.55; color: var(--muted); }
+      code {
+        font: 0.84rem/1.4 ui-monospace, "SFMono-Regular", Menlo, monospace;
+        color: var(--ink);
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <section class="topbar">
+        <h1>Manager review queue</h1>
+        <p>Submitted travel requests now keep a durable approval queue with live policy posture and rationale-backed decision history.</p>
+        <div class="actions">
+          <a class="button primary" href="/portal/requests/new">Draft another request</a>
+          <a class="button" href="/portal">Back to portal home</a>
+        </div>
+      </section>
+
+      <section class="card">
+        <table>
+          <thead>
+            <tr>
+              <th>Traveler</th>
+              <th>Trip</th>
+              <th>Status</th>
+              <th>Policy posture</th>
+              <th>Decision history</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for review in reviews %}
+              <tr>
+                <td>
+                  <a href="/portal/manager/reviews/{{ review.request_id }}"><strong>{{ review.traveler_name }}</strong></a>
+                  <div class="muted">{{ review.trip_id }}</div>
+                </td>
+                <td>
+                  <div>{{ review.business_purpose }}</div>
+                  <div class="muted">{{ review.destination }}</div>
+                </td>
+                <td>
+                  <span class="badge {% if review.status.value != 'pending_manager_review' %}warn{% endif %}">{{ review.status.value }}</span>
+                </td>
+                <td>
+                  <div>{{ review.evaluation_result.outcome }}</div>
+                  <div class="muted">{{ review.policy_snapshot.policy_status }}</div>
+                </td>
+                <td>
+                  <div>{{ review.history | length }} decision{% if review.history|length != 1 %}s{% endif %}</div>
+                  <div class="muted">Updated {{ review.updated_at.strftime("%Y-%m-%d %H:%M UTC") }}</div>
+                </td>
+              </tr>
+            {% else %}
+              <tr>
+                <td colspan="5">
+                  <p>No manager review requests are queued yet.</p>
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </section>
+    </main>
+  </body>
+</html>

--- a/src/travel_plan_permission/templates/portal_manager_review.html
+++ b/src/travel_plan_permission/templates/portal_manager_review.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Manager Review Detail</title>
+    <style>
+      :root {
+        --ink: #112431;
+        --muted: #5a6f7d;
+        --paper: rgba(255, 255, 255, 0.9);
+        --line: rgba(17, 36, 49, 0.12);
+        --accent: #0f685a;
+        --warn: #b25a24;
+        --shadow: 0 26px 62px rgba(17, 36, 49, 0.14);
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        color: var(--ink);
+        font-family: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, serif;
+        background:
+          radial-gradient(circle at top right, rgba(15, 104, 90, 0.12), transparent 30%),
+          linear-gradient(135deg, #eef1ea 0%, #dde8ef 100%);
+      }
+      main { max-width: 1200px; margin: 0 auto; padding: 32px 18px 72px; }
+      .topbar, .panel {
+        background: var(--paper);
+        border: 1px solid var(--line);
+        border-radius: 24px;
+        box-shadow: var(--shadow);
+      }
+      .topbar { padding: 24px; margin-bottom: 20px; display: grid; gap: 14px; }
+      .layout {
+        display: grid;
+        gap: 20px;
+        grid-template-columns: minmax(0, 1fr) minmax(320px, 0.85fr);
+      }
+      .panel { padding: 22px; }
+      h1, h2, h3, p { margin: 0; }
+      h1 { font-size: clamp(2.2rem, 3.8vw, 3.8rem); letter-spacing: -0.03em; }
+      h2 { font-size: 1.25rem; }
+      h3 {
+        font: 700 0.78rem/1 ui-monospace, "SFMono-Regular", Menlo, monospace;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+      }
+      p, li { color: var(--muted); line-height: 1.55; }
+      ul { margin: 12px 0 0; padding-left: 18px; }
+      li + li { margin-top: 8px; }
+      .actions { display: flex; gap: 12px; flex-wrap: wrap; }
+      .button, button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 12px 16px;
+        border-radius: 999px;
+        border: 1px solid var(--line);
+        text-decoration: none;
+        background: white;
+        color: var(--ink);
+        font: 700 0.94rem/1 inherit;
+      }
+      button.primary { background: var(--ink); color: white; border-color: transparent; cursor: pointer; }
+      .badge {
+        display: inline-flex;
+        padding: 7px 12px;
+        border-radius: 999px;
+        background: rgba(15, 104, 90, 0.12);
+        color: var(--accent);
+        font: 600 0.8rem/1 ui-monospace, "SFMono-Regular", Menlo, monospace;
+      }
+      .badge.warn {
+        background: rgba(178, 90, 36, 0.14);
+        color: var(--warn);
+      }
+      .grid { display: grid; gap: 16px; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); }
+      .callout {
+        margin-top: 16px;
+        padding: 16px;
+        border-radius: 18px;
+        border: 1px solid var(--line);
+        background: rgba(255, 255, 255, 0.72);
+      }
+      form { display: grid; gap: 12px; margin-top: 14px; }
+      label { display: grid; gap: 6px; font-size: 0.95rem; }
+      input, textarea, select {
+        width: 100%;
+        border-radius: 14px;
+        border: 1px solid var(--line);
+        padding: 12px 14px;
+        font: inherit;
+      }
+      textarea { min-height: 120px; resize: vertical; }
+      pre {
+        margin: 0;
+        padding: 14px;
+        border-radius: 16px;
+        background: #122330;
+        color: #edf4f7;
+        overflow: auto;
+        font: 0.84rem/1.45 ui-monospace, "SFMono-Regular", Menlo, monospace;
+      }
+      @media (max-width: 920px) {
+        .layout { grid-template-columns: 1fr; }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <section class="topbar">
+        <div class="actions">
+          <a class="button" href="/portal/manager/reviews">Back to queue</a>
+          <a class="button" href="/portal">Portal home</a>
+        </div>
+        <h1>{{ review_record.traveler_name }}</h1>
+        <p>{{ review_record.business_purpose }} for {{ review_record.destination }}.</p>
+        <div class="actions">
+          <span class="badge {% if review_record.status.value != 'pending_manager_review' %}warn{% endif %}">{{ review_record.status.value }}</span>
+          <span class="badge {% if review_record.policy_snapshot.policy_status == 'fail' %}warn{% endif %}">policy {{ review_record.policy_snapshot.policy_status }}</span>
+          <span class="badge {% if review_record.evaluation_result.outcome != 'compliant' %}warn{% endif %}">{{ review_record.evaluation_result.outcome }}</span>
+        </div>
+      </section>
+
+      <div class="layout">
+        <section class="panel">
+          <h2>Review summary</h2>
+          <div class="grid" style="margin-top: 16px;">
+            <div class="callout">
+              <h3>Trip</h3>
+              <p><strong>{{ review_record.trip_id }}</strong></p>
+              <p>Submitted {{ review_record.submitted_at.strftime("%Y-%m-%d %H:%M UTC") }}</p>
+            </div>
+            <div class="callout">
+              <h3>Approval triggers</h3>
+              <ul>
+                {% for trigger in review_record.policy_snapshot.approval_triggers %}
+                  <li>{{ trigger.summary }}</li>
+                {% else %}
+                  <li>No approval triggers surfaced.</li>
+                {% endfor %}
+              </ul>
+            </div>
+            <div class="callout">
+              <h3>Blocking issues</h3>
+              <ul>
+                {% for issue in review_record.evaluation_result.blocking_issues %}
+                  <li>{{ issue.message }}</li>
+                {% else %}
+                  <li>No blocking issues are currently open.</li>
+                {% endfor %}
+              </ul>
+            </div>
+            <div class="callout">
+              <h3>Exception workflow</h3>
+              <ul>
+                {% for requirement in review_record.evaluation_result.exception_requirements %}
+                  <li>{{ requirement.summary }}</li>
+                {% else %}
+                  <li>No exception approvals are waiting.</li>
+                {% endfor %}
+              </ul>
+            </div>
+          </div>
+
+          <div class="callout">
+            <h3>Decision history</h3>
+            <ul>
+              {% for entry in review_record.history %}
+                <li>
+                  <strong>{{ entry.decision.value }}</strong> by {{ entry.reviewer_id }} on
+                  {{ entry.decided_at.strftime("%Y-%m-%d %H:%M UTC") }}: {{ entry.rationale }}
+                </li>
+              {% else %}
+                <li>No manager decisions recorded yet.</li>
+              {% endfor %}
+            </ul>
+          </div>
+
+          <div class="callout">
+            <h3>Latest submission contract</h3>
+            <pre>{{ review_record.submission_response.model_dump_json(indent=2) }}</pre>
+          </div>
+        </section>
+
+        <aside class="panel">
+          <h2>Record manager decision</h2>
+          <p style="margin-top: 10px;">Use a bootstrap token with <code>approve</code> permission when posting this decision route.</p>
+          <form method="post" action="/portal/manager/reviews/{{ review_record.request_id }}/decision">
+            <label>
+              Reviewer ID
+              <input name="reviewer_id" type="text" value="manager@example.edu" required />
+            </label>
+            <label>
+              Decision
+              <select name="decision" required>
+                <option value="approve">Approve</option>
+                <option value="request_changes">Request changes</option>
+                <option value="reject">Reject</option>
+              </select>
+            </label>
+            <label>
+              Rationale
+              <textarea name="rationale" required>Reviewed current policy posture and request context.</textarea>
+            </label>
+            <button class="primary" type="submit">Record decision</button>
+          </form>
+
+          <div class="callout">
+            <h3>Approval history snapshot</h3>
+            <ul>
+              {% for event in review_record.trip_plan.approval_history %}
+                <li>{{ event.level }} {{ event.outcome.value }} by {{ event.approver_id }}</li>
+              {% else %}
+                <li>No approval-history entries yet.</li>
+              {% endfor %}
+            </ul>
+          </div>
+        </aside>
+      </div>
+    </main>
+  </body>
+</html>

--- a/src/travel_plan_permission/templates/portal_request.html
+++ b/src/travel_plan_permission/templates/portal_request.html
@@ -457,6 +457,19 @@
               <h2>Submission result</h2>
               <p style="margin-top: 10px;">The proposal submission seam accepted the browser draft.</p>
               <pre>{{ review.submission_response.model_dump_json(indent=2) }}</pre>
+              {% if review.manager_review %}
+                <div class="callout" style="margin-top: 16px;">
+                  <h3>Manager review queue</h3>
+                  <p>
+                    Request <code>{{ review.manager_review.request_id }}</code> is now in the durable
+                    manager review queue with status <strong>{{ review.manager_review.status.value }}</strong>.
+                  </p>
+                  <div class="actions" style="margin-top: 14px;">
+                    <a class="button primary" href="/portal/manager/reviews/{{ review.manager_review.request_id }}">Open manager review</a>
+                    <a class="button secondary" href="/portal/manager/reviews">View queue</a>
+                  </div>
+                </div>
+              {% endif %}
             </section>
           {% endif %}
 

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -34,6 +34,28 @@ def _set_bootstrap_runtime_env(monkeypatch, *, provider: str = "google") -> None
     monkeypatch.setenv("TPP_BOOTSTRAP_SIGNING_SECRET", "bootstrap-secret-123")
 
 
+def _approve_header(*, provider: str = "google") -> dict[str, str]:
+    token = mint_bootstrap_token(
+        subject="manager-reviewer",
+        permissions=(Permission.VIEW, Permission.APPROVE),
+        provider=provider,
+        secret="bootstrap-secret-123",
+        expires_in_seconds=600,
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _create_header(*, provider: str = "google") -> dict[str, str]:
+    token = mint_bootstrap_token(
+        subject="portal-submit",
+        permissions=(Permission.VIEW, Permission.CREATE),
+        provider=provider,
+        secret="bootstrap-secret-123",
+        expires_in_seconds=600,
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
 def _portal_form_payload() -> dict[str, str]:
     return {
         "traveler_name": "Alex Rivera",
@@ -293,6 +315,7 @@ def test_portal_home_and_request_form_render() -> None:
 
     assert home.status_code == 200
     assert "Travel Request Portal" in home.text
+    assert "Open manager queue" in home.text
     assert form.status_code == 200
     assert "Draft a travel request through the real service runtime." in form.text
 
@@ -460,3 +483,63 @@ def test_portal_submit_requires_bearer_token(monkeypatch) -> None:
 
     assert submit.status_code == 401
     assert submit.json()["detail"] == "Missing bearer token."
+
+
+def test_portal_submission_creates_manager_review_queue_and_decision_flow(
+    monkeypatch, tmp_path: Path
+) -> None:
+    _set_bootstrap_runtime_env(monkeypatch)
+    monkeypatch.setenv("TPP_REVIEW_STORE_PATH", str(tmp_path / "review-store"))
+    client = TestClient(create_app(PlannerProposalStore()))
+
+    review_response = client.post(
+        "/portal/requests/review",
+        data=_portal_form_payload(),
+        follow_redirects=True,
+    )
+    assert review_response.status_code == 200
+    draft_match = re.search(r"/portal/requests/([^/]+)/artifacts/itinerary", review_response.text)
+    assert draft_match is not None
+    draft_id = draft_match.group(1)
+
+    submit = client.post(
+        f"/portal/requests/{draft_id}/submit",
+        headers=_create_header(),
+        follow_redirects=True,
+    )
+    assert submit.status_code == 200
+    assert "Manager review queue" in submit.text
+
+    request_match = re.search(r"/portal/manager/reviews/([a-z0-9-]+)", submit.text)
+    assert request_match is not None
+    request_id = request_match.group(1)
+
+    queue = client.get("/portal/manager/reviews")
+    assert queue.status_code == 200
+    assert "pending_manager_review" in queue.text
+    assert "Regional partner summit" in queue.text
+
+    detail = client.get(f"/portal/manager/reviews/{request_id}")
+    assert detail.status_code == 200
+    assert "Record manager decision" in detail.text
+    assert "No manager decisions recorded yet." in detail.text
+
+    decision = client.post(
+        f"/portal/manager/reviews/{request_id}/decision",
+        headers=_approve_header(),
+        data={
+            "reviewer_id": "manager@example.edu",
+            "decision": "request_changes",
+            "rationale": "Need a short explanation for the hotel price delta.",
+        },
+        follow_redirects=True,
+    )
+    assert decision.status_code == 200
+    assert "changes_requested" in decision.text
+    assert "Need a short explanation for the hotel price delta." in decision.text
+
+    stored_record = Path(tmp_path / "review-store" / f"{request_id}.json")
+    assert stored_record.exists()
+    stored_payload = json.loads(stored_record.read_text(encoding="utf-8"))
+    assert stored_payload["status"] == "changes_requested"
+    assert stored_payload["history"][0]["decision"] == "request_changes"

--- a/tests/python/test_review_workflow.py
+++ b/tests/python/test_review_workflow.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from travel_plan_permission.canonical import load_trip_plan_input
+from travel_plan_permission.policy_api import (
+    PlannerPolicySnapshotRequest,
+    PlannerProposalEvaluationRequest,
+    PlannerProposalSubmissionRequest,
+    get_evaluation_result,
+    get_policy_snapshot,
+    submit_proposal,
+)
+from travel_plan_permission.review_workflow import (
+    ManagerReviewDecision,
+    ManagerReviewStatus,
+    ReviewWorkflowStore,
+)
+
+
+def _load_trip_plan() -> tuple[dict[str, object], object]:
+    fixture_path = (
+        Path(__file__).resolve().parents[1]
+        / "fixtures"
+        / "planner_integration"
+        / "proposal_submission.json"
+    )
+    payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    trip_input = load_trip_plan_input(payload)
+    return payload, trip_input.plan
+
+
+def test_review_workflow_store_persists_and_reloads_manager_decisions(tmp_path: Path) -> None:
+    _, trip_plan = _load_trip_plan()
+    policy_snapshot = get_policy_snapshot(
+        trip_plan,
+        PlannerPolicySnapshotRequest(trip_id=trip_plan.trip_id),
+    )
+    submission_request = PlannerProposalSubmissionRequest(
+        trip_id=trip_plan.trip_id,
+        proposal_id=f"{trip_plan.trip_id.lower()}-portal-request",
+        proposal_version="portal-v1",
+        payload={"channel": "workflow-portal"},
+    )
+    submission_response = submit_proposal(trip_plan, submission_request)
+    execution_id = str(submission_response.result_payload["execution_id"])
+    evaluation_result = get_evaluation_result(
+        trip_plan,
+        PlannerProposalEvaluationRequest(
+            trip_id=trip_plan.trip_id,
+            proposal_id=submission_request.proposal_id,
+            proposal_version=submission_request.proposal_version,
+            execution_id=execution_id,
+        ),
+    )
+
+    store = ReviewWorkflowStore(tmp_path / "reviews")
+    created = store.create_record(
+        draft_id="draft-123",
+        portal_answers={"traveler_name": trip_plan.traveler_name},
+        trip_plan=trip_plan,
+        policy_snapshot=policy_snapshot,
+        evaluation_result=evaluation_result,
+        submission_response=submission_response,
+    )
+
+    assert created.status == ManagerReviewStatus.PENDING
+    assert (tmp_path / "reviews" / f"{created.request_id}.json").exists()
+
+    updated = store.record_manager_decision(
+        created.request_id,
+        decision=ManagerReviewDecision.APPROVE,
+        reviewer_id="manager@example.edu",
+        rationale="Policy posture is acceptable for the current budget and routing.",
+    )
+
+    assert updated.status == ManagerReviewStatus.APPROVED
+    assert len(updated.history) == 1
+    assert updated.trip_plan.approval_history[-1].outcome.value == "approved"
+
+    reloaded = store.get_record(created.request_id)
+    assert reloaded is not None
+    assert reloaded.status == ManagerReviewStatus.APPROVED
+    assert reloaded.history[0].reviewer_id == "manager@example.edu"


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #799

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The repo models approvals, policy outcomes, and security concepts, but it still
lacks a concrete persisted review workflow that moves a request through manager
and board/approver decisions. That is the main missing bridge between the
current library/service surface and the intended travel workflow product.

#### Tasks
- [ ] Introduce persisted workflow/request-review state for itinerary approval steps and decision history
- [ ] Add manager review queue and detail views with decision actions, rationale capture, and current policy posture summaries
- [ ] Surface approval requirements and exception indicators from the existing domain layer in the review UI
- [ ] Record review decisions in a durable audit/history model rather than transient service-only responses
- [ ] Add tests covering request state transitions, manager decision actions, and rendered review summaries
- [ ] Update docs to describe the delivered itinerary approval workflow and its current boundaries

#### Acceptance criteria
- [ ] A submitted request can move through a persisted manager review workflow with visible current status
- [ ] Reviewers can approve, reject, or request changes through a real UI backed by durable state
- [ ] Decision history and rationale are retained and test-covered
- [ ] The delivered workflow matches the documented Stage 1/2 scope

**Head SHA:** 2ab37c2155348b78aa19d174a027ecbba14b8b5c
**Latest Runs:** ❌ failure — Gate
**Required:** gate: ❌ failure

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| .github/workflows/autofix.yml | ❌ failure | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24446249139) |
| .github/workflows/ci.yml | ❌ failure | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24446248595) |
| .github/workflows/claude-code-review.yml | ❌ failure | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24446248837) |
| Agents Auto-Pilot | ⏭️ skipped | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24446264054) |
| Agents Bot Comment Handler | ⏹️ cancelled | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24446264492) |
| Agents Gate Followups | ⏹️ cancelled | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24446264532) |
| Agents Keepalive Loop | ⏹️ cancelled | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24446264513) |
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24446358626) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24446358631) |
| Agents Verifier | ✅ success | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24446264483) |
| Claude Code Review (Opt-in) | ✅ success | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24446264318) |
| Copilot code review | ❔ in progress | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24446263771) |
| Create Issue from Verification (DEPRECATED) | ⏭️ skipped | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24446264230) |
| Create Issue from Verification (Enhanced) | ⏭️ skipped | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24446264435) |
| Create New PR from Verification | ⏭️ skipped | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24446264337) |
| Dependabot Auto-merge | ⏭️ skipped | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24446255305) |
| Gate | ❌ failure | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24446264536) |
| Health 45 Agents Guard | ⏹️ cancelled | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24446264236) |
<!-- auto-status-summary:end -->