### PR TITLE
Follow-up for #798: close portal verifier gaps

### DIFF
--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -26,7 +26,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel, Field, ValidationError
 
-from .canonical import CanonicalTripPlan, canonical_trip_plan_to_model
+from .canonical import CanonicalTripPlan, load_trip_plan_input
 from .models import TripPlan
 from .planner_auth import PlannerAuthConfig, authenticate_request
 from .policy_api import (
@@ -37,6 +37,7 @@ from .policy_api import (
     PlannerProposalOperationResponse,
     PlannerProposalStatusRequest,
     PlannerProposalSubmissionRequest,
+    build_portal_policy_review,
     check_trip_plan,
     get_evaluation_result,
     get_policy_snapshot,
@@ -49,9 +50,7 @@ from .review_workflow import ReviewAction, ReviewRequest, ReviewWorkflowStore
 from .security import Permission
 
 _OPTIONAL_SNAPSHOT_BODY = Body(default=None)
-_TEMPLATES = Jinja2Templates(
-    directory=str(Path(__file__).resolve().parent / "templates")
-)
+_TEMPLATES = Jinja2Templates(directory=str(Path(__file__).resolve().parent / "templates"))
 _PORTAL_CANONICAL_FIELDS: tuple[str, ...] = (
     "traveler_name",
     "business_purpose",
@@ -336,9 +335,7 @@ class PlannerProposalStore:
         self.remember_plan(trip_plan)
         execution_id = response.result_payload.get("execution_id")
         if not isinstance(execution_id, str):
-            raise ValueError(
-                "Planner proposal response missing required string execution_id"
-            )
+            raise ValueError("Planner proposal response missing required string execution_id")
         self.proposals_by_execution_id[execution_id] = StoredProposal(
             trip_plan=trip_plan.model_copy(deep=True),
             request=request.model_copy(deep=True),
@@ -597,9 +594,7 @@ def _portal_artifacts(
 
 
 def _portal_validation_state(answers: dict[str, object]) -> PortalReviewState:
-    missing_fields = required_field_gaps(
-        answers, required_fields=_PORTAL_REQUIRED_FIELDS
-    )
+    missing_fields = required_field_gaps(answers, required_fields=_PORTAL_REQUIRED_FIELDS)
     next_questions: list[dict[str, object]] = [
         {
             "prompt": question.prompt,
@@ -614,7 +609,7 @@ def _portal_validation_state(answers: dict[str, object]) -> PortalReviewState:
     if not missing_fields:
         canonical_payload = _canonical_payload_from_answers(answers)
         try:
-            CanonicalTripPlan.model_validate(canonical_payload)
+            load_trip_plan_input(canonical_payload)
         except ValidationError as exc:
             validation_errors = _review_validation_errors(exc)
 
@@ -650,13 +645,14 @@ def _portal_review_state(
     artifacts: dict[str, PortalArtifact] = {}
 
     if not missing_fields and canonical_payload is not None and not validation_errors:
-        canonical = CanonicalTripPlan.model_validate(canonical_payload)
-        trip_plan = canonical_trip_plan_to_model(canonical)
-        policy_snapshot = get_policy_snapshot(
-            trip_plan,
-            PlannerPolicySnapshotRequest(trip_id=trip_plan.trip_id),
-        )
-        policy_result = check_trip_plan(trip_plan)
+        trip_input = load_trip_plan_input(canonical_payload)
+        canonical = trip_input.canonical
+        if canonical is None:
+            raise RuntimeError("portal review requires canonical trip payloads")
+        trip_plan = trip_input.plan
+        policy_review = build_portal_policy_review(trip_plan)
+        policy_snapshot = policy_review.policy_snapshot
+        policy_result = policy_review.policy_result
         artifacts = _portal_artifacts(
             canonical=canonical,
             plan=trip_plan,
@@ -783,9 +779,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         review = _portal_review_state(
             draft.draft_id,
             draft.answers,
-            manager_review=proposal_store.lookup_manager_review_for_draft(
-                draft.draft_id
-            ),
+            manager_review=proposal_store.lookup_manager_review_for_draft(draft.draft_id),
         )
         if review.artifacts and not draft.cached_artifacts:
             proposal_store.cache_portal_artifacts(draft.draft_id, review.artifacts)
@@ -812,11 +806,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
                 detail=f"No portal draft found for '{draft_id}'.",
             )
         review = _portal_review_state(draft.draft_id, draft.answers)
-        if (
-            review.trip_plan is None
-            or review.missing_fields
-            or review.validation_errors
-        ):
+        if review.trip_plan is None or review.missing_fields or review.validation_errors:
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="Complete the request review before submitting the portal draft.",
@@ -904,9 +894,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
             authorization,
             required_permission=Permission.APPROVE,
         )
-        parsed = parse_qs(
-            (await request.body()).decode("utf-8"), keep_blank_values=True
-        )
+        parsed = parse_qs((await request.body()).decode("utf-8"), keep_blank_values=True)
         action_name = parsed.get("action", [""])[-1].strip()
         actor_id = parsed.get("actor_id", [""])[-1].strip()
         rationale = parsed.get("rationale", [""])[-1].strip()
@@ -979,9 +967,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         return Response(
             content=artifact.content,
             media_type=artifact.media_type,
-            headers={
-                "Content-Disposition": f'attachment; filename="{artifact.filename}"'
-            },
+            headers={"Content-Disposition": f'attachment; filename="{artifact.filename}"'},
         )
 
     @app.get(
@@ -1085,9 +1071,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         if stored.request.proposal_id != proposal_id:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail=(
-                    f"Execution '{execution_id}' does not belong to proposal '{proposal_id}'."
-                ),
+                detail=(f"Execution '{execution_id}' does not belong to proposal '{proposal_id}'."),
             )
         status_request = _submission_status_request(
             stored,

--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -38,12 +38,14 @@ from .policy_api import (
     PlannerProposalStatusRequest,
     PlannerProposalSubmissionRequest,
     build_portal_policy_review,
-    check_trip_plan,
     get_evaluation_result,
     get_policy_snapshot,
     poll_execution_status,
     render_travel_spreadsheet_bytes,
     submit_proposal,
+)
+from .policy_api import (
+    check_trip_plan as policy_check_trip_plan,
 )
 from .prompt_flow import build_output_bundle, generate_questions, required_field_gaps
 from .review_workflow import ReviewAction, ReviewRequest, ReviewWorkflowStore
@@ -51,6 +53,7 @@ from .security import Permission
 
 _OPTIONAL_SNAPSHOT_BODY = Body(default=None)
 _TEMPLATES = Jinja2Templates(directory=str(Path(__file__).resolve().parent / "templates"))
+check_trip_plan = policy_check_trip_plan
 _PORTAL_CANONICAL_FIELDS: tuple[str, ...] = (
     "traveler_name",
     "business_purpose",

--- a/src/travel_plan_permission/policy_api.py
+++ b/src/travel_plan_permission/policy_api.py
@@ -68,9 +68,7 @@ PlannerExecutionState = Literal[
 PolicyIssueContextValue = str | int | float | bool | None
 _PLANNER_POLICY_CONTRACT_VERSION = "2026-04-11"
 _PLANNER_POLICY_TTL = timedelta(hours=24)
-_DOCUMENTATION_RULE_IDS = frozenset(
-    {"fare_evidence", "hotel_comparison", "third_party_paid"}
-)
+_DOCUMENTATION_RULE_IDS = frozenset({"fare_evidence", "hotel_comparison", "third_party_paid"})
 
 __all__ = [
     "PolicyIssueSeverity",
@@ -103,11 +101,13 @@ __all__ = [
     "PlannerExceptionRequirement",
     "PlannerReoptimizationGuidance",
     "PlannerProposalEvaluationResult",
+    "PortalPolicyReview",
     "ReconciliationResult",
     "UnfilledMappingEntry",
     "UnfilledMappingReport",
     "TripPlan",
     "Receipt",
+    "build_portal_policy_review",
     "check_trip_plan",
     "fill_travel_spreadsheet",
     "get_evaluation_result",
@@ -137,9 +137,7 @@ class PolicyCheckResult(BaseModel):
     issues: list[PolicyIssue] = Field(
         default_factory=list, description="Policy issues raised by the check"
     )
-    policy_version: str = Field(
-        ..., description="Deterministic policy version identifier"
-    )
+    policy_version: str = Field(..., description="Deterministic policy version identifier")
 
 
 class PlannerPolicySnapshotRequest(BaseModel):
@@ -187,9 +185,7 @@ class PlannerAuthContract(BaseModel):
     """Authentication contract for the planner-facing policy snapshot seam."""
 
     endpoint: str = Field(..., description="Stable planner-facing endpoint identifier")
-    required_permission: str = Field(
-        ..., description="Permission required to read the snapshot"
-    )
+    required_permission: str = Field(..., description="Permission required to read the snapshot")
     auth_scheme: str = Field(..., description="Authentication scheme to use")
     supported_sso: list[str] = Field(
         default_factory=list,
@@ -292,9 +288,7 @@ class PlannerProposalExecutionStatus(BaseModel):
     state: PlannerExecutionState = Field(..., description="Current execution state")
     terminal: bool = Field(..., description="Whether the execution has finished")
     summary: str = Field(..., description="Human-readable execution summary")
-    external_status: str = Field(
-        ..., description="Transport or HTTP-style status summary"
-    )
+    external_status: str = Field(..., description="Transport or HTTP-style status summary")
     poll_after_seconds: float | None = Field(
         default=None, ge=0, description="Suggested poll interval for non-terminal states"
     )
@@ -466,9 +460,7 @@ class PlannerProposalEvaluationResult(BaseModel):
     correlation_id: PlannerCorrelationId = Field(
         ..., description="Correlation identifier shared across proposal operations"
     )
-    outcome: PlannerEvaluationOutcome = Field(
-        ..., description="Planner-facing evaluation outcome"
-    )
+    outcome: PlannerEvaluationOutcome = Field(..., description="Planner-facing evaluation outcome")
     result_endpoint: str = Field(
         ..., description="Stable endpoint for re-fetching this evaluation result"
     )
@@ -497,6 +489,14 @@ class PlannerProposalEvaluationResult(BaseModel):
     generated_at: datetime = Field(..., description="When this result payload was generated")
 
 
+@dataclass(frozen=True)
+class PortalPolicyReview:
+    """Bundled portal review policy snapshot and evaluation result."""
+
+    policy_snapshot: PlannerPolicySnapshot
+    policy_result: PolicyCheckResult
+
+
 class ReconciliationResult(BaseModel):
     """Summary of post-trip expense reconciliation."""
 
@@ -505,9 +505,7 @@ class ReconciliationResult(BaseModel):
     planned_total: Decimal = Field(..., description="Estimated trip total")
     actual_total: Decimal = Field(..., description="Actual reconciled spend")
     variance: Decimal = Field(..., description="Actual minus planned spend variance")
-    status: ReconciliationStatus = Field(
-        ..., description="Budget reconciliation status"
-    )
+    status: ReconciliationStatus = Field(..., description="Budget reconciliation status")
     receipt_count: int = Field(..., ge=0, description="Number of receipts")
     receipts_by_type: dict[str, int] = Field(
         default_factory=dict, description="Receipt counts by file type"
@@ -567,9 +565,7 @@ def _default_template_path(template_file: str | None = None) -> Path:
         if candidate.exists():
             return candidate
     try:
-        resource = resources.files("travel_plan_permission").joinpath(
-            "templates", template_name
-        )
+        resource = resources.files("travel_plan_permission").joinpath("templates", template_name)
     except ModuleNotFoundError:
         resource = None
     if resource is not None and resource.is_file():
@@ -591,9 +587,7 @@ def _default_template_bytes(template_file: str | None = None) -> bytes:
         if candidate.exists():
             return candidate.read_bytes()
     try:
-        resource = resources.files("travel_plan_permission").joinpath(
-            "templates", template_name
-        )
+        resource = resources.files("travel_plan_permission").joinpath("templates", template_name)
     except ModuleNotFoundError:
         resource = None
     if resource is not None and resource.is_file():
@@ -636,12 +630,8 @@ def _plan_field_values(
             ),
             "city_state": city_state,
             "destination_zip": zip_code,
-            "depart_date": (
-                canonical_plan.depart_date if canonical_plan else plan.departure_date
-            ),
-            "return_date": (
-                canonical_plan.return_date if canonical_plan else plan.return_date
-            ),
+            "depart_date": (canonical_plan.depart_date if canonical_plan else plan.departure_date),
+            "return_date": (canonical_plan.return_date if canonical_plan else plan.return_date),
             "event_registration_cost": (
                 canonical_plan.event_registration_cost
                 if canonical_plan and canonical_plan.event_registration_cost is not None
@@ -854,10 +844,7 @@ def _planner_snapshot_etag(plan: TripPlan, *, policy_version: str) -> str:
         separators=(",", ":"),
     )
     plan_revision = sha256(plan_payload.encode("utf-8")).hexdigest()[:12]
-    return (
-        f"{plan.trip_id}:{policy_version}:{_PLANNER_POLICY_CONTRACT_VERSION}:"
-        f"{plan_revision}"
-    )
+    return f"{plan.trip_id}:{policy_version}:{_PLANNER_POLICY_CONTRACT_VERSION}:" f"{plan_revision}"
 
 
 def _stable_operation_id(prefix: str, *parts: str) -> str:
@@ -875,9 +862,7 @@ def _proposal_request_id(
 ) -> str:
     if provided:
         return provided
-    return _stable_operation_id(
-        "req", operation, trip_id, proposal_id, proposal_version
-    )
+    return _stable_operation_id("req", operation, trip_id, proposal_id, proposal_version)
 
 
 def _proposal_correlation_id(
@@ -894,17 +879,13 @@ def _proposal_correlation_id(
     )
 
 
-def _proposal_execution_id(
-    *, trip_id: str, proposal_id: str, proposal_version: str
-) -> str:
+def _proposal_execution_id(*, trip_id: str, proposal_id: str, proposal_version: str) -> str:
     return _stable_operation_id("exec", trip_id, proposal_id, proposal_version)
 
 
 def _proposal_status_endpoint(*, proposal_id: str, execution_id: str) -> str:
-    return (
-        PLANNER_EXECUTION_STATUS_ENDPOINT.replace(":proposal_id", proposal_id).replace(
-            ":execution_id", execution_id
-        )
+    return PLANNER_EXECUTION_STATUS_ENDPOINT.replace(":proposal_id", proposal_id).replace(
+        ":execution_id", execution_id
     )
 
 
@@ -947,9 +928,7 @@ def _proposal_response_for_plan(
     execution_id = _proposal_execution_id(
         trip_id=trip_id, proposal_id=proposal_id, proposal_version=proposal_version
     )
-    status_endpoint = _proposal_status_endpoint(
-        proposal_id=proposal_id, execution_id=execution_id
-    )
+    status_endpoint = _proposal_status_endpoint(proposal_id=proposal_id, execution_id=execution_id)
     base_payload = _proposal_result_payload(
         trip_id=trip_id,
         proposal_id=proposal_id,
@@ -1033,14 +1012,8 @@ def _proposal_response_for_plan(
             status_endpoint=status_endpoint,
         )
 
-    pending_state: PlannerExecutionState = (
-        "running" if transport_pattern == "async" else "deferred"
-    )
-    queue_state = (
-        "running"
-        if transport_pattern == "async"
-        else "waiting_for_policy_engine"
-    )
+    pending_state: PlannerExecutionState = "running" if transport_pattern == "async" else "deferred"
+    queue_state = "running" if transport_pattern == "async" else "waiting_for_policy_engine"
     poll_after_seconds = 15.0 if transport_pattern == "async" else 30.0
 
     return PlannerProposalOperationResponse(
@@ -1318,8 +1291,7 @@ def get_policy_snapshot(
             contract_version=_PLANNER_POLICY_CONTRACT_VERSION,
             policy_version=policy_version,
             planner_known_policy_version=request.known_policy_version,
-            compatible_with_planner_cache=request.known_policy_version
-            in (None, policy_version),
+            compatible_with_planner_cache=request.known_policy_version in (None, policy_version),
             etag=_planner_snapshot_etag(plan, policy_version=policy_version),
         ),
     )
@@ -1493,6 +1465,18 @@ def get_evaluation_result(
     )
 
 
+def build_portal_policy_review(plan: TripPlan) -> PortalPolicyReview:
+    """Build the policy review data needed by the workflow portal."""
+
+    return PortalPolicyReview(
+        policy_snapshot=get_policy_snapshot(
+            plan,
+            PlannerPolicySnapshotRequest(trip_id=plan.trip_id),
+        ),
+        policy_result=check_trip_plan(plan),
+    )
+
+
 def check_trip_plan(plan: TripPlan) -> PolicyCheckResult:
     """Evaluate a trip plan using the policy-lite engine."""
 
@@ -1504,9 +1488,7 @@ def check_trip_plan(plan: TripPlan) -> PolicyCheckResult:
         not result.passed and result.severity == Severity.BLOCKING for result in results
     )
     status: PolicyCheckStatus = "fail" if has_blocking else "pass"
-    return PolicyCheckResult(
-        status=status, issues=issues, policy_version=_policy_version(engine)
-    )
+    return PolicyCheckResult(status=status, issues=issues, policy_version=_policy_version(engine))
 
 
 def list_allowed_vendors(plan: TripPlan) -> list[str]:
@@ -1518,9 +1500,7 @@ def list_allowed_vendors(plan: TripPlan) -> list[str]:
     providers = {
         provider.name
         for provider_type in ProviderType
-        for provider in registry.lookup(
-            provider_type, destination, reference_date=reference_date
-        )
+        for provider in registry.lookup(provider_type, destination, reference_date=reference_date)
     }
     return sorted(providers, key=str.lower)
 
@@ -1533,9 +1513,7 @@ def _allowed_vendors_for_type(plan: TripPlan, provider_type: ProviderType) -> li
     reference_date = plan.departure_date
     providers = {
         provider.name
-        for provider in registry.lookup(
-            provider_type, destination, reference_date=reference_date
-        )
+        for provider in registry.lookup(provider_type, destination, reference_date=reference_date)
     }
     return sorted(providers, key=str.lower)
 
@@ -1656,18 +1634,14 @@ def fill_travel_spreadsheet(
 
     output_path = Path(output_path)
     output_path.write_bytes(
-        render_travel_spreadsheet_bytes(
-            plan, canonical_plan=canonical_plan, report=report
-        )
+        render_travel_spreadsheet_bytes(plan, canonical_plan=canonical_plan, report=report)
     )
     return output_path
 
 
 def _expense_from_receipt(receipt: Receipt) -> ExpenseItem:
     explanation = (
-        "Third-party payment recorded on receipt."
-        if receipt.paid_by_third_party
-        else None
+        "Third-party payment recorded on receipt." if receipt.paid_by_third_party else None
     )
     return ExpenseItem(
         category=ExpenseCategory.OTHER,

--- a/src/travel_plan_permission/templates/validation_feedback.html
+++ b/src/travel_plan_permission/templates/validation_feedback.html
@@ -15,14 +15,20 @@
 
       <div class="callout" style="margin-bottom: 18px;">
         <h3>Validation feedback</h3>
-        <ul class="missing-fields">
-          {% for field in review.missing_fields %}
-            <li><code>{{ field }}</code></li>
-          {% endfor %}
-          {% for error in review.validation_errors %}
-            <li>{{ error }}</li>
-          {% endfor %}
-        </ul>
+        {% if review.missing_fields %}
+          <ul class="missing-fields">
+            {% for field in review.missing_fields %}
+              <li><code>{{ field }}</code></li>
+            {% endfor %}
+          </ul>
+        {% endif %}
+        {% if review.validation_errors %}
+          <ul class="validation-errors">
+            {% for error in review.validation_errors %}
+              <li>{{ error }}</li>
+            {% endfor %}
+          </ul>
+        {% endif %}
       </div>
 
       {% if review.next_questions %}

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
 import json
+import os
 import re
+import subprocess
 from pathlib import Path
+import sys
+import textwrap
 
 from fastapi.testclient import TestClient
 
@@ -13,6 +17,7 @@ from travel_plan_permission.policy_api import PlannerProposalOperationResponse
 from travel_plan_permission.security import Permission
 
 FIXTURE_ROOT = Path(__file__).resolve().parents[1] / "fixtures" / "planner_integration"
+REPO_ROOT = Path(__file__).resolve().parents[2]
 AUTH_HEADER = {"Authorization": "Bearer dev-token"}
 
 
@@ -320,9 +325,7 @@ def test_portal_draft_validation_returns_bad_request_without_saving() -> None:
 
     assert response.status_code == 400
     assert 'data-template="validation-feedback"' in response.text
-    assert (
-        "Complete the missing details before this draft can be saved." in response.text
-    )
+    assert "Complete the missing details before this draft can be saved." in response.text
     assert store.portal_drafts_by_id == {}
     assert re.search(
         r'<ul class="missing-fields">.*?<li><code>destination_zip</code></li>',
@@ -332,9 +335,7 @@ def test_portal_draft_validation_returns_bad_request_without_saving() -> None:
     assert "Where are you headed and what" in response.text
 
 
-def test_portal_draft_validation_rejects_invalid_present_payload_without_saving() -> (
-    None
-):
+def test_portal_draft_validation_rejects_invalid_present_payload_without_saving() -> None:
     store = PlannerProposalStore()
     client = TestClient(create_app(store))
     payload = _portal_form_payload()
@@ -345,6 +346,8 @@ def test_portal_draft_validation_rejects_invalid_present_payload_without_saving(
     assert response.status_code == 400
     assert 'data-template="validation-feedback"' in response.text
     assert store.portal_drafts_by_id == {}
+    assert '<ul class="missing-fields">' not in response.text
+    assert '<ul class="validation-errors">' in response.text
     assert "destination_zip:" in response.text
 
 
@@ -468,9 +471,7 @@ def test_submission_creates_manager_review_queue_entry(monkeypatch) -> None:
         data=_portal_form_payload(),
         follow_redirects=True,
     )
-    draft_match = re.search(
-        r"/portal/review/([^/]+)/artifacts/itinerary", response.text
-    )
+    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
     assert draft_match is not None
     draft_id = draft_match.group(1)
 
@@ -508,9 +509,7 @@ def test_manager_review_decision_updates_status_and_history(monkeypatch) -> None
         data=_portal_form_payload(),
         follow_redirects=True,
     )
-    draft_match = re.search(
-        r"/portal/review/([^/]+)/artifacts/itinerary", response.text
-    )
+    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
     assert draft_match is not None
     draft_id = draft_match.group(1)
 
@@ -569,9 +568,7 @@ def test_manager_review_routes_require_authorization(monkeypatch) -> None:
         data=_portal_form_payload(),
         follow_redirects=True,
     )
-    draft_match = re.search(
-        r"/portal/review/([^/]+)/artifacts/itinerary", response.text
-    )
+    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
     assert draft_match is not None
     draft_id = draft_match.group(1)
     client.post(
@@ -608,9 +605,7 @@ def test_manager_review_decision_requires_approve_permission(monkeypatch) -> Non
         data=_portal_form_payload(),
         follow_redirects=True,
     )
-    draft_match = re.search(
-        r"/portal/review/([^/]+)/artifacts/itinerary", response.text
-    )
+    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
     assert draft_match is not None
     draft_id = draft_match.group(1)
     client.post(
@@ -740,9 +735,7 @@ def test_portal_artifacts_raise_runtime_error_without_bundle_mappings(
     monkeypatch,
 ) -> None:
     _set_runtime_env(monkeypatch)
-    client = TestClient(
-        create_app(PlannerProposalStore()), raise_server_exceptions=False
-    )
+    client = TestClient(create_app(PlannerProposalStore()), raise_server_exceptions=False)
 
     def invalid_bundle(**_kwargs):
         return {"itinerary_excel": "bad", "summary_pdf": "bad"}
@@ -755,3 +748,59 @@ def test_portal_artifacts_raise_runtime_error_without_bundle_mappings(
     )
 
     assert response.status_code == 500
+
+
+def test_portal_artifacts_raise_runtime_error_under_python_optimization() -> None:
+    env = os.environ.copy()
+    pythonpath = str(REPO_ROOT / "src")
+    existing_pythonpath = env.get("PYTHONPATH")
+    if existing_pythonpath:
+        pythonpath = f"{pythonpath}{os.pathsep}{existing_pythonpath}"
+    env["PYTHONPATH"] = pythonpath
+
+    script = textwrap.dedent("""
+        from travel_plan_permission.canonical import load_trip_plan_input
+        from travel_plan_permission.http_service import _portal_artifacts
+        import travel_plan_permission.http_service as http_service
+
+        http_service.render_travel_spreadsheet_bytes = lambda *args, **kwargs: b"PK"
+        http_service.build_output_bundle = lambda **kwargs: {
+            "itinerary_excel": "bad",
+            "summary_pdf": "bad",
+        }
+
+        trip_input = load_trip_plan_input(
+            {
+                "type": "trip",
+                "traveler_name": "Alex Rivera",
+                "business_purpose": "Regional partner summit",
+                "destination_zip": "98101",
+                "city_state": "Seattle, WA",
+                "depart_date": "2025-10-05",
+                "return_date": "2025-10-09",
+            }
+        )
+
+        try:
+            _portal_artifacts(
+                canonical=trip_input.canonical,
+                plan=trip_input.plan,
+                answers={},
+            )
+        except RuntimeError as exc:
+            print(exc)
+        else:
+            raise SystemExit("expected RuntimeError under python -O")
+        """)
+
+    result = subprocess.run(
+        [sys.executable, "-O", "-c", script],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "bundle payload must be a mapping" in result.stdout

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -4,9 +4,9 @@ import json
 import os
 import re
 import subprocess
-from pathlib import Path
 import sys
 import textwrap
+from pathlib import Path
 
 from fastapi.testclient import TestClient
 


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #798

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The repository has strong domain logic, planner-facing APIs, spreadsheet export, and policy evaluation, but it still does not provide the lightweight end-user workflow portal implied by the Stage 2 plan. That leaves the repo usable as a backend package, but not yet as a complete travel request product.

#### Tasks
### Portal Routes
- [ ] Create GET route for displaying the draft creation form in `src/travel_plan_permission/http_service.py`
- [ ] Create POST route for handling draft submission in `src/travel_plan_permission/http_service.py`
- [ ] Create GET route for displaying the review screen in `src/travel_plan_permission/http_service.py`
- [ ] Mount all new portal routes on the existing FastAPI app instance

### HTML Templates
- [ ] Create HTML template for the draft entry form with all required input fields under `src/travel_plan_permission/templates/`
- [ ] Create HTML template for displaying validation feedback and missing field errors under `src/travel_plan_permission/templates/`
- [ ] Create HTML template for the request review and summary screen under `src/travel_plan_permission/templates/`

### Draft Handling Logic
- [ ] Implement draft data model to capture trip details, travel purpose, and cost context
- [ ] Integrate `src/travel_plan_permission/canonical.py` seams to validate and normalize draft input data
- [ ] Integrate `src/travel_plan_permission/prompt_flow.py` to identify missing required fields in draft submissions
- [ ] Add error handling and user-friendly error messages for validation failures

### Policy Integration
- [ ] Update the portal review route to display policy-readiness diagnostics by reusing `src/travel_plan_permission/policy_api.py` instead of duplicating policy logic

### Tests
- [ ] Add test for successful draft creation POST request with valid inputs under `tests/python/`
- [ ] Add test for draft creation POST with missing required fields returns validation errors under `tests/python/`
- [ ] Add test for validation error rendering displays correct missing field messages under `tests/python/`
- [ ] Add test for review page rendering displays draft data and policy readiness status under `tests/python/`

### Documentation
- [ ] Update `docs/workflows.md` with steps to run the portal locally via the standard service workflow
- [ ] Update `docs/plan.md` with portal architecture and integration points

#### Acceptance criteria
- [ ] The portal serves a draft creation form at `/portal/draft/new`, accepts POST submissions to `/portal/draft`, and displays a review screen at `/portal/review/{draft_id}` with data from `canonical.py` and `policy_api.py`
- [ ] When required inputs are missing, the portal returns HTTP 400 with an HTML response containing a list element for each missing field identified by `prompt_flow.py`, and the form is not submitted to the backend
- [ ] The portal's policy-readiness and canonical evaluation paths call into `src/travel_plan_permission/canonical.py`, `src/travel_plan_permission/prompt_flow.py`, and `src/travel_plan_permission/policy_api.py` (no duplicated policy/canonical logic in route handlers)
- [ ] All tests under `tests/python/` pass, covering draft creation, validation feedback rendering, and review-state rendering

**Head SHA:** e2ea0e22860f1f8552779ff55ea934fa65fb5e01
**Latest Runs:** ❔ in progress — Gate
**Required:** gate: ❔ in progress

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| .github/workflows/autofix.yml | ❌ failure | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24452142906) |
| .github/workflows/ci.yml | ❌ failure | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24452142608) |
| .github/workflows/claude-code-review.yml | ❌ failure | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24452143171) |
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24452159118) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24452159102) |
| Claude Code Review (Opt-in) | ✅ success | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24452144510) |
| Dependabot Auto-merge | ⏭️ skipped | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24452143990) |
| Gate | ❔ in progress | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24452144715) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24452144479) |
<!-- auto-status-summary:end -->