### PR TITLE
Issue #800: productize portal security and audit admin

### DIFF
--- a/docs/audit-trail.md
+++ b/docs/audit-trail.md
@@ -18,9 +18,25 @@ Each snapshot is stored as a compact JSON document (`<trip_id>/<timestamp>.json`
 
 - Snapshots are written whenever an approval decision is recorded (approved, rejected, flagged, or overridden) when a `ValidationSnapshotStore` is provided.
 - Captures include the exact validation results used for the decision; if they are missing, the policy validator is run automatically before writing the snapshot.
+- The portal admin runtime also records lightweight audit events for draft saves, manager-review submissions, manager decisions, exception requests and decisions, and artifact exports so the current request/review workflow can be inspected end to end from `/portal/admin`.
 
 ## Storage and integrity
 
 - Files are written immutably and chained by hash; any modification breaks the chain.
 - Snapshots are serialized with compact separators and rejected if they exceed 10KB to keep typical audit entries lightweight.
 - The comparison report (`compare_results`) highlights which rules changed between the original snapshot and a re-check under a new policy hash.
+
+## Shipped vs later audit scope
+
+Shipped now:
+
+- request draft + submission transitions
+- manager review history
+- exception workflow history
+- artifact export events from the current portal runtime
+
+Later hardening:
+
+- external append-only audit storage beyond the current runtime process
+- reimbursement settlement events from downstream accounting systems
+- retention and search controls for enterprise-scale audit archives

--- a/docs/exception-policy.md
+++ b/docs/exception-policy.md
@@ -43,3 +43,13 @@ Use `build_exception_dashboard` to generate pattern summaries for dashboards:
 - `by_type`: counts by exception type
 - `by_requestor`: counts by requester
 - `by_approver`: counts completed approvals by approver
+
+## Current portal workflow
+
+The current shipped portal/admin surface supports a bounded exception loop:
+
+- Travelers can attach an exception request from the draft review summary before or after submission.
+- Review-capable roles can inspect pending exceptions from `/portal/admin` and from the manager review detail page.
+- Approve-capable roles can record approve/reject decisions with notes, and those actions are reflected in the runtime audit trail.
+
+This is intentionally narrower than a full enterprise exception-management platform. Bulk workflow routing, durable inboxes, and downstream reimbursement settlement handling remain later work.

--- a/docs/exception-policy.md
+++ b/docs/exception-policy.md
@@ -50,6 +50,6 @@ The current shipped portal/admin surface supports a bounded exception loop:
 
 - Travelers can attach an exception request from the draft review summary before or after submission.
 - Review-capable roles can inspect pending exceptions from `/portal/admin` and from the manager review detail page.
-- Approve-capable roles can record approve/reject decisions with notes, and those actions are reflected in the runtime audit trail.
+- Approve-capable roles can record approve/reject decisions, and those actions are reflected in the runtime audit trail, including any supplied notes.
 
 This is intentionally narrower than a full enterprise exception-management platform. Bulk workflow routing, durable inboxes, and downstream reimbursement settlement handling remain later work.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -102,7 +102,7 @@ Before rollout, share this model with the security review board for sign-off on 
 The portal now exposes a practical admin/runtime layer for the current product stage:
 
 - `/portal/admin` shows the active auth mode, the currently selected view-as role (`actor_role`), and the concrete permissions associated with that simulated role selection.
-- `/portal/manager/reviews` and `/portal/manager/reviews/{review_id}` expose role-aware review actions. Read-only roles can inspect review state, while approve-capable roles can record review and exception decisions.
+- `/portal/manager/reviews` and `/portal/manager/reviews/{review_id}` expose role-aware review actions. Read-only roles can inspect review state, while approve-capable roles can record review and exception decisions; the UI treats `actor_role` as a simulated role view rather than as the authenticated caller identity.
 - The admin views are intentionally lightweight and in-repo. They are not a full enterprise identity marketplace, SSO admin console, or policy-authoring studio.
 
 ## Later hardening work

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -101,7 +101,7 @@ Before rollout, share this model with the security review board for sign-off on 
 
 The portal now exposes a practical admin/runtime layer for the current product stage:
 
-- `/portal/admin` shows the active auth mode, current viewer role, and the concrete permissions granted by that role.
+- `/portal/admin` shows the active auth mode, the currently selected view-as role (`actor_role`), and the concrete permissions associated with that simulated role selection.
 - `/portal/manager/reviews` and `/portal/manager/reviews/{review_id}` expose role-aware review actions. Read-only roles can inspect review state, while approve-capable roles can record review and exception decisions.
 - The admin views are intentionally lightweight and in-repo. They are not a full enterprise identity marketplace, SSO admin console, or policy-authoring studio.
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -96,3 +96,19 @@ All plans rely on OIDC token validation with PKCE and JWKS verification.
 ## Security team review
 
 Before rollout, share this model with the security review board for sign-off on role coverage, endpoint mapping, and audit scope.
+
+## Current shipped admin surface
+
+The portal now exposes a practical admin/runtime layer for the current product stage:
+
+- `/portal/admin` shows the active auth mode, current viewer role, and the concrete permissions granted by that role.
+- `/portal/manager/reviews` and `/portal/manager/reviews/{review_id}` expose role-aware review actions. Read-only roles can inspect review state, while approve-capable roles can record review and exception decisions.
+- The admin views are intentionally lightweight and in-repo. They are not a full enterprise identity marketplace, SSO admin console, or policy-authoring studio.
+
+## Later hardening work
+
+The following still remain future hardening items rather than shipped-now product surface:
+
+- external identity provider self-service configuration
+- durable user/role provisioning outside the in-memory runtime
+- richer segregation-of-duties controls and reimbursement-specific finance workflows

--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -6,8 +6,8 @@ import argparse
 import sys
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
-from typing import Any
 from urllib.parse import parse_qs
 from uuid import uuid4
 
@@ -24,9 +24,9 @@ from fastapi import (
 )
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
-from .models import ExceptionRequest, ExceptionStatus, ExceptionType, TripPlan
+from .models import ExceptionRequest, ExceptionType, TripPlan
 from .planner_auth import PlannerAuthConfig, authenticate_request
 from .policy_api import (
     PlannerPolicySnapshot,
@@ -49,7 +49,14 @@ from .portal_review import (
     portal_validation_state,
 )
 from .review_workflow import ReviewAction, ReviewRequest, ReviewWorkflowStore
-from .security import AuditEventType, AuditLogEvent, DEFAULT_ROLES, Permission, RoleName, SecurityModel
+from .security import (
+    DEFAULT_ROLES,
+    AuditEventType,
+    AuditLogEvent,
+    Permission,
+    RoleName,
+    SecurityModel,
+)
 
 __all__ = [
     "PlannerProposalStore",
@@ -393,6 +400,7 @@ class PlannerProposalStore:
                 key=lambda item: item[1].updated_at,
             )[0]
             del self.portal_drafts_by_id[oldest_draft_id]
+            self.exception_requests_by_draft_id.pop(oldest_draft_id, None)
         draft = PortalDraft(
             draft_id=uuid4().hex[:12],
             answers=dict(answers),
@@ -561,16 +569,19 @@ class PlannerProposalStore:
         else:
             target.reject()
             outcome = "rejected"
+        metadata: dict[str, object] = {
+            "exception_type": target.type.value,
+            "exception_index": exception_index,
+            "status": target.status.value,
+        }
+        if notes is not None:
+            metadata["notes"] = notes
         self.security.audit_log.record(
             event_type=AuditEventType.EXCEPTION,
             actor=actor_id,
             subject=draft_id,
             outcome=outcome,
-            metadata={
-                "exception_type": target.type.value,
-                "exception_index": exception_index,
-                "status": target.status.value,
-            },
+            metadata=metadata,
         )
         return _copy_exception_request(target)
 
@@ -922,13 +933,26 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
 
         supporting_doc = parsed.get("supporting_doc", [""])[-1].strip()
         amount_text = parsed.get("amount", [""])[-1].strip()
-        exception_request = ExceptionRequest(
-            type=exception_type,
-            justification=parsed.get("justification", [""])[-1].strip(),
-            requestor=str(draft.answers.get("traveler_name") or "portal-traveler"),
-            amount=amount_text or None,
-            supporting_docs=[supporting_doc] if supporting_doc else [],
-        )
+        try:
+            parsed_amount = Decimal(amount_text) if amount_text else None
+        except InvalidOperation as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Amount must be a valid non-negative decimal value.",
+            ) from exc
+        try:
+            exception_request = ExceptionRequest(
+                type=exception_type,
+                justification=parsed.get("justification", [""])[-1].strip(),
+                requestor=str(draft.answers.get("traveler_name") or "portal-traveler"),
+                amount=parsed_amount,
+                supporting_docs=[supporting_doc] if supporting_doc else [],
+            )
+        except ValidationError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=str(exc),
+            ) from exc
         proposal_store.create_exception_request(draft_id, exception_request)
         return RedirectResponse(
             url=request.url_for("portal_review_detail", draft_id=draft_id),
@@ -1157,13 +1181,19 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Actor ID is required for exception decisions.",
             )
-        proposal_store.decide_exception_request(
-            draft_id,
-            exception_index=exception_index,
-            actor_id=actor_id,
-            approved=parsed.get("decision", ["reject"])[-1].strip() == "approve",
-            notes=parsed.get("notes", [""])[-1].strip() or None,
-        )
+        try:
+            proposal_store.decide_exception_request(
+                draft_id,
+                exception_index=exception_index,
+                actor_id=actor_id,
+                approved=parsed.get("decision", ["reject"])[-1].strip() == "approve",
+                notes=parsed.get("notes", [""])[-1].strip() or None,
+            )
+        except KeyError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Exception request not found.",
+            ) from exc
         review = proposal_store.lookup_manager_review_for_draft(draft_id)
         resolved_role = _resolve_role_view(actor_role).role.value
         if review is not None:

