### PR TITLE
Follow-up for #806: close portal verifier gaps

### DIFF
--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -24,11 +24,17 @@ from fastapi import (
 )
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, Field
 
-from .canonical import CanonicalTripPlan, canonical_trip_plan_to_model
+from .canonical import CanonicalTripPlan
 from .models import TripPlan
 from .planner_auth import PlannerAuthConfig, authenticate_request
+from .portal_review import (
+    PortalArtifact,
+    PortalReviewState,
+    portal_review_state,
+    portal_validation_state,
+)
 from .policy_api import (
     PlannerPolicySnapshot,
     PlannerPolicySnapshotRequest,
@@ -41,10 +47,8 @@ from .policy_api import (
     get_evaluation_result,
     get_policy_snapshot,
     poll_execution_status,
-    render_travel_spreadsheet_bytes,
     submit_proposal,
 )
-from .prompt_flow import build_output_bundle, generate_questions, required_field_gaps
 from .review_workflow import ReviewAction, ReviewRequest, ReviewWorkflowStore
 from .security import Permission
 
@@ -156,33 +160,6 @@ class PortalDraft:
     answers: dict[str, object]
     updated_at: datetime
     cached_artifacts: dict[str, PortalArtifact] = field(default_factory=dict)
-
-
-@dataclass(frozen=True)
-class PortalArtifact:
-    """Generated portal artifact metadata and payload."""
-
-    filename: str
-    content: bytes
-    media_type: str
-
-
-@dataclass(frozen=True)
-class PortalReviewState:
-    """Computed portal review context derived from a draft."""
-
-    draft_id: str
-    answers: dict[str, object]
-    missing_fields: list[str]
-    next_questions: list[dict[str, object]]
-    validation_errors: list[str]
-    canonical_payload: dict[str, object] | None
-    trip_plan: TripPlan | None
-    policy_snapshot: PlannerPolicySnapshot | None
-    policy_result: Any | None
-    artifacts: dict[str, PortalArtifact]
-    submission_response: PlannerProposalOperationResponse | None = None
-    manager_review: ReviewRequest | None = None
 
 
 class PlannerRuntimeConfigError(RuntimeError):
@@ -560,125 +537,6 @@ def _canonical_payload_from_answers(answers: dict[str, object]) -> dict[str, obj
     return payload
 
 
-def _review_validation_errors(exc: ValidationError) -> list[str]:
-    errors: list[str] = []
-    for error in exc.errors():
-        location = ".".join(str(part) for part in error["loc"])
-        errors.append(f"{location}: {error['msg']}")
-    return errors
-
-
-def _portal_artifacts(
-    *,
-    canonical: CanonicalTripPlan,
-    plan: TripPlan,
-    answers: dict[str, object],
-) -> dict[str, PortalArtifact]:
-    itinerary_excel = render_travel_spreadsheet_bytes(plan, canonical_plan=canonical)
-    bundle = build_output_bundle(itinerary_excel=itinerary_excel, answers=answers)
-    itinerary_payload = bundle["itinerary_excel"]
-    summary_payload = bundle["summary_pdf"]
-    if not isinstance(itinerary_payload, dict):
-        raise RuntimeError("itinerary_excel bundle payload must be a mapping")
-    if not isinstance(summary_payload, dict):
-        raise RuntimeError("summary_pdf bundle payload must be a mapping")
-    return {
-        "itinerary": PortalArtifact(
-            filename=str(itinerary_payload["filename"]),
-            content=itinerary_excel,
-            media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-        ),
-        "summary": PortalArtifact(
-            filename=str(summary_payload["filename"]),
-            content=bytes(summary_payload["content"]),
-            media_type=str(summary_payload["mime_type"]),
-        ),
-    }
-
-
-def _portal_validation_state(answers: dict[str, object]) -> PortalReviewState:
-    missing_fields = required_field_gaps(
-        answers, required_fields=_PORTAL_REQUIRED_FIELDS
-    )
-    next_questions: list[dict[str, object]] = [
-        {
-            "prompt": question.prompt,
-            "fields": ", ".join(question.fields),
-            "kind": question.kind,
-        }
-        for question in generate_questions(answers, max_questions=4)
-    ]
-    validation_errors: list[str] = []
-    canonical_payload: dict[str, object] | None = None
-
-    if not missing_fields:
-        canonical_payload = _canonical_payload_from_answers(answers)
-        try:
-            CanonicalTripPlan.model_validate(canonical_payload)
-        except ValidationError as exc:
-            validation_errors = _review_validation_errors(exc)
-
-    return PortalReviewState(
-        draft_id="",
-        answers=answers,
-        missing_fields=missing_fields,
-        next_questions=next_questions,
-        validation_errors=validation_errors,
-        canonical_payload=canonical_payload,
-        trip_plan=None,
-        policy_snapshot=None,
-        policy_result=None,
-        artifacts={},
-    )
-
-
-def _portal_review_state(
-    draft_id: str,
-    answers: dict[str, object],
-    *,
-    submission_response: PlannerProposalOperationResponse | None = None,
-    manager_review: ReviewRequest | None = None,
-) -> PortalReviewState:
-    validation_state = _portal_validation_state(answers)
-    missing_fields = validation_state.missing_fields
-    next_questions = validation_state.next_questions
-    validation_errors = validation_state.validation_errors
-    canonical_payload = validation_state.canonical_payload
-    trip_plan: TripPlan | None = None
-    policy_snapshot: PlannerPolicySnapshot | None = None
-    policy_result: Any | None = None
-    artifacts: dict[str, PortalArtifact] = {}
-
-    if not missing_fields and canonical_payload is not None and not validation_errors:
-        canonical = CanonicalTripPlan.model_validate(canonical_payload)
-        trip_plan = canonical_trip_plan_to_model(canonical)
-        policy_snapshot = get_policy_snapshot(
-            trip_plan,
-            PlannerPolicySnapshotRequest(trip_id=trip_plan.trip_id),
-        )
-        policy_result = check_trip_plan(trip_plan)
-        artifacts = _portal_artifacts(
-            canonical=canonical,
-            plan=trip_plan,
-            answers=answers,
-        )
-
-    return PortalReviewState(
-        draft_id=draft_id,
-        answers=answers,
-        missing_fields=missing_fields,
-        next_questions=next_questions,
-        validation_errors=validation_errors,
-        canonical_payload=canonical_payload,
-        trip_plan=trip_plan,
-        policy_snapshot=policy_snapshot,
-        policy_result=policy_result,
-        artifacts=artifacts,
-        submission_response=submission_response,
-        manager_review=manager_review,
-    )
-
-
 def _portal_template_context(
     request: Request,
     review: PortalReviewState | None = None,
@@ -752,7 +610,11 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
     @app.post("/portal/draft")
     async def portal_draft_review(request: Request) -> Response:
         answers = _portal_answers_from_encoded_body(await request.body())
-        review = _portal_validation_state(answers)
+        review = portal_validation_state(
+            answers,
+            required_fields=_PORTAL_REQUIRED_FIELDS,
+            canonical_payload_builder=_canonical_payload_from_answers,
+        )
         if review.missing_fields or review.validation_errors:
             return _TEMPLATES.TemplateResponse(
                 request=request,
@@ -780,9 +642,11 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"No portal draft found for '{draft_id}'.",
             )
-        review = _portal_review_state(
+        review = portal_review_state(
             draft.draft_id,
             draft.answers,
+            required_fields=_PORTAL_REQUIRED_FIELDS,
+            canonical_payload_builder=_canonical_payload_from_answers,
             manager_review=proposal_store.lookup_manager_review_for_draft(
                 draft.draft_id
             ),
@@ -811,7 +675,12 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"No portal draft found for '{draft_id}'.",
             )
-        review = _portal_review_state(draft.draft_id, draft.answers)
+        review = portal_review_state(
+            draft.draft_id,
+            draft.answers,
+            required_fields=_PORTAL_REQUIRED_FIELDS,
+            canonical_payload_builder=_canonical_payload_from_answers,
+        )
         if (
             review.trip_plan is None
             or review.missing_fields
@@ -838,9 +707,11 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
             submission_response,
         )
         manager_review = proposal_store.create_manager_review(review)
-        review = _portal_review_state(
+        review = portal_review_state(
             draft.draft_id,
             draft.answers,
+            required_fields=_PORTAL_REQUIRED_FIELDS,
+            canonical_payload_builder=_canonical_payload_from_answers,
             submission_response=submission_response,
             manager_review=manager_review,
         )
@@ -966,7 +837,12 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
             )
         artifacts = draft.cached_artifacts
         if not artifacts:
-            review = _portal_review_state(draft.draft_id, draft.answers)
+            review = portal_review_state(
+                draft.draft_id,
+                draft.answers,
+                required_fields=_PORTAL_REQUIRED_FIELDS,
+                canonical_payload_builder=_canonical_payload_from_answers,
+            )
             artifacts = review.artifacts
             if artifacts:
                 proposal_store.cache_portal_artifacts(draft.draft_id, artifacts)

--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -35,6 +35,7 @@ from .policy_api import (
     PlannerProposalOperationResponse,
     PlannerProposalStatusRequest,
     PlannerProposalSubmissionRequest,
+    check_trip_plan,
     get_evaluation_result,
     get_policy_snapshot,
     poll_execution_status,
@@ -48,6 +49,16 @@ from .portal_review import (
 )
 from .review_workflow import ReviewAction, ReviewRequest, ReviewWorkflowStore
 from .security import Permission
+
+__all__ = [
+    "PlannerProposalStore",
+    "PortalDraft",
+    "TripPlan",
+    "check_trip_plan",
+    "create_app",
+    "get_policy_snapshot",
+    "main",
+]
 
 _OPTIONAL_SNAPSHOT_BODY = Body(default=None)
 _TEMPLATES = Jinja2Templates(

--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -7,7 +7,6 @@ import sys
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
 from urllib.parse import parse_qs
 from uuid import uuid4
 
@@ -26,15 +25,8 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel, Field
 
-from .canonical import CanonicalTripPlan
 from .models import TripPlan
 from .planner_auth import PlannerAuthConfig, authenticate_request
-from .portal_review import (
-    PortalArtifact,
-    PortalReviewState,
-    portal_review_state,
-    portal_validation_state,
-)
 from .policy_api import (
     PlannerPolicySnapshot,
     PlannerPolicySnapshotRequest,
@@ -43,11 +35,16 @@ from .policy_api import (
     PlannerProposalOperationResponse,
     PlannerProposalStatusRequest,
     PlannerProposalSubmissionRequest,
-    check_trip_plan,
     get_evaluation_result,
     get_policy_snapshot,
     poll_execution_status,
     submit_proposal,
+)
+from .portal_review import (
+    PortalArtifact,
+    PortalReviewState,
+    portal_review_state,
+    portal_validation_state,
 )
 from .review_workflow import ReviewAction, ReviewRequest, ReviewWorkflowStore
 from .security import Permission

--- a/src/travel_plan_permission/portal_review.py
+++ b/src/travel_plan_permission/portal_review.py
@@ -1,0 +1,178 @@
+"""Shared portal validation and review-state builders."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Callable
+
+from pydantic import ValidationError
+
+from .canonical import CanonicalTripPlan, canonical_trip_plan_to_model
+from .models import TripPlan
+from .policy_api import (
+    PlannerPolicySnapshot,
+    PlannerPolicySnapshotRequest,
+    PlannerProposalOperationResponse,
+    check_trip_plan,
+    get_policy_snapshot,
+    render_travel_spreadsheet_bytes,
+)
+from .prompt_flow import build_output_bundle, generate_questions, required_field_gaps
+
+if TYPE_CHECKING:
+    from .review_workflow import ReviewRequest
+
+
+@dataclass(frozen=True)
+class PortalArtifact:
+    """Generated portal artifact metadata and payload."""
+
+    filename: str
+    content: bytes
+    media_type: str
+
+
+@dataclass(frozen=True)
+class PortalReviewState:
+    """Computed portal review context derived from a draft."""
+
+    draft_id: str
+    answers: dict[str, object]
+    missing_fields: list[str]
+    next_questions: list[dict[str, object]]
+    validation_errors: list[str]
+    canonical_payload: dict[str, object] | None
+    trip_plan: TripPlan | None
+    policy_snapshot: PlannerPolicySnapshot | None
+    policy_result: Any | None
+    artifacts: dict[str, PortalArtifact]
+    submission_response: PlannerProposalOperationResponse | None = None
+    manager_review: ReviewRequest | None = None
+
+
+def _review_validation_errors(exc: ValidationError) -> list[str]:
+    errors: list[str] = []
+    for error in exc.errors():
+        location = ".".join(str(part) for part in error["loc"])
+        errors.append(f"{location}: {error['msg']}")
+    return errors
+
+
+def _portal_artifacts(
+    *,
+    canonical: CanonicalTripPlan,
+    plan: TripPlan,
+    answers: dict[str, object],
+) -> dict[str, PortalArtifact]:
+    itinerary_excel = render_travel_spreadsheet_bytes(plan, canonical_plan=canonical)
+    bundle = build_output_bundle(itinerary_excel=itinerary_excel, answers=answers)
+    itinerary_payload = bundle["itinerary_excel"]
+    summary_payload = bundle["summary_pdf"]
+    if not isinstance(itinerary_payload, dict):
+        raise RuntimeError("itinerary_excel bundle payload must be a mapping")
+    if not isinstance(summary_payload, dict):
+        raise RuntimeError("summary_pdf bundle payload must be a mapping")
+    return {
+        "itinerary": PortalArtifact(
+            filename=str(itinerary_payload["filename"]),
+            content=itinerary_excel,
+            media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        ),
+        "summary": PortalArtifact(
+            filename=str(summary_payload["filename"]),
+            content=bytes(summary_payload["content"]),
+            media_type=str(summary_payload["mime_type"]),
+        ),
+    }
+
+
+def portal_validation_state(
+    answers: dict[str, object],
+    *,
+    required_fields: tuple[str, ...],
+    canonical_payload_builder: Callable[[dict[str, object]], dict[str, object]],
+) -> PortalReviewState:
+    missing_fields = required_field_gaps(answers, required_fields=required_fields)
+    next_questions: list[dict[str, object]] = [
+        {
+            "prompt": question.prompt,
+            "fields": ", ".join(question.fields),
+            "kind": question.kind,
+        }
+        for question in generate_questions(answers, max_questions=4)
+    ]
+    validation_errors: list[str] = []
+    canonical_payload: dict[str, object] | None = None
+
+    if not missing_fields:
+        canonical_payload = canonical_payload_builder(answers)
+        try:
+            CanonicalTripPlan.model_validate(canonical_payload)
+        except ValidationError as exc:
+            validation_errors = _review_validation_errors(exc)
+
+    return PortalReviewState(
+        draft_id="",
+        answers=answers,
+        missing_fields=missing_fields,
+        next_questions=next_questions,
+        validation_errors=validation_errors,
+        canonical_payload=canonical_payload,
+        trip_plan=None,
+        policy_snapshot=None,
+        policy_result=None,
+        artifacts={},
+    )
+
+
+def portal_review_state(
+    draft_id: str,
+    answers: dict[str, object],
+    *,
+    required_fields: tuple[str, ...],
+    canonical_payload_builder: Callable[[dict[str, object]], dict[str, object]],
+    submission_response: PlannerProposalOperationResponse | None = None,
+    manager_review: ReviewRequest | None = None,
+) -> PortalReviewState:
+    validation_state = portal_validation_state(
+        answers,
+        required_fields=required_fields,
+        canonical_payload_builder=canonical_payload_builder,
+    )
+    missing_fields = validation_state.missing_fields
+    next_questions = validation_state.next_questions
+    validation_errors = validation_state.validation_errors
+    canonical_payload = validation_state.canonical_payload
+    trip_plan: TripPlan | None = None
+    policy_snapshot: PlannerPolicySnapshot | None = None
+    policy_result: Any | None = None
+    artifacts: dict[str, PortalArtifact] = {}
+
+    if not missing_fields and canonical_payload is not None and not validation_errors:
+        canonical = CanonicalTripPlan.model_validate(canonical_payload)
+        trip_plan = canonical_trip_plan_to_model(canonical)
+        policy_snapshot = get_policy_snapshot(
+            trip_plan,
+            PlannerPolicySnapshotRequest(trip_id=trip_plan.trip_id),
+        )
+        policy_result = check_trip_plan(trip_plan)
+        artifacts = _portal_artifacts(
+            canonical=canonical,
+            plan=trip_plan,
+            answers=answers,
+        )
+
+    return PortalReviewState(
+        draft_id=draft_id,
+        answers=answers,
+        missing_fields=missing_fields,
+        next_questions=next_questions,
+        validation_errors=validation_errors,
+        canonical_payload=canonical_payload,
+        trip_plan=trip_plan,
+        policy_snapshot=policy_snapshot,
+        policy_result=policy_result,
+        artifacts=artifacts,
+        submission_response=submission_response,
+        manager_review=manager_review,
+    )

--- a/src/travel_plan_permission/portal_review.py
+++ b/src/travel_plan_permission/portal_review.py
@@ -42,6 +42,7 @@ class PortalReviewState:
     next_questions: list[dict[str, object]]
     validation_errors: list[str]
     canonical_payload: dict[str, object] | None
+    canonical_plan: CanonicalTripPlan | None
     trip_plan: TripPlan | None
     policy_snapshot: PlannerPolicySnapshot | None
     policy_result: Any | None
@@ -103,11 +104,12 @@ def portal_validation_state(
     ]
     validation_errors: list[str] = []
     canonical_payload: dict[str, object] | None = None
+    canonical_plan: CanonicalTripPlan | None = None
 
     if not missing_fields:
         canonical_payload = canonical_payload_builder(answers)
         try:
-            CanonicalTripPlan.model_validate(canonical_payload)
+            canonical_plan = CanonicalTripPlan.model_validate(canonical_payload)
         except ValidationError as exc:
             validation_errors = _review_validation_errors(exc)
 
@@ -118,6 +120,7 @@ def portal_validation_state(
         next_questions=next_questions,
         validation_errors=validation_errors,
         canonical_payload=canonical_payload,
+        canonical_plan=canonical_plan,
         trip_plan=None,
         policy_snapshot=None,
         policy_result=None,
@@ -143,21 +146,21 @@ def portal_review_state(
     next_questions = validation_state.next_questions
     validation_errors = validation_state.validation_errors
     canonical_payload = validation_state.canonical_payload
+    canonical_plan = validation_state.canonical_plan
     trip_plan: TripPlan | None = None
     policy_snapshot: PlannerPolicySnapshot | None = None
     policy_result: Any | None = None
     artifacts: dict[str, PortalArtifact] = {}
 
-    if not missing_fields and canonical_payload is not None and not validation_errors:
-        canonical = CanonicalTripPlan.model_validate(canonical_payload)
-        trip_plan = canonical_trip_plan_to_model(canonical)
+    if not missing_fields and canonical_plan is not None and not validation_errors:
+        trip_plan = canonical_trip_plan_to_model(canonical_plan)
         policy_snapshot = get_policy_snapshot(
             trip_plan,
             PlannerPolicySnapshotRequest(trip_id=trip_plan.trip_id),
         )
         policy_result = check_trip_plan(trip_plan)
         artifacts = _portal_artifacts(
-            canonical=canonical,
+            canonical=canonical_plan,
             plan=trip_plan,
             answers=answers,
         )
@@ -169,6 +172,7 @@ def portal_review_state(
         next_questions=next_questions,
         validation_errors=validation_errors,
         canonical_payload=canonical_payload,
+        canonical_plan=canonical_plan,
         trip_plan=trip_plan,
         policy_snapshot=policy_snapshot,
         policy_result=policy_result,

--- a/src/travel_plan_permission/portal_review.py
+++ b/src/travel_plan_permission/portal_review.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 from pydantic import ValidationError
 

--- a/src/travel_plan_permission/templates/validation_feedback.html
+++ b/src/travel_plan_permission/templates/validation_feedback.html
@@ -15,14 +15,20 @@
 
       <div class="callout" style="margin-bottom: 18px;">
         <h3>Validation feedback</h3>
-        <ul class="missing-fields">
-          {% for field in review.missing_fields %}
-            <li><code>{{ field }}</code></li>
-          {% endfor %}
-          {% for error in review.validation_errors %}
-            <li>{{ error }}</li>
-          {% endfor %}
-        </ul>
+        {% if review.missing_fields %}
+          <ul class="missing-fields">
+            {% for field in review.missing_fields %}
+              <li><code>{{ field }}</code></li>
+            {% endfor %}
+          </ul>
+        {% endif %}
+        {% if review.validation_errors %}
+          <ul class="validation-errors">
+            {% for error in review.validation_errors %}
+              <li>{{ error }}</li>
+            {% endfor %}
+          </ul>
+        {% endif %}
       </div>
 
       {% if review.next_questions %}

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 import json
 import re
+import subprocess
+import sys
 from pathlib import Path
 
 from fastapi.testclient import TestClient
 
 from travel_plan_permission import http_service
+from travel_plan_permission import portal_review
 from travel_plan_permission.http_service import PlannerProposalStore, create_app, main
 from travel_plan_permission.planner_auth import mint_bootstrap_token
 from travel_plan_permission.policy_api import PlannerProposalOperationResponse
@@ -346,6 +349,8 @@ def test_portal_draft_validation_rejects_invalid_present_payload_without_saving(
     assert 'data-template="validation-feedback"' in response.text
     assert store.portal_drafts_by_id == {}
     assert "destination_zip:" in response.text
+    assert '<ul class="missing-fields">' not in response.text
+    assert '<ul class="validation-errors">' in response.text
 
 
 def test_portal_review_allows_optional_fields_to_remain_blank(monkeypatch) -> None:
@@ -692,8 +697,8 @@ def test_portal_artifact_downloads_use_cached_review_artifacts(monkeypatch) -> N
     def fail_render(*_args, **_kwargs):
         raise AssertionError("artifact download should use cached payloads")
 
-    monkeypatch.setattr(http_service, "render_travel_spreadsheet_bytes", fail_render)
-    monkeypatch.setattr(http_service, "build_output_bundle", fail_render)
+    monkeypatch.setattr(portal_review, "render_travel_spreadsheet_bytes", fail_render)
+    monkeypatch.setattr(portal_review, "build_output_bundle", fail_render)
 
     itinerary = client.get(f"/portal/review/{draft_id}/artifacts/itinerary")
     summary = client.get(f"/portal/review/{draft_id}/artifacts/summary")
@@ -747,7 +752,7 @@ def test_portal_artifacts_raise_runtime_error_without_bundle_mappings(
     def invalid_bundle(**_kwargs):
         return {"itinerary_excel": "bad", "summary_pdf": "bad"}
 
-    monkeypatch.setattr(http_service, "build_output_bundle", invalid_bundle)
+    monkeypatch.setattr(portal_review, "build_output_bundle", invalid_bundle)
 
     response = client.post(
         "/portal/draft",
@@ -755,3 +760,40 @@ def test_portal_artifacts_raise_runtime_error_without_bundle_mappings(
     )
 
     assert response.status_code == 500
+
+
+def test_portal_artifacts_runtime_error_survives_python_optimized_mode() -> None:
+    project_root = Path(__file__).resolve().parents[2]
+    script = """
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path.cwd() / "src"))
+
+import travel_plan_permission.portal_review as portal_review
+
+portal_review.render_travel_spreadsheet_bytes = lambda *args, **kwargs: b"x"
+portal_review.build_output_bundle = (
+    lambda **kwargs: {"itinerary_excel": "bad", "summary_pdf": "bad"}
+)
+
+try:
+    portal_review._portal_artifacts(canonical=object(), plan=object(), answers={})
+except RuntimeError:
+    raise SystemExit(0)
+except Exception as exc:
+    print(type(exc).__name__, exc)
+    raise SystemExit(2)
+
+raise SystemExit(1)
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-O", "-c", script],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -8,8 +8,7 @@ from pathlib import Path
 
 from fastapi.testclient import TestClient
 
-from travel_plan_permission import http_service
-from travel_plan_permission import portal_review
+from travel_plan_permission import http_service, portal_review
 from travel_plan_permission.http_service import PlannerProposalStore, create_app, main
 from travel_plan_permission.planner_auth import mint_bootstrap_token
 from travel_plan_permission.policy_api import PlannerProposalOperationResponse


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #806

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
PR #803 addressed issue #798, but verification identified remaining gaps and the verdict was **FAIL**. This follow-up focuses on completing the portal flow against the required endpoint contract, validation behavior, rendering split, shared integration paths, auth expectations, cleanup, tests, and documentation with a clearer task structure.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#803](https://github.com/stranske/Travel-Plan-Permission/issues/803)
- [#798](https://github.com/stranske/Travel-Plan-Permission/issues/798)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
### Route Registration
- [ ] Register new portal routes for GET /portal/draft/new, POST /portal/draft, and GET /portal/review/{draft_id} in the app router module
- [ ] Remove all legacy /portal/requests/* route registrations from the app router and route registration modules
- [ ] Verify that no active route registration exists for /portal/requests/* endpoints after removal

### Validation Implementation
- [ ] Implement required-field validation in the `POST /portal/draft` handler by calling `prompt_flow.py` before any draft persistence call
- [ ] Add logic to return HTTP 400 when `prompt_flow.py` reports missing fields, rendering an HTML `<ul>` with one `<li>` per missing field
- [ ] Ensure no draft persistence method is called when validation fails

### Template Creation
- [ ] Create templates/draft_entry.html template file with appropriate structure for draft form entry
- [ ] Create templates/validation_feedback.html template file with structure for displaying validation errors in a ul/li format
- [ ] Create templates/review_summary.html template file with structure for displaying draft review information

### Handler Updates
- [ ] Update GET /portal/draft/new handler to render templates/draft_entry.html
- [ ] Update POST /portal/draft handler to render templates/validation_feedback.html when validation fails
- [ ] Update GET /portal/review/{draft_id} handler to render templates/review_summary.html

### Review Integration
- [ ] Update the `GET /portal/review/{draft_id}` handler to build review state by calling integration points in `canonical.py` and `policy_api.py` without inline canonicalization/policy evaluation logic
- [ ] Verify that the existing `policy_api.py` contract is preserved for existing callers and tests

### Authorization
- [ ] Remove planner bearer-token authorization middleware/decorators from the `POST /portal/draft` route
- [ ] Update auth-related tests to verify `POST /portal/draft` accepts requests without an `Authorization` header

### Code Cleanup
- [ ] Remove _portal_answers_from_form function if it has no remaining references in the codebase
- [ ] Replace all bare assert statements in _portal_artifacts with explicit runtime exceptions
- [ ] Add unit tests to verify that _portal_artifacts runtime exceptions fire under python -O optimization mode

### Test Updates
- [ ] Update existing portal route tests to use new route names /portal/draft/new, /portal/draft, and /portal/review/{draft_id}
- [ ] Remove all test references and assertions that rely on legacy /portal/requests/* route names
- [ ] Add automated test verifying that missing-field submission to POST /portal/draft returns HTTP 400 without redirect
- [ ] Add automated test verifying that missing-field response contains a ul element with li entries for each missing field
- [ ] Add automated test verifying that successful POST /portal/draft submission redirects to /portal/review/{draft_id}

### Documentation
- [ ] Update docs/workflows.md to document the three portal endpoints GET /portal/draft/new, POST /portal/draft, and GET /portal/review/{draft_id}
- [ ] Update docs/plan.md to document HTTP 400 behavior for missing required fields including the ul/li HTML structure
- [ ] Update docs/plan.md to document that no draft is saved when required fields are missing
- [ ] Update docs/workflows.md to describe the existence of separate templates for entry, validation feedback, and review states
- [ ] Update docs/plan.md to describe the existence of separate templates for entry, validation feedback, and review states

#### Acceptance criteria
### Route Behavior
- [ ] A `GET` request to `/portal/draft/new` returns HTTP 200 and is not a redirect
- [ ] `GET /portal/draft/new` renders `templates/draft_entry.html`
- [ ] A `POST` request to `/portal/draft` with a valid form submission returns an HTTP redirect to `/portal/review/{draft_id}` where `{draft_id}` is the created draft identifier
- [ ] A `GET` request to `/portal/review/{draft_id}` for an existing draft returns HTTP 200
- [ ] `GET /portal/review/{draft_id}` renders `templates/review_summary.html`
- [ ] No active portal route registration exists for legacy `/portal/requests/*` endpoints

### Validation Behavior
- [ ] When required fields are missing, `POST /portal/draft` returns HTTP 400 and does not return a redirect status
- [ ] For a submission missing required fields, the `POST /portal/draft` response body contains exactly one `<li>` element for each missing field reported by `prompt_flow.py`, wrapped inside a `<ul>` element
- [ ] Invalid `POST /portal/draft` renders `templates/validation_feedback.html`
- [ ] When `prompt_flow.py` reports missing required fields, no draft persistence method is called during `POST /portal/draft` handling
- [ ] The `POST /portal/draft` handler invokes `prompt_flow.py` validation before any call to draft persistence for every submission path

### Template Files
- [ ] The codebase contains `templates/draft_entry.html`
- [ ] The codebase contains `templates/validation_feedback.html`
- [ ] The codebase contains `templates/review_summary.html`

### Integration
- [ ] The review route handler contains no inline canonicalization or policy evaluation logic and instead calls integration points in `canonical.py` and `policy_api.py` to build the review state
- [ ] Existing callers/tests for `policy_api.py` continue to use the same route/response contract after the portal review integration change

### Authorization
- [ ] A `POST /portal/draft` request without any `Authorization` header is processed by the route handler and is not rejected with 401 or 403
- [ ] The `POST /portal/draft` route is not decorated with, wrapped by, or registered behind planner bearer-token authorization middleware

### Code Cleanup
- [ ] No function or symbol named `_portal_answers_from_form` remains referenced anywhere in the application code
- [ ] The `_portal_artifacts` implementation contains no bare `assert` statements
- [ ] When an `_portal_artifacts` invariant/error condition is triggered, the code raises an explicit runtime exception in both normal and optimized Python execution modes

### Test Coverage
- [ ] Portal route tests cover `GET /portal/draft/new`, `POST /portal/draft`, and `GET /portal/review/{draft_id}` and do not rely on `/portal/requests/*` route names
- [ ] At least one automated test verifies missing-field submission to `POST /portal/draft` returns HTTP 400, does not redirect, and includes a `<ul>` with the expected missing-field entries
- [ ] At least one automated test verifies a successful `POST /portal/draft` submission redirects to `/portal/review/{draft_id}`

### Documentation
- [ ] `docs/workflows.md` documents the portal endpoints `GET /portal/draft/new`, `POST /portal/draft`, and `GET /portal/review/{draft_id}` exactly
- [ ] `docs/plan.md` documents that missing required fields on `POST /portal/draft` produce HTTP 400 and an HTML response containing a `<ul>` with one entry per missing field, and that no draft is saved in that case
- [ ] Both `docs/workflows.md` and `docs/plan.md` explicitly describe the existence of separate templates for entry, validation feedback, and review states

**Head SHA:** ff546f35ea893963fe4c7655c8c884ce8606789d
**Latest Runs:** ❔ in progress — Gate
**Required:** gate: ❔ in progress

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| .github/workflows/autofix.yml | ❌ failure | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24454352810) |
| .github/workflows/ci.yml | ❌ failure | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24454353108) |
| .github/workflows/claude-code-review.yml | ❌ failure | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24454353382) |
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24454400644) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24454400668) |
| Claude Code Review (Opt-in) | ✅ success | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24454355036) |
| Dependabot Auto-merge | ⏭️ skipped | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24454354562) |
| Gate | ❔ in progress | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24454355403) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24454355114) |
<!-- auto-status-summary:end -->