--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -7,6 +7,7 @@ import sys
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 from urllib.parse import parse_qs
 from uuid import uuid4
 
@@ -25,7 +26,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel, Field
 
-from .models import TripPlan
+from .models import ExceptionRequest, ExceptionStatus, ExceptionType, TripPlan
 from .planner_auth import PlannerAuthConfig, authenticate_request
 from .policy_api import (
     PlannerPolicySnapshot,
@@ -48,7 +49,7 @@ from .portal_review import (
     portal_validation_state,
 )
 from .review_workflow import ReviewAction, ReviewRequest, ReviewWorkflowStore
-from .security import Permission
+from .security import AuditEventType, AuditLogEvent, DEFAULT_ROLES, Permission, RoleName, SecurityModel
 
 __all__ = [
     "PlannerProposalStore",
@@ -170,6 +171,26 @@ class PortalDraft:
     cached_artifacts: dict[str, PortalArtifact] = field(default_factory=dict)
 
 
+@dataclass(frozen=True)
+class DraftExceptionEntry:
+    """Exception request scoped to a saved draft and optional review."""
+
+    draft_id: str
+    exception_index: int
+    review_id: str | None
+    traveler_name: str | None
+    destination: str | None
+    request: ExceptionRequest
+
+
+@dataclass(frozen=True)
+class RoleView:
+    """Resolved role metadata for the admin portal."""
+
+    role: RoleName
+    permissions: tuple[Permission, ...]
+
+
 class PlannerRuntimeConfigError(RuntimeError):
     """Raised when the planner-facing HTTP runtime is misconfigured."""
 
@@ -256,6 +277,23 @@ def _authorize_request(
         ) from exc
 
 
+def _copy_exception_request(request: ExceptionRequest) -> ExceptionRequest:
+    """Return a deep copy of an exception request."""
+
+    return ExceptionRequest.model_validate(request.model_dump(mode="python"))
+
+
+def _resolve_role_view(role_name: str | None) -> RoleView:
+    """Resolve a role name into a UI-ready role/permission view."""
+
+    try:
+        role = RoleName(role_name or RoleName.TRAVELER.value)
+    except ValueError:
+        role = RoleName.TRAVELER
+    permissions = tuple(sorted(DEFAULT_ROLES[role].permissions, key=lambda item: item.value))
+    return RoleView(role=role, permissions=permissions)
+
+
 class PlannerReadinessResponse(BaseModel):
     """Health/readiness payload for the local service runtime."""
 
@@ -296,6 +334,10 @@ class PlannerProposalStore:
     proposals_by_execution_id: dict[str, StoredProposal] = field(default_factory=dict)
     portal_drafts_by_id: dict[str, PortalDraft] = field(default_factory=dict)
     manager_reviews: ReviewWorkflowStore = field(default_factory=ReviewWorkflowStore)
+    exception_requests_by_draft_id: dict[str, list[ExceptionRequest]] = field(
+        default_factory=dict
+    )
+    security: SecurityModel = field(default_factory=SecurityModel)
 
     def remember_plan(self, trip_plan: TripPlan) -> None:
         """Store the latest planner trip payload by trip identifier."""
@@ -357,6 +399,13 @@ class PlannerProposalStore:
             updated_at=datetime.now(UTC),
         )
         self.portal_drafts_by_id[draft.draft_id] = draft
+        self.security.audit_log.record(
+            event_type=AuditEventType.REQUEST,
+            actor=str(answers.get("traveler_name") or "portal-traveler"),
+            subject=draft.draft_id,
+            outcome="draft_saved",
+            metadata={"surface": "workflow-portal"},
+        )
         return draft
 
     def cache_portal_artifacts(
@@ -399,12 +448,22 @@ class PlannerProposalStore:
             or review.policy_result is None
         ):
             raise ValueError("Manager review requires a completed portal review state.")
-        return self.manager_reviews.create_or_get(
+        trip_plan = review.trip_plan.model_copy(deep=True)
+        trip_plan.exception_requests = self.list_exception_requests(review.draft_id)
+        manager_review = self.manager_reviews.create_or_get(
             draft_id=review.draft_id,
-            trip_plan=review.trip_plan,
+            trip_plan=trip_plan,
             policy_snapshot=review.policy_snapshot,
             policy_result=review.policy_result,
         )
+        self.security.audit_log.record(
+            event_type=AuditEventType.REVIEW,
+            actor="workflow-portal",
+            subject=manager_review.review_id,
+            outcome="submitted_for_manager_review",
+            metadata={"draft_id": review.draft_id, "trip_id": trip_plan.trip_id},
+        )
+        return manager_review
 
     def lookup_manager_review(self, review_id: str) -> ReviewRequest | None:
         """Return a persisted manager review by identifier."""
@@ -431,11 +490,133 @@ class PlannerProposalStore:
     ) -> ReviewRequest:
         """Persist a manager decision against an existing review request."""
 
-        return self.manager_reviews.apply_action(
+        updated = self.manager_reviews.apply_action(
             review_id,
             action=action,
             actor_id=actor_id,
             rationale=rationale,
+        )
+        self.security.audit_log.record(
+            event_type=AuditEventType.REVIEW,
+            actor=actor_id,
+            subject=review_id,
+            outcome=action.value,
+            metadata={"draft_id": updated.draft_id, "status": updated.status.value},
+        )
+        return updated
+
+    def list_exception_requests(self, draft_id: str) -> list[ExceptionRequest]:
+        """Return exception requests attached to a draft."""
+
+        return [
+            _copy_exception_request(item)
+            for item in self.exception_requests_by_draft_id.get(draft_id, [])
+        ]
+
+    def create_exception_request(
+        self,
+        draft_id: str,
+        exception_request: ExceptionRequest,
+    ) -> list[ExceptionRequest]:
+        """Attach a new exception request to a draft."""
+
+        stored = self.exception_requests_by_draft_id.setdefault(draft_id, [])
+        stored.append(_copy_exception_request(exception_request))
+        self.security.audit_log.record(
+            event_type=AuditEventType.EXCEPTION,
+            actor=exception_request.requestor,
+            subject=draft_id,
+            outcome="requested",
+            metadata={
+                "exception_type": exception_request.type.value,
+                "approval_level": (
+                    exception_request.approval_level.value
+                    if exception_request.approval_level is not None
+                    else None
+                ),
+            },
+        )
+        return self.list_exception_requests(draft_id)
+
+    def decide_exception_request(
+        self,
+        draft_id: str,
+        *,
+        exception_index: int,
+        actor_id: str,
+        approved: bool,
+        notes: str | None = None,
+    ) -> ExceptionRequest:
+        """Approve or reject an exception request tied to a draft."""
+
+        requests = self.exception_requests_by_draft_id.get(draft_id)
+        if requests is None or exception_index < 0 or exception_index >= len(requests):
+            raise KeyError(
+                f"No exception request {exception_index} found for draft '{draft_id}'."
+            )
+        target = requests[exception_index]
+        if approved:
+            target.approve(approver_id=actor_id, notes=notes)
+            outcome = "approved"
+        else:
+            target.reject()
+            outcome = "rejected"
+        self.security.audit_log.record(
+            event_type=AuditEventType.EXCEPTION,
+            actor=actor_id,
+            subject=draft_id,
+            outcome=outcome,
+            metadata={
+                "exception_type": target.type.value,
+                "exception_index": exception_index,
+                "status": target.status.value,
+            },
+        )
+        return _copy_exception_request(target)
+
+    def list_exception_entries(self) -> list[DraftExceptionEntry]:
+        """Return flattened exception entries ordered by newest draft activity."""
+
+        entries: list[DraftExceptionEntry] = []
+        for draft_id, requests in self.exception_requests_by_draft_id.items():
+            draft = self.portal_drafts_by_id.get(draft_id)
+            review = self.lookup_manager_review_for_draft(draft_id)
+            traveler_name = None
+            destination = None
+            if review is not None:
+                traveler_name = review.trip_plan.traveler_name
+                destination = review.trip_plan.destination
+            elif draft is not None:
+                traveler_name = str(draft.answers.get("traveler_name") or "") or None
+                destination = str(draft.answers.get("city_state") or "") or None
+            for index, request in enumerate(requests):
+                entries.append(
+                    DraftExceptionEntry(
+                        draft_id=draft_id,
+                        exception_index=index,
+                        review_id=review.review_id if review is not None else None,
+                        traveler_name=traveler_name,
+                        destination=destination,
+                        request=_copy_exception_request(request),
+                    )
+                )
+        entries.sort(
+            key=lambda item: (
+                item.request.requested_at,
+                item.request.requestor,
+                item.request.type.value,
+            ),
+            reverse=True,
+        )
+        return entries
+
+    def list_audit_events(self) -> list[AuditLogEvent]:
+        """Return the current audit log ordered by most recent first."""
+
+        return sorted(
+            self.security.audit_log.events,
+            key=lambda event: event.timestamp,
+            reverse=True,
         )
 
 
@@ -548,12 +729,16 @@ def _canonical_payload_from_answers(answers: dict[str, object]) -> dict[str, obj
 def _portal_template_context(
     request: Request,
     review: PortalReviewState | None = None,
+    *,
+    exceptions: list[ExceptionRequest] | None = None,
 ) -> dict[str, object]:
     answers = review.answers if review is not None else {}
     return {
         "request": request,
         "answers": answers,
         "review": review,
+        "exceptions": exceptions or [],
+        "exception_types": tuple(ExceptionType),
         "ground_transport_options": (
             "rideshare/taxi",
             "rental car",
@@ -567,21 +752,57 @@ def _portal_template_context(
 def _manager_review_queue_context(
     request: Request,
     reviews: list[ReviewRequest],
+    *,
+    role_view: RoleView,
 ) -> dict[str, object]:
-    return {"request": request, "reviews": reviews}
+    return {
+        "request": request,
+        "reviews": reviews,
+        "role_view": role_view,
+        "role_can_approve": Permission.APPROVE in role_view.permissions,
+    }
 
 
 def _manager_review_detail_context(
     request: Request,
     review: ReviewRequest,
     *,
+    role_view: RoleView,
+    exceptions: list[ExceptionRequest] | None = None,
+    audit_events: list[AuditLogEvent] | None = None,
     error_message: str | None = None,
 ) -> dict[str, object]:
     return {
         "request": request,
         "review": review,
+        "role_view": role_view,
+        "role_can_approve": Permission.APPROVE in role_view.permissions,
+        "exceptions": exceptions or [],
+        "audit_events": audit_events or [],
         "error_message": error_message,
         "review_actions": tuple(ReviewAction),
+    }
+
+
+def _admin_dashboard_context(
+    request: Request,
+    *,
+    role_view: RoleView,
+    reviews: list[ReviewRequest],
+    exception_entries: list[DraftExceptionEntry],
+    audit_events: list[AuditLogEvent],
+    runtime_config: PlannerRuntimeConfig,
+) -> dict[str, object]:
+    return {
+        "request": request,
+        "role_view": role_view,
+        "role_can_approve": Permission.APPROVE in role_view.permissions,
+        "role_can_configure": Permission.CONFIGURE in role_view.permissions,
+        "available_roles": tuple(RoleName),
+        "reviews": reviews,
+        "exception_entries": exception_entries,
+        "audit_events": audit_events,
+        "runtime_config": runtime_config,
     }
 
 
@@ -604,7 +825,10 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         return _TEMPLATES.TemplateResponse(
             request=request,
             name="portal_home.html",
-            context={"service_ready": _readiness_response().status == "ready"},
+            context={
+                "service_ready": _readiness_response().status == "ready",
+                "runtime_config": PlannerRuntimeConfig.from_env(),
+            },
         )
 
     @app.get("/portal/draft/new", response_class=HTMLResponse)
@@ -627,7 +851,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
             return _TEMPLATES.TemplateResponse(
                 request=request,
                 name="validation_feedback.html",
-                context=_portal_template_context(request, review),
+                context=_portal_template_context(request, review, exceptions=[]),
                 status_code=status.HTTP_400_BAD_REQUEST,
             )
         draft = proposal_store.save_portal_draft(answers)
@@ -664,7 +888,51 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         return _TEMPLATES.TemplateResponse(
             request=request,
             name="review_summary.html",
-            context=_portal_template_context(request, review),
+            context=_portal_template_context(
+                request,
+                review,
+                exceptions=proposal_store.list_exception_requests(draft_id),
+            ),
+        )
+
+    @app.post("/portal/review/{draft_id}/exceptions")
+    async def portal_submit_exception_request(
+        request: Request,
+        draft_id: str,
+    ) -> RedirectResponse:
+        draft = proposal_store.lookup_portal_draft(draft_id)
+        if draft is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"No portal draft found for '{draft_id}'.",
+            )
+        parsed = parse_qs(
+            (await request.body()).decode("utf-8"),
+            keep_blank_values=True,
+        )
+        try:
+            exception_type = ExceptionType(
+                parsed.get("exception_type", [""])[-1].strip()
+            )
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Select a valid exception type.",
+            ) from exc
+
+        supporting_doc = parsed.get("supporting_doc", [""])[-1].strip()
+        amount_text = parsed.get("amount", [""])[-1].strip()
+        exception_request = ExceptionRequest(
+            type=exception_type,
+            justification=parsed.get("justification", [""])[-1].strip(),
+            requestor=str(draft.answers.get("traveler_name") or "portal-traveler"),
+            amount=amount_text or None,
+            supporting_docs=[supporting_doc] if supporting_doc else [],
+        )
+        proposal_store.create_exception_request(draft_id, exception_request)
+        return RedirectResponse(
+            url=request.url_for("portal_review_detail", draft_id=draft_id),
+            status_code=status.HTTP_303_SEE_OTHER,
         )
 
     @app.post("/portal/review/{draft_id}/submit", response_class=HTMLResponse)
@@ -726,24 +994,31 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         return _TEMPLATES.TemplateResponse(
             request=request,
             name="review_summary.html",
-            context=_portal_template_context(request, review),
+            context=_portal_template_context(
+                request,
+                review,
+                exceptions=proposal_store.list_exception_requests(draft_id),
+            ),
         )
 
     @app.get("/portal/manager/reviews", response_class=HTMLResponse)
     def portal_manager_review_queue(
         request: Request,
         authorization: str | None = Header(default=None),
+        actor_role: str | None = Query(default=RoleName.TRAVELER.value),
     ) -> HTMLResponse:
         _authorize_request(
             authorization,
             required_permission=Permission.VIEW,
         )
+        role_view = _resolve_role_view(actor_role)
         return _TEMPLATES.TemplateResponse(
             request=request,
             name="manager_review_queue.html",
             context=_manager_review_queue_context(
                 request,
                 proposal_store.list_manager_reviews(),
+                role_view=role_view,
             ),
         )
 
@@ -756,11 +1031,13 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         request: Request,
         review_id: str,
         authorization: str | None = Header(default=None),
+        actor_role: str | None = Query(default=RoleName.TRAVELER.value),
     ) -> HTMLResponse:
         _authorize_request(
             authorization,
             required_permission=Permission.VIEW,
         )
+        role_view = _resolve_role_view(actor_role)
         review = proposal_store.lookup_manager_review(review_id)
         if review is None:
             raise HTTPException(
@@ -770,7 +1047,17 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         return _TEMPLATES.TemplateResponse(
             request=request,
             name="manager_review_detail.html",
-            context=_manager_review_detail_context(request, review),
+            context=_manager_review_detail_context(
+                request,
+                review,
+                role_view=role_view,
+                exceptions=proposal_store.list_exception_requests(review.draft_id),
+                audit_events=[
+                    event
+                    for event in proposal_store.list_audit_events()
+                    if event.subject in {review.review_id, review.draft_id}
+                ],
+            ),
         )
 
     @app.post("/portal/manager/reviews/{review_id}/decision")
@@ -778,11 +1065,13 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         request: Request,
         review_id: str,
         authorization: str | None = Header(default=None),
+        actor_role: str | None = Query(default=RoleName.TRAVELER.value),
     ) -> Response:
         _authorize_request(
             authorization,
             required_permission=Permission.APPROVE,
         )
+        role_view = _resolve_role_view(actor_role)
         parsed = parse_qs(
             (await request.body()).decode("utf-8"), keep_blank_values=True
         )
@@ -803,6 +1092,13 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
                 context=_manager_review_detail_context(
                     request,
                     review,
+                    role_view=role_view,
+                    exceptions=proposal_store.list_exception_requests(review.draft_id),
+                    audit_events=[
+                        event
+                        for event in proposal_store.list_audit_events()
+                        if event.subject in {review.review_id, review.draft_id}
+                    ],
                     error_message="Manager actor ID is required.",
                 ),
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -823,6 +1119,13 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
                 context=_manager_review_detail_context(
                     request,
                     refreshed,
+                    role_view=role_view,
+                    exceptions=proposal_store.list_exception_requests(refreshed.draft_id),
+                    audit_events=[
+                        event
+                        for event in proposal_store.list_audit_events()
+                        if event.subject in {refreshed.review_id, refreshed.draft_id}
+                    ],
                     error_message=str(exc),
                 ),
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -830,6 +1133,81 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         return RedirectResponse(
             url=request.url_for("portal_manager_review_detail", review_id=review_id),
             status_code=status.HTTP_303_SEE_OTHER,
+        )
+
+    @app.post("/portal/admin/exceptions/{draft_id}/{exception_index}/decision")
+    async def portal_exception_decision(
+        request: Request,
+        draft_id: str,
+        exception_index: int,
+        authorization: str | None = Header(default=None),
+        actor_role: str | None = Query(default=RoleName.TRAVELER.value),
+    ) -> RedirectResponse:
+        _authorize_request(
+            authorization,
+            required_permission=Permission.APPROVE,
+        )
+        parsed = parse_qs(
+            (await request.body()).decode("utf-8"),
+            keep_blank_values=True,
+        )
+        actor_id = parsed.get("actor_id", [""])[-1].strip()
+        if not actor_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Actor ID is required for exception decisions.",
+            )
+        proposal_store.decide_exception_request(
+            draft_id,
+            exception_index=exception_index,
+            actor_id=actor_id,
+            approved=parsed.get("decision", ["reject"])[-1].strip() == "approve",
+            notes=parsed.get("notes", [""])[-1].strip() or None,
+        )
+        review = proposal_store.lookup_manager_review_for_draft(draft_id)
+        resolved_role = _resolve_role_view(actor_role).role.value
+        if review is not None:
+            return RedirectResponse(
+                url=str(
+                    request.url_for(
+                        "portal_manager_review_detail", review_id=review.review_id
+                    )
+                )
+                + f"?actor_role={resolved_role}",
+                status_code=status.HTTP_303_SEE_OTHER,
+            )
+        return RedirectResponse(
+            url=str(request.url_for("portal_admin_dashboard"))
+            + f"?actor_role={resolved_role}",
+            status_code=status.HTTP_303_SEE_OTHER,
+        )
+
+    @app.get(
+        "/portal/admin",
+        response_class=HTMLResponse,
+        name="portal_admin_dashboard",
+    )
+    def portal_admin_dashboard(
+        request: Request,
+        authorization: str | None = Header(default=None),
+        actor_role: str | None = Query(default=RoleName.TRAVELER.value),
+    ) -> HTMLResponse:
+        _authorize_request(
+            authorization,
+            required_permission=Permission.VIEW,
+        )
+        role_view = _resolve_role_view(actor_role)
+        return _TEMPLATES.TemplateResponse(
+            request=request,
+            name="portal_admin.html",
+            context=_admin_dashboard_context(
+                request,
+                role_view=role_view,
+                reviews=proposal_store.list_manager_reviews(),
+                exception_entries=proposal_store.list_exception_entries(),
+                audit_events=proposal_store.list_audit_events(),
+                runtime_config=PlannerRuntimeConfig.from_env(),
+            ),
         )
 
     @app.get("/portal/review/{draft_id}/artifacts/{artifact_name}")
@@ -860,6 +1238,13 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"No artifact named '{artifact_name}' for draft '{draft_id}'.",
             )
+        proposal_store.security.audit_log.record(
+            event_type=AuditEventType.EXPORT,
+            actor="workflow-portal",
+            subject=draft_id,
+            outcome="artifact_downloaded",
+            metadata={"artifact": artifact_name},
+        )
         return Response(
             content=artifact.content,
             media_type=artifact.media_type,

--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -912,7 +912,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
     async def portal_submit_exception_request(
         request: Request,
         draft_id: str,
-    ) -> RedirectResponse:
+    ) -> Response:
         draft = proposal_store.lookup_portal_draft(draft_id)
         if draft is None:
             raise HTTPException(
@@ -946,7 +946,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
             proposal_store.cache_portal_artifacts(draft.draft_id, review.artifacts)
         try:
             parsed_amount = Decimal(amount_text) if amount_text else None
-        except InvalidOperation as exc:
+        except InvalidOperation:
             return _TEMPLATES.TemplateResponse(
                 request=request,
                 name="review_summary.html",

--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -27,7 +27,7 @@ from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel, Field, ValidationError
 
 from .models import ExceptionRequest, ExceptionType, TripPlan
-from .planner_auth import PlannerAuthConfig, authenticate_request
+from .planner_auth import PlannerAuthConfig, PlannerAuthContext, authenticate_request
 from .policy_api import (
     PlannerPolicySnapshot,
     PlannerPolicySnapshotRequest,
@@ -256,7 +256,7 @@ def _authorize_request(
     authorization: str | None,
     *,
     required_permission: Permission,
-) -> None:
+) -> PlannerAuthContext:
     config = PlannerAuthConfig.from_env()
     if not config.is_ready:
         raise HTTPException(
@@ -264,7 +264,7 @@ def _authorize_request(
             detail="Planner auth config is not ready.",
         )
     try:
-        authenticate_request(
+        return authenticate_request(
             authorization,
             config=config,
             required_permission=required_permission,
@@ -767,12 +767,16 @@ def _manager_review_queue_context(
     reviews: list[ReviewRequest],
     *,
     role_view: RoleView,
+    auth_context: PlannerAuthContext,
 ) -> dict[str, object]:
     return {
         "request": request,
         "reviews": reviews,
         "role_view": role_view,
-        "role_can_approve": Permission.APPROVE in role_view.permissions,
+        "actor_permissions": tuple(
+            sorted(auth_context.permissions, key=lambda item: item.value)
+        ),
+        "role_can_approve": auth_context.can(Permission.APPROVE),
     }
 
 
@@ -781,6 +785,7 @@ def _manager_review_detail_context(
     review: ReviewRequest,
     *,
     role_view: RoleView,
+    auth_context: PlannerAuthContext,
     exceptions: list[ExceptionRequest] | None = None,
     audit_events: list[AuditLogEvent] | None = None,
     error_message: str | None = None,
@@ -789,7 +794,10 @@ def _manager_review_detail_context(
         "request": request,
         "review": review,
         "role_view": role_view,
-        "role_can_approve": Permission.APPROVE in role_view.permissions,
+        "actor_permissions": tuple(
+            sorted(auth_context.permissions, key=lambda item: item.value)
+        ),
+        "role_can_approve": auth_context.can(Permission.APPROVE),
         "exceptions": exceptions or [],
         "audit_events": audit_events or [],
         "error_message": error_message,
@@ -801,6 +809,7 @@ def _admin_dashboard_context(
     request: Request,
     *,
     role_view: RoleView,
+    auth_context: PlannerAuthContext,
     reviews: list[ReviewRequest],
     exception_entries: list[DraftExceptionEntry],
     audit_events: list[AuditLogEvent],
@@ -809,8 +818,11 @@ def _admin_dashboard_context(
     return {
         "request": request,
         "role_view": role_view,
-        "role_can_approve": Permission.APPROVE in role_view.permissions,
-        "role_can_configure": Permission.CONFIGURE in role_view.permissions,
+        "actor_permissions": tuple(
+            sorted(auth_context.permissions, key=lambda item: item.value)
+        ),
+        "role_can_approve": auth_context.can(Permission.APPROVE),
+        "role_can_configure": auth_context.can(Permission.CONFIGURE),
         "available_roles": tuple(RoleName),
         "reviews": reviews,
         "exception_entries": exception_entries,
@@ -1059,7 +1071,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         authorization: str | None = Header(default=None),
         actor_role: str | None = Query(default=RoleName.TRAVELER.value),
     ) -> HTMLResponse:
-        _authorize_request(
+        auth_context = _authorize_request(
             authorization,
             required_permission=Permission.VIEW,
         )
@@ -1071,6 +1083,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
                 request,
                 proposal_store.list_manager_reviews(),
                 role_view=role_view,
+                auth_context=auth_context,
             ),
         )
 
@@ -1085,7 +1098,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         authorization: str | None = Header(default=None),
         actor_role: str | None = Query(default=RoleName.TRAVELER.value),
     ) -> HTMLResponse:
-        _authorize_request(
+        auth_context = _authorize_request(
             authorization,
             required_permission=Permission.VIEW,
         )
@@ -1103,6 +1116,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
                 request,
                 review,
                 role_view=role_view,
+                auth_context=auth_context,
                 exceptions=proposal_store.list_exception_requests(review.draft_id),
                 audit_events=[
                     event
@@ -1119,7 +1133,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         authorization: str | None = Header(default=None),
         actor_role: str | None = Query(default=RoleName.TRAVELER.value),
     ) -> Response:
-        _authorize_request(
+        auth_context = _authorize_request(
             authorization,
             required_permission=Permission.APPROVE,
         )
@@ -1145,6 +1159,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
                     request,
                     review,
                     role_view=role_view,
+                    auth_context=auth_context,
                     exceptions=proposal_store.list_exception_requests(review.draft_id),
                     audit_events=[
                         event
@@ -1172,6 +1187,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
                     request,
                     refreshed,
                     role_view=role_view,
+                    auth_context=auth_context,
                     exceptions=proposal_store.list_exception_requests(refreshed.draft_id),
                     audit_events=[
                         event
@@ -1250,7 +1266,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         authorization: str | None = Header(default=None),
         actor_role: str | None = Query(default=RoleName.TRAVELER.value),
     ) -> HTMLResponse:
-        _authorize_request(
+        auth_context = _authorize_request(
             authorization,
             required_permission=Permission.VIEW,
         )
@@ -1261,6 +1277,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
             context=_admin_dashboard_context(
                 request,
                 role_view=role_view,
+                auth_context=auth_context,
                 reviews=proposal_store.list_manager_reviews(),
                 exception_entries=proposal_store.list_exception_entries(),
                 audit_events=proposal_store.list_audit_events(),

--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -742,6 +742,7 @@ def _portal_template_context(
     review: PortalReviewState | None = None,
     *,
     exceptions: list[ExceptionRequest] | None = None,
+    error_message: str | None = None,
 ) -> dict[str, object]:
     answers = review.answers if review is not None else {}
     return {
@@ -757,6 +758,7 @@ def _portal_template_context(
             "personal vehicle",
         ),
         "optional_fields": _PORTAL_OPTIONAL_FIELDS,
+        "error_message": error_message,
     }
 
 
@@ -933,13 +935,29 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
 
         supporting_doc = parsed.get("supporting_doc", [""])[-1].strip()
         amount_text = parsed.get("amount", [""])[-1].strip()
+        review = portal_review_state(
+            draft.draft_id,
+            draft.answers,
+            required_fields=_PORTAL_REQUIRED_FIELDS,
+            canonical_payload_builder=_canonical_payload_from_answers,
+            manager_review=proposal_store.lookup_manager_review_for_draft(draft.draft_id),
+        )
+        if review.artifacts and not draft.cached_artifacts:
+            proposal_store.cache_portal_artifacts(draft.draft_id, review.artifacts)
         try:
             parsed_amount = Decimal(amount_text) if amount_text else None
         except InvalidOperation as exc:
-            raise HTTPException(
+            return _TEMPLATES.TemplateResponse(
+                request=request,
+                name="review_summary.html",
+                context=_portal_template_context(
+                    request,
+                    review,
+                    exceptions=proposal_store.list_exception_requests(draft_id),
+                    error_message="Amount must be a valid non-negative decimal value.",
+                ),
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Amount must be a valid non-negative decimal value.",
-            ) from exc
+            )
         try:
             exception_request = ExceptionRequest(
                 type=exception_type,
@@ -949,10 +967,20 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
                 supporting_docs=[supporting_doc] if supporting_doc else [],
             )
         except ValidationError as exc:
-            raise HTTPException(
+            messages = "; ".join(
+                error["msg"] for error in exc.errors() if error.get("msg")
+            )
+            return _TEMPLATES.TemplateResponse(
+                request=request,
+                name="review_summary.html",
+                context=_portal_template_context(
+                    request,
+                    review,
+                    exceptions=proposal_store.list_exception_requests(draft_id),
+                    error_message=messages or "Provide a valid exception request.",
+                ),
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=str(exc),
-            ) from exc
+            )
         proposal_store.create_exception_request(draft_id, exception_request)
         return RedirectResponse(
             url=request.url_for("portal_review_detail", draft_id=draft_id),

--- a/src/travel_plan_permission/security.py
+++ b/src/travel_plan_permission/security.py
@@ -107,6 +107,10 @@ class AuditEventType(StrEnum):
     AUTHORIZATION = "authorization"
     ROLE_CHANGE = "role_change"
     DELEGATION = "delegation"
+    REQUEST = "request"
+    REVIEW = "review"
+    EXCEPTION = "exception"
+    EXPORT = "export"
 
 
 @dataclass

--- a/src/travel_plan_permission/templates/manager_review_detail.html
+++ b/src/travel_plan_permission/templates/manager_review_detail.html
@@ -168,6 +168,14 @@
               Role view simulation: <strong>{{ role_view.role.value }}</strong>, showing
               {% for permission in role_view.permissions %}<code>{{ permission.value }}</code>{% if not loop.last %}, {% endif %}{% endfor %}.
             </p>
+            <p style="margin-top: 10px;">
+              Authenticated token permissions:
+              {% for permission in actor_permissions %}
+                <code>{{ permission.value }}</code>{% if not loop.last %}, {% endif %}
+              {% else %}
+                <code>none</code>
+              {% endfor %}.
+            </p>
             {% if error_message %}
               <div class="callout" style="margin-top: 16px;">
                 <h3>Decision error</h3>

--- a/src/travel_plan_permission/templates/manager_review_detail.html
+++ b/src/travel_plan_permission/templates/manager_review_detail.html
@@ -72,8 +72,9 @@
           <p style="margin-top: 10px;">Decision state, policy posture, and immutable approval history for one submitted request.</p>
         </div>
         <div class="actions">
-          <a class="link" href="/portal/manager/reviews">Review queue</a>
-          <a class="link" href="/portal/requests/{{ review.draft_id }}">Open draft review</a>
+          <a class="link" href="/portal/admin?actor_role={{ role_view.role.value }}">Admin console</a>
+          <a class="link" href="/portal/manager/reviews?actor_role={{ role_view.role.value }}">Review queue</a>
+          <a class="link" href="/portal/review/{{ review.draft_id }}">Open draft review</a>
         </div>
       </div>
 
@@ -86,6 +87,7 @@
             <span>Trip {{ review.trip_plan.trip_id }}</span>
             <span>Submitted {{ review.submitted_at.isoformat() }}</span>
             <span>Updated {{ review.updated_at.isoformat() }}</span>
+            <span>Viewer {{ role_view.role.value }}</span>
           </div>
 
           <div class="grid" style="margin-top: 18px;">
@@ -131,41 +133,112 @@
               {% endfor %}
             </ul>
           </div>
+
+          <div class="callout" style="margin-top: 18px;">
+            <h3>Exception workflow</h3>
+            <ul>
+              {% for item in exceptions %}
+                <li>
+                  {{ item.type.value }} · {{ item.status.value }}
+                  {% if item.approval_level %} · {{ item.approval_level.value }}{% endif %}
+                  {% if item.approval %} · {{ item.approval.approver_id }}{% endif %}
+                </li>
+              {% else %}
+                <li>No exception requests attached to this draft.</li>
+              {% endfor %}
+            </ul>
+          </div>
+
+          <div class="callout" style="margin-top: 18px;">
+            <h3>Runtime audit trail</h3>
+            <ul>
+              {% for event in audit_events %}
+                <li>{{ event.timestamp.isoformat() }}: {{ event.event_type.value }} · {{ event.outcome }} by {{ event.actor }}{% if event.metadata %} — {{ event.metadata }}{% endif %}</li>
+              {% else %}
+                <li>No audit events recorded for this review yet.</li>
+              {% endfor %}
+            </ul>
+          </div>
         </section>
 
         <aside class="stack">
           <section class="panel">
             <h2>Record manager decision</h2>
-            <p style="margin-top: 10px;">Capture the decision and rationale so the runtime retains the current approval state.</p>
+            <p style="margin-top: 10px;">
+              Viewing as <strong>{{ role_view.role.value }}</strong> with
+              {% for permission in role_view.permissions %}<code>{{ permission.value }}</code>{% if not loop.last %}, {% endif %}{% endfor %}.
+            </p>
             {% if error_message %}
               <div class="callout" style="margin-top: 16px;">
                 <h3>Decision error</h3>
                 <p style="margin-top: 10px;">{{ error_message }}</p>
               </div>
             {% endif %}
-            <form method="post" action="/portal/manager/reviews/{{ review.review_id }}/decision" style="margin-top: 16px;">
-              <div class="stack">
-                <label>
-                  <span>Manager actor ID</span>
-                  <input name="actor_id" value="manager-1" />
-                </label>
-                <label>
-                  <span>Decision</span>
-                  <select name="action">
-                    {% for action in review_actions %}
-                      <option value="{{ action.value }}">{{ action.value }}</option>
-                    {% endfor %}
-                  </select>
-                </label>
-                <label>
-                  <span>Rationale</span>
-                  <textarea name="rationale" placeholder="Summarize the decision context and next expectation."></textarea>
-                </label>
-                <div class="actions">
-                  <button class="primary" type="submit">Save manager decision</button>
+            {% if role_can_approve %}
+              <form method="post" action="/portal/manager/reviews/{{ review.review_id }}/decision?actor_role={{ role_view.role.value }}" style="margin-top: 16px;">
+                <div class="stack">
+                  <label>
+                    <span>Manager actor ID</span>
+                    <input name="actor_id" value="manager-1" />
+                  </label>
+                  <label>
+                    <span>Decision</span>
+                    <select name="action">
+                      {% for action in review_actions %}
+                        <option value="{{ action.value }}">{{ action.value }}</option>
+                      {% endfor %}
+                    </select>
+                  </label>
+                  <label>
+                    <span>Rationale</span>
+                    <textarea name="rationale" placeholder="Summarize the decision context and next expectation."></textarea>
+                  </label>
+                  <div class="actions">
+                    <button class="primary" type="submit">Save manager decision</button>
+                  </div>
                 </div>
+              </form>
+            {% else %}
+              <div class="callout" style="margin-top: 16px;">
+                <h3>Read-only role</h3>
+                <p style="margin-top: 10px;">This role can inspect the review but cannot record approval actions.</p>
               </div>
-            </form>
+            {% endif %}
+
+            {% if exceptions %}
+              <div class="callout" style="margin-top: 18px;">
+                <h3>Exception decisions</h3>
+                {% for item in exceptions %}
+                  <div style="margin-top: 14px;">
+                    <p><strong>{{ item.type.value }}</strong> · {{ item.status.value }}</p>
+                    {% if role_can_approve and item.status.value == "pending" %}
+                      <form method="post" action="/portal/admin/exceptions/{{ review.draft_id }}/{{ loop.index0 }}/decision?actor_role={{ role_view.role.value }}" style="margin-top: 10px;">
+                        <div class="stack">
+                          <label>
+                            <span>Actor ID</span>
+                            <input name="actor_id" value="manager-1" />
+                          </label>
+                          <label>
+                            <span>Decision</span>
+                            <select name="decision">
+                              <option value="approve">approve</option>
+                              <option value="reject">reject</option>
+                            </select>
+                          </label>
+                          <label>
+                            <span>Notes</span>
+                            <textarea name="notes" placeholder="Summarize the exception decision."></textarea>
+                          </label>
+                          <div class="actions">
+                            <button class="primary" type="submit">Save exception decision</button>
+                          </div>
+                        </div>
+                      </form>
+                    {% endif %}
+                  </div>
+                {% endfor %}
+              </div>
+            {% endif %}
           </section>
         </aside>
       </div>

--- a/src/travel_plan_permission/templates/manager_review_detail.html
+++ b/src/travel_plan_permission/templates/manager_review_detail.html
@@ -165,7 +165,7 @@
           <section class="panel">
             <h2>Record manager decision</h2>
             <p style="margin-top: 10px;">
-              Viewing as <strong>{{ role_view.role.value }}</strong> with
+              Role view simulation: <strong>{{ role_view.role.value }}</strong>, showing
               {% for permission in role_view.permissions %}<code>{{ permission.value }}</code>{% if not loop.last %}, {% endif %}{% endfor %}.
             </p>
             {% if error_message %}

--- a/src/travel_plan_permission/templates/manager_review_queue.html
+++ b/src/travel_plan_permission/templates/manager_review_queue.html
@@ -53,8 +53,15 @@
           <div>
             <h1>Manager review queue</h1>
             <p style="margin-top: 10px;">Submitted browser requests stay here with policy posture and decision history until a manager acts.</p>
+            <p style="margin-top: 10px;">
+              Viewing as <strong>{{ role_view.role.value }}</strong> with
+              {% for permission in role_view.permissions %}<code>{{ permission.value }}</code>{% if not loop.last %}, {% endif %}{% endfor %}.
+            </p>
           </div>
-          <a class="link" href="/portal">Portal home</a>
+          <div class="row">
+            <a class="link" href="/portal/admin?actor_role={{ role_view.role.value }}">Admin console</a>
+            <a class="link" href="/portal">Portal home</a>
+          </div>
         </div>
 
         {% if reviews %}

--- a/src/travel_plan_permission/templates/manager_review_queue.html
+++ b/src/travel_plan_permission/templates/manager_review_queue.html
@@ -54,7 +54,7 @@
             <h1>Manager review queue</h1>
             <p style="margin-top: 10px;">Submitted browser requests stay here with policy posture and decision history until a manager acts.</p>
             <p style="margin-top: 10px;">
-              Viewing as <strong>{{ role_view.role.value }}</strong> with
+              Role view simulation: <strong>{{ role_view.role.value }}</strong>, showing
               {% for permission in role_view.permissions %}<code>{{ permission.value }}</code>{% if not loop.last %}, {% endif %}{% endfor %}.
             </p>
           </div>

--- a/src/travel_plan_permission/templates/portal_admin.html
+++ b/src/travel_plan_permission/templates/portal_admin.html
@@ -79,11 +79,11 @@
       <div class="layout">
         <aside class="stack">
           <section class="panel">
-            <h2>Role permissions (view as)</h2>
+            <h2>Role view simulation</h2>
             <form method="get" action="/portal/admin" style="margin-top: 16px;">
               <div class="stack">
                 <label>
-                  <span>Viewer role</span>
+                  <span>Simulated role</span>
                   <select name="actor_role">
                     {% for role in available_roles %}
                       <option value="{{ role.value }}" {% if role == role_view.role %}selected{% endif %}>{{ role.value }}</option>

--- a/src/travel_plan_permission/templates/portal_admin.html
+++ b/src/travel_plan_permission/templates/portal_admin.html
@@ -101,6 +101,14 @@
                 <span><code>{{ permission.value }}</code></span>
               {% endfor %}
             </div>
+            <p style="margin-top: 12px;">
+              Authenticated token permissions:
+              {% for permission in actor_permissions %}
+                <code>{{ permission.value }}</code>{% if not loop.last %}, {% endif %}
+              {% else %}
+                <code>none</code>
+              {% endfor %}.
+            </p>
           </section>
 
           <section class="panel">

--- a/src/travel_plan_permission/templates/portal_admin.html
+++ b/src/travel_plan_permission/templates/portal_admin.html
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Portal Admin Console</title>
+    <style>
+      :root {
+        --ink: #122432;
+        --muted: #5b7280;
+        --paper: rgba(255, 255, 255, 0.93);
+        --line: rgba(18, 36, 50, 0.14);
+        --shadow: 0 24px 64px rgba(18, 36, 50, 0.14);
+        --accent: #184d47;
+        --accent-soft: rgba(24, 77, 71, 0.12);
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        color: var(--ink);
+        font-family: "Iowan Old Style", "Palatino Linotype", Georgia, serif;
+        background:
+          radial-gradient(circle at top right, rgba(24, 77, 71, 0.12), transparent 32%),
+          linear-gradient(135deg, #f8f1e8 0%, #dfe9ef 100%);
+      }
+      main { max-width: 1240px; margin: 0 auto; padding: 36px 18px 72px; }
+      .layout { display: grid; gap: 20px; grid-template-columns: minmax(320px, 0.9fr) minmax(0, 1.1fr); }
+      .panel, .card {
+        background: var(--paper);
+        border: 1px solid var(--line);
+        border-radius: 24px;
+        box-shadow: var(--shadow);
+      }
+      .panel { padding: 24px; }
+      .card { padding: 18px; }
+      h1, h2, h3, p { margin: 0; }
+      p { color: var(--muted); line-height: 1.52; }
+      .stack, .list { display: grid; gap: 16px; }
+      .topbar, .actions, .meta { display: flex; gap: 12px; flex-wrap: wrap; }
+      .topbar { justify-content: space-between; align-items: center; margin-bottom: 20px; }
+      .badge, .link, button {
+        display: inline-flex; align-items: center; justify-content: center;
+        border-radius: 999px; padding: 10px 14px; text-decoration: none;
+      }
+      .badge { background: var(--accent-soft); color: var(--accent); font: 600 0.82rem/1 ui-monospace, Menlo, monospace; }
+      .link, button { border: 1px solid var(--line); background: white; color: var(--ink); font: 700 0.92rem/1 inherit; }
+      button.primary { background: var(--ink); color: white; }
+      .meta { color: var(--muted); font-size: 0.92rem; }
+      code { font-family: ui-monospace, Menlo, monospace; }
+      label { display: grid; gap: 8px; }
+      select, input, textarea {
+        width: 100%;
+        border: 1px solid var(--line);
+        border-radius: 14px;
+        padding: 12px 14px;
+        font: inherit;
+      }
+      textarea { min-height: 90px; resize: vertical; }
+      ul { margin: 10px 0 0; padding-left: 18px; color: var(--muted); }
+      li + li { margin-top: 8px; }
+      @media (max-width: 980px) {
+        .layout { grid-template-columns: 1fr; }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <div class="topbar">
+        <div>
+          <h1>Portal admin console</h1>
+          <p style="margin-top: 10px;">Current runtime posture, role-sensitive review actions, exception decisions, and audit history.</p>
+        </div>
+        <div class="actions">
+          <a class="link" href="/portal">Portal home</a>
+          <a class="link" href="/portal/manager/reviews?actor_role={{ role_view.role.value }}">Review queue</a>
+        </div>
+      </div>
+
+      <div class="layout">
+        <aside class="stack">
+          <section class="panel">
+            <h2>Current actor permissions</h2>
+            <form method="get" action="/portal/admin" style="margin-top: 16px;">
+              <div class="stack">
+                <label>
+                  <span>Viewer role</span>
+                  <select name="actor_role">
+                    {% for role in available_roles %}
+                      <option value="{{ role.value }}" {% if role == role_view.role %}selected{% endif %}>{{ role.value }}</option>
+                    {% endfor %}
+                  </select>
+                </label>
+                <div class="actions">
+                  <button type="submit">Change role view</button>
+                </div>
+              </div>
+            </form>
+            <div class="meta" style="margin-top: 16px;">
+              <span class="badge">{{ role_view.role.value }}</span>
+              {% for permission in role_view.permissions %}
+                <span><code>{{ permission.value }}</code></span>
+              {% endfor %}
+            </div>
+          </section>
+
+          <section class="panel">
+            <h2>Auth/runtime posture</h2>
+            <ul>
+              <li>Auth mode: <code>{{ runtime_config.auth_mode or "unconfigured" }}</code></li>
+              <li>OIDC provider: <code>{{ runtime_config.oidc_provider or "unconfigured" }}</code></li>
+              <li>Access token configured: <strong>{{ runtime_config.access_token_configured }}</strong></li>
+              <li>Bootstrap secret configured: <strong>{{ runtime_config.bootstrap_secret_configured }}</strong></li>
+            </ul>
+          </section>
+        </aside>
+
+        <section class="stack">
+          <section class="panel">
+            <h2>Manager review queue</h2>
+            <div class="list" style="margin-top: 16px;">
+              {% for review in reviews %}
+                <article class="card">
+                  <div class="topbar">
+                    <div>
+                      <h3>{{ review.trip_plan.traveler_name }} to {{ review.trip_plan.destination }}</h3>
+                      <p style="margin-top: 8px;">{{ review.trip_plan.purpose }}</p>
+                    </div>
+                    <span class="badge">{{ review.status.value }}</span>
+                  </div>
+                  <div class="meta">
+                    <span>Draft {{ review.draft_id }}</span>
+                    <span>Trip {{ review.trip_plan.trip_id }}</span>
+                  </div>
+                  <div class="actions" style="margin-top: 14px;">
+                    <a class="link" href="/portal/manager/reviews/{{ review.review_id }}?actor_role={{ role_view.role.value }}">Open review detail</a>
+                    {% if role_can_approve %}
+                      <span class="badge">approval actions enabled</span>
+                    {% else %}
+                      <span class="badge">read-only</span>
+                    {% endif %}
+                  </div>
+                </article>
+              {% else %}
+                <article class="card">
+                  <h3>No manager reviews yet</h3>
+                </article>
+              {% endfor %}
+            </div>
+          </section>
+
+          <section class="panel">
+            <h2>Exception review queue</h2>
+            <div class="list" style="margin-top: 16px;">
+              {% for entry in exception_entries %}
+                <article class="card">
+                  <div class="topbar">
+                    <div>
+                      <h3>{{ entry.request.type.value }}</h3>
+                      <p style="margin-top: 8px;">{{ entry.traveler_name or "Unknown traveler" }}{% if entry.destination %} to {{ entry.destination }}{% endif %}</p>
+                    </div>
+                    <span class="badge">{{ entry.request.status.value }}</span>
+                  </div>
+                  <div class="meta">
+                    <span>Draft {{ entry.draft_id }}</span>
+                    {% if entry.review_id %}<span>Review {{ entry.review_id }}</span>{% endif %}
+                    {% if entry.request.approval_level %}<span>{{ entry.request.approval_level.value }}</span>{% endif %}
+                  </div>
+                  <p style="margin-top: 10px;">{{ entry.request.justification }}</p>
+                  {% if role_can_approve and entry.request.status.value == "pending" %}
+                    <form method="post" action="/portal/admin/exceptions/{{ entry.draft_id }}/{{ entry.exception_index }}/decision?actor_role={{ role_view.role.value }}" style="margin-top: 14px;">
+                      <div class="stack">
+                        <label>
+                          <span>Actor ID</span>
+                          <input name="actor_id" value="admin-1" />
+                        </label>
+                        <label>
+                          <span>Decision</span>
+                          <select name="decision">
+                            <option value="approve">approve</option>
+                            <option value="reject">reject</option>
+                          </select>
+                        </label>
+                        <label>
+                          <span>Notes</span>
+                          <textarea name="notes" placeholder="Summarize the exception disposition."></textarea>
+                        </label>
+                        <div class="actions">
+                          <button class="primary" type="submit">Save exception decision</button>
+                        </div>
+                      </div>
+                    </form>
+                  {% endif %}
+                </article>
+              {% else %}
+                <article class="card">
+                  <h3>No exception requests yet</h3>
+                </article>
+              {% endfor %}
+            </div>
+          </section>
+
+          <section class="panel">
+            <h2>Audit history</h2>
+            <ul>
+              {% for event in audit_events %}
+                <li>{{ event.timestamp.isoformat() }}: {{ event.event_type.value }} · {{ event.outcome }} by {{ event.actor }}{% if event.subject %} on {{ event.subject }}{% endif %}</li>
+              {% else %}
+                <li>No audit events recorded yet.</li>
+              {% endfor %}
+            </ul>
+          </section>
+        </section>
+      </div>
+    </main>
+  </body>
+</html>

--- a/src/travel_plan_permission/templates/portal_admin.html
+++ b/src/travel_plan_permission/templates/portal_admin.html
@@ -68,7 +68,7 @@
       <div class="topbar">
         <div>
           <h1>Portal admin console</h1>
-          <p style="margin-top: 10px;">Current runtime posture, role-sensitive review actions, exception decisions, and audit history.</p>
+          <p style="margin-top: 10px;">Current runtime posture, role-view review actions, exception decisions, and audit history.</p>
         </div>
         <div class="actions">
           <a class="link" href="/portal">Portal home</a>
@@ -79,7 +79,7 @@
       <div class="layout">
         <aside class="stack">
           <section class="panel">
-            <h2>Current actor permissions</h2>
+            <h2>Role permissions (view as)</h2>
             <form method="get" action="/portal/admin" style="margin-top: 16px;">
               <div class="stack">
                 <label>

--- a/src/travel_plan_permission/templates/portal_home.html
+++ b/src/travel_plan_permission/templates/portal_home.html
@@ -121,6 +121,7 @@
         <div class="actions">
           <a class="button primary" href="/portal/draft/new">Start a new request</a>
           <a class="button secondary" href="/readyz">Check runtime readiness</a>
+          <a class="button secondary" href="/portal/admin">Open admin console</a>
         </div>
       </section>
 
@@ -146,6 +147,9 @@
             The portal shell is available without planner credentials; the lower-level planner
             API still follows the normal token requirements.
           </p>
+          {% if runtime_config.auth_mode %}
+            <p style="margin-top: 12px;">Auth mode: <strong>{{ runtime_config.auth_mode }}</strong></p>
+          {% endif %}
         </article>
       </section>
     </main>

--- a/src/travel_plan_permission/templates/review_summary.html
+++ b/src/travel_plan_permission/templates/review_summary.html
@@ -107,6 +107,57 @@
         </section>
       {% endif %}
 
+      {% if review and review.canonical_payload %}
+        <section class="panel">
+          <h2>Policy exception workflow</h2>
+          <p style="margin-top: 10px;">
+            Capture an exception request before approval when the current policy posture needs a
+            documented override.
+          </p>
+          {% if exceptions %}
+            <div class="callout" style="margin-top: 16px;">
+              <h3>Current exception requests</h3>
+              <ul>
+                {% for item in exceptions %}
+                  <li>
+                    {{ item.type.value }} · {{ item.status.value }}
+                    {% if item.approval_level %} · {{ item.approval_level.value }}{% endif %}
+                    {% if item.approval %} · approved by {{ item.approval.approver_id }}{% endif %}
+                  </li>
+                {% endfor %}
+              </ul>
+            </div>
+          {% endif %}
+          <form method="post" action="/portal/review/{{ review.draft_id }}/exceptions" style="margin-top: 16px;">
+            <div class="stack">
+              <label>
+                <span>Exception type</span>
+                <select name="exception_type">
+                  {% for exception_type in exception_types %}
+                    <option value="{{ exception_type.value }}">{{ exception_type.value }}</option>
+                  {% endfor %}
+                </select>
+              </label>
+              <label>
+                <span>Financial impact</span>
+                <input name="amount" type="number" step="0.01" placeholder="Optional amount" />
+              </label>
+              <label>
+                <span>Supporting doc reference</span>
+                <input name="supporting_doc" placeholder="Optional URL or file note" />
+              </label>
+              <label>
+                <span>Justification</span>
+                <textarea name="justification" placeholder="Explain why the traveler needs this exception."></textarea>
+              </label>
+              <div class="actions">
+                <button class="secondary" type="submit">Save exception request</button>
+              </div>
+            </div>
+          </form>
+        </section>
+      {% endif %}
+
       {% if review and review.artifacts %}
         <section class="panel">
           <h2>Generated artifacts</h2>
@@ -133,6 +184,12 @@
           <h2>Submission result</h2>
           <p style="margin-top: 10px;">The proposal submission seam accepted the browser draft.</p>
           <pre>{{ review.submission_response.model_dump_json(indent=2) }}</pre>
+          {% if review.manager_review %}
+            <div class="actions" style="margin-top: 16px;">
+              <a class="button primary" href="/portal/manager/reviews/{{ review.manager_review.review_id }}">Open manager review</a>
+              <a class="button secondary" href="/portal/admin">Open admin console</a>
+            </div>
+          {% endif %}
         </section>
       {% endif %}
     </aside>

--- a/src/travel_plan_permission/templates/review_summary.html
+++ b/src/travel_plan_permission/templates/review_summary.html
@@ -114,6 +114,12 @@
             Capture an exception request before approval when the current policy posture needs a
             documented override.
           </p>
+          {% if error_message %}
+            <div class="callout" style="margin-top: 16px;">
+              <h3>Exception request error</h3>
+              <p style="margin-top: 10px;">{{ error_message }}</p>
+            </div>
+          {% endif %}
           {% if exceptions %}
             <div class="callout" style="margin-top: 16px;">
               <h3>Current exception requests</h3>

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -733,7 +733,7 @@ def test_portal_admin_console_surfaces_permissions_runtime_and_audit_history(
 
     assert console.status_code == 200
     assert "Portal admin console" in console.text
-    assert "Role permissions (view as)" in console.text
+    assert "Role view simulation" in console.text
     assert "finance_admin" in console.text
     assert "static-token" in console.text
     assert "advance_booking" in console.text
@@ -867,7 +867,9 @@ def test_portal_submit_exception_request_returns_400_for_invalid_payload(
     monkeypatch,
 ) -> None:
     _set_runtime_env(monkeypatch)
-    client = TestClient(create_app(PlannerProposalStore()))
+    client = TestClient(
+        create_app(PlannerProposalStore()), raise_server_exceptions=False
+    )
 
     review_response = client.post(
         "/portal/draft",
@@ -887,11 +889,12 @@ def test_portal_submit_exception_request_returns_400_for_invalid_payload(
             "amount": "-5",
             "justification": "too short",
         },
-        follow_redirects=False,
+        follow_redirects=True,
     )
 
     assert response.status_code == 400
-    assert "justification" in response.json()["detail"]
+    assert "Exception request error" in response.text
+    assert "greater than or equal to 0" in response.text
 
 
 def test_portal_exception_decision_returns_404_for_missing_request(monkeypatch) -> None:

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -734,10 +734,64 @@ def test_portal_admin_console_surfaces_permissions_runtime_and_audit_history(
     assert console.status_code == 200
     assert "Portal admin console" in console.text
     assert "Role view simulation" in console.text
+    assert "Authenticated token permissions" in console.text
     assert "finance_admin" in console.text
     assert "static-token" in console.text
     assert "advance_booking" in console.text
     assert "artifact_downloaded" in console.text
+
+
+def test_manager_review_detail_uses_authenticated_permissions_for_actions(
+    monkeypatch,
+) -> None:
+    _set_bootstrap_runtime_env(monkeypatch)
+    store = PlannerProposalStore()
+    client = TestClient(create_app(store))
+
+    response = client.post(
+        "/portal/draft",
+        data=_portal_form_payload(),
+        follow_redirects=True,
+    )
+    draft_match = re.search(
+        r"/portal/review/([^/]+)/artifacts/itinerary", response.text
+    )
+    assert draft_match is not None
+    draft_id = draft_match.group(1)
+    client.post(
+        f"/portal/review/{draft_id}/submit",
+        headers={
+            "Authorization": "Bearer "
+            + mint_bootstrap_token(
+                subject="traveler",
+                permissions=(Permission.CREATE,),
+                provider="google",
+                secret="bootstrap-secret-123",
+                expires_in_seconds=600,
+            )
+        },
+        follow_redirects=True,
+    )
+    review = store.lookup_manager_review_for_draft(draft_id)
+    assert review is not None
+
+    approver_token = mint_bootstrap_token(
+        subject="approver-8",
+        permissions=(Permission.VIEW, Permission.APPROVE),
+        provider="google",
+        secret="bootstrap-secret-123",
+        expires_in_seconds=600,
+    )
+    detail = client.get(
+        f"/portal/manager/reviews/{review.review_id}?actor_role=traveler",
+        headers={"Authorization": f"Bearer {approver_token}"},
+    )
+
+    assert detail.status_code == 200
+    assert "Role view simulation: <strong>traveler</strong>" in detail.text
+    assert "Authenticated token permissions:" in detail.text
+    assert "<code>approve</code>" in detail.text
+    assert "Save manager decision" in detail.text
 
 
 def test_exception_decision_updates_review_detail_and_audit_log(monkeypatch) -> None:

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -733,6 +733,7 @@ def test_portal_admin_console_surfaces_permissions_runtime_and_audit_history(
 
     assert console.status_code == 200
     assert "Portal admin console" in console.text
+    assert "Role permissions (view as)" in console.text
     assert "finance_admin" in console.text
     assert "static-token" in console.text
     assert "advance_booking" in console.text
@@ -804,6 +805,141 @@ def test_exception_decision_updates_review_detail_and_audit_log(monkeypatch) -> 
     assert decision.status_code == 200
     assert "approved by approver-7" in decision.text
     assert "exception · approved by approver-7" in decision.text
+
+
+def test_exception_rejection_keeps_notes_in_audit_log(monkeypatch) -> None:
+    _set_bootstrap_runtime_env(monkeypatch)
+    store = PlannerProposalStore()
+    client = TestClient(create_app(store))
+
+    review_response = client.post(
+        "/portal/draft",
+        data=_portal_form_payload(),
+        follow_redirects=True,
+    )
+    draft_match = re.search(
+        r"/portal/review/([^/]+)/artifacts/itinerary", review_response.text
+    )
+    assert draft_match is not None
+    draft_id = draft_match.group(1)
+    client.post(
+        f"/portal/review/{draft_id}/exceptions",
+        data={
+            "exception_type": "advance_booking",
+            "amount": "6000",
+            "justification": ("Need to lock in the only compliant conference fare. " * 2),
+            "supporting_doc": "docs/approval-workflow.md",
+        },
+        follow_redirects=False,
+    )
+
+    decision = client.post(
+        f"/portal/admin/exceptions/{draft_id}/0/decision?actor_role=approver",
+        headers={
+            "Authorization": "Bearer "
+            + mint_bootstrap_token(
+                subject="approver-9",
+                permissions=(Permission.VIEW, Permission.APPROVE),
+                provider="google",
+                secret="bootstrap-secret-123",
+                expires_in_seconds=600,
+            )
+        },
+        data={
+            "actor_id": "approver-9",
+            "decision": "reject",
+            "notes": "Missing conference justification and fare documentation.",
+        },
+        follow_redirects=False,
+    )
+
+    assert decision.status_code == 303
+    assert any(
+        event.outcome == "rejected"
+        and event.metadata
+        and event.metadata.get("notes")
+        == "Missing conference justification and fare documentation."
+        for event in store.list_audit_events()
+    )
+
+
+def test_portal_submit_exception_request_returns_400_for_invalid_payload(
+    monkeypatch,
+) -> None:
+    _set_runtime_env(monkeypatch)
+    client = TestClient(create_app(PlannerProposalStore()))
+
+    review_response = client.post(
+        "/portal/draft",
+        data=_portal_form_payload(),
+        follow_redirects=True,
+    )
+    draft_match = re.search(
+        r"/portal/review/([^/]+)/artifacts/itinerary", review_response.text
+    )
+    assert draft_match is not None
+    draft_id = draft_match.group(1)
+
+    response = client.post(
+        f"/portal/review/{draft_id}/exceptions",
+        data={
+            "exception_type": "advance_booking",
+            "amount": "-5",
+            "justification": "too short",
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 400
+    assert "justification" in response.json()["detail"]
+
+
+def test_portal_exception_decision_returns_404_for_missing_request(monkeypatch) -> None:
+    _set_bootstrap_runtime_env(monkeypatch)
+    client = TestClient(create_app(PlannerProposalStore()))
+
+    response = client.post(
+        "/portal/admin/exceptions/missing-draft/0/decision?actor_role=approver",
+        headers={
+            "Authorization": "Bearer "
+            + mint_bootstrap_token(
+                subject="approver-7",
+                permissions=(Permission.VIEW, Permission.APPROVE),
+                provider="google",
+                secret="bootstrap-secret-123",
+                expires_in_seconds=600,
+            )
+        },
+        data={
+            "actor_id": "approver-7",
+            "decision": "approve",
+            "notes": "No matching request.",
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Exception request not found."
+
+
+def test_save_portal_draft_evicts_exception_state_with_oldest_draft() -> None:
+    store = PlannerProposalStore()
+    old_draft = store.save_portal_draft({"traveler_name": "First"})
+    store.create_exception_request(
+        old_draft.draft_id,
+        http_service.ExceptionRequest(
+            type=http_service.ExceptionType.ADVANCE_BOOKING,
+            justification="Need to keep the first bounded exception state attached. " * 2,
+            requestor="traveler-1",
+            amount="100",
+        ),
+    )
+
+    for index in range(1, http_service._PORTAL_MAX_DRAFTS + 1):
+        store.save_portal_draft({"traveler_name": f"Traveler {index}"})
+
+    assert old_draft.draft_id not in store.portal_drafts_by_id
+    assert old_draft.draft_id not in store.exception_requests_by_draft_id
 
 
 def test_manager_review_store_returns_copies() -> None:

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -655,6 +655,157 @@ def test_manager_review_decision_requires_approve_permission(monkeypatch) -> Non
     assert "does not grant 'approve'" in decision.json()["detail"]
 
 
+def test_manager_review_detail_hides_decision_form_for_read_only_role(
+    monkeypatch,
+) -> None:
+    _set_runtime_env(monkeypatch)
+    store = PlannerProposalStore()
+    client = TestClient(create_app(store))
+
+    response = client.post(
+        "/portal/draft",
+        data=_portal_form_payload(),
+        follow_redirects=True,
+    )
+    draft_match = re.search(
+        r"/portal/review/([^/]+)/artifacts/itinerary", response.text
+    )
+    assert draft_match is not None
+    draft_id = draft_match.group(1)
+    client.post(
+        f"/portal/review/{draft_id}/submit",
+        headers=AUTH_HEADER,
+        follow_redirects=True,
+    )
+    review = store.lookup_manager_review_for_draft(draft_id)
+    assert review is not None
+
+    detail = client.get(
+        f"/portal/manager/reviews/{review.review_id}?actor_role=traveler",
+        headers=AUTH_HEADER,
+    )
+
+    assert detail.status_code == 200
+    assert "Read-only role" in detail.text
+    assert "Save manager decision" not in detail.text
+
+
+def test_portal_admin_console_surfaces_permissions_runtime_and_audit_history(
+    monkeypatch,
+) -> None:
+    _set_runtime_env(monkeypatch)
+    store = PlannerProposalStore()
+    client = TestClient(create_app(store))
+
+    review_response = client.post(
+        "/portal/draft",
+        data=_portal_form_payload(),
+        follow_redirects=True,
+    )
+    draft_match = re.search(
+        r"/portal/review/([^/]+)/artifacts/itinerary", review_response.text
+    )
+    assert draft_match is not None
+    draft_id = draft_match.group(1)
+    client.post(
+        f"/portal/review/{draft_id}/exceptions",
+        data={
+            "exception_type": "advance_booking",
+            "amount": "6000",
+            "justification": ("Need to lock in the only compliant conference fare. " * 2),
+            "supporting_doc": "docs/approval-workflow.md",
+        },
+        follow_redirects=False,
+    )
+    client.post(
+        f"/portal/review/{draft_id}/submit",
+        headers=AUTH_HEADER,
+        follow_redirects=True,
+    )
+    review = store.lookup_manager_review_for_draft(draft_id)
+    assert review is not None
+    client.get(f"/portal/review/{draft_id}/artifacts/summary")
+
+    console = client.get(
+        "/portal/admin?actor_role=finance_admin",
+        headers=AUTH_HEADER,
+    )
+
+    assert console.status_code == 200
+    assert "Portal admin console" in console.text
+    assert "finance_admin" in console.text
+    assert "static-token" in console.text
+    assert "advance_booking" in console.text
+    assert "artifact_downloaded" in console.text
+
+
+def test_exception_decision_updates_review_detail_and_audit_log(monkeypatch) -> None:
+    _set_bootstrap_runtime_env(monkeypatch)
+    store = PlannerProposalStore()
+    client = TestClient(create_app(store))
+
+    review_response = client.post(
+        "/portal/draft",
+        data=_portal_form_payload(),
+        follow_redirects=True,
+    )
+    draft_match = re.search(
+        r"/portal/review/([^/]+)/artifacts/itinerary", review_response.text
+    )
+    assert draft_match is not None
+    draft_id = draft_match.group(1)
+    client.post(
+        f"/portal/review/{draft_id}/exceptions",
+        data={
+            "exception_type": "advance_booking",
+            "amount": "6000",
+            "justification": ("Need to lock in the only compliant conference fare. " * 2),
+            "supporting_doc": "docs/approval-workflow.md",
+        },
+        follow_redirects=False,
+    )
+    client.post(
+        f"/portal/review/{draft_id}/submit",
+        headers={
+            "Authorization": "Bearer "
+            + mint_bootstrap_token(
+                subject="traveler",
+                permissions=(Permission.CREATE,),
+                provider="google",
+                secret="bootstrap-secret-123",
+                expires_in_seconds=600,
+            )
+        },
+        follow_redirects=True,
+    )
+    review = store.lookup_manager_review_for_draft(draft_id)
+    assert review is not None
+
+    decision = client.post(
+        f"/portal/admin/exceptions/{draft_id}/0/decision?actor_role=approver",
+        headers={
+            "Authorization": "Bearer "
+            + mint_bootstrap_token(
+                subject="approver-7",
+                permissions=(Permission.VIEW, Permission.APPROVE),
+                provider="google",
+                secret="bootstrap-secret-123",
+                expires_in_seconds=600,
+            )
+        },
+        data={
+            "actor_id": "approver-7",
+            "decision": "approve",
+            "notes": "Conference booking window requires the exception.",
+        },
+        follow_redirects=True,
+    )
+
+    assert decision.status_code == 200
+    assert "approved by approver-7" in decision.text
+    assert "exception · approved by approver-7" in decision.text
+
+
 def test_manager_review_store_returns_copies() -> None:
     store = PlannerProposalStore()
     fixture = _load_fixture("proposal_submission.json")


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #800

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The repo already contains strong security, exception, and approval models, but
those capabilities are still mostly domain-layer assets. To reach a mature
implementable product state, the portal needs concrete admin/runtime surfaces
for access control, exception review, and audit inspection.

#### Tasks
- [ ] Add portal/admin views for role-aware review actions and current actor permissions
- [ ] Add exception request and exception review UI using the existing exception/security models
- [ ] Expose audit history views for request, review, and reimbursement actions using a durable stored audit trail
- [ ] Tighten auth/runtime configuration docs so the portal and planner-service auth stories are both explicit
- [ ] Add tests covering permission-sensitive UI/actions, exception transitions, and audit-history rendering
- [ ] Update security and audit docs to distinguish what is fully shipped now from later hardening work

#### Acceptance criteria
- [ ] Role-sensitive portal actions are enforced and visible in the UI
- [ ] Exception requests and decisions move through a concrete, test-covered workflow
- [ ] Audit history is inspectable for the main workflow transitions
- [ ] Security and auth docs match the actual product surface

**Head SHA:** f6ae3a55384244376781966024ea67fc888584c4
**Latest Runs:** ❔ in progress — Agents PR Meta
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24470972440) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24470976341) |
<!-- auto-status-summary:end -->