### PR TITLE
Issue #801: add expense portal review and exports

### DIFF
--- a/docs/accounting-integration.md
+++ b/docs/accounting-integration.md
@@ -2,6 +2,8 @@
 
 The accounting export provides CSV and Excel outputs that finance teams can import directly into downstream systems.
 
+The browser-facing expense portal at `/portal/expenses/new` now generates these same artifacts for draft reimbursement reports, so accounting handoff stays aligned with the repo’s shared export layer.
+
 ## Column schema and order
 
 The exports always include a header row using the following columns in order:
@@ -34,3 +36,4 @@ Receipt links are signed for 7 days and emitted as clickable hyperlinks in the E
 * Batch exports support up to **100** expense reports.
 * CSV output is UTF-8 encoded with a header row.
 * Excel amounts are formatted with currency number formatting for rapid review.
+* The expense portal is export-only for now; direct accounting-system writes remain out of scope.

--- a/docs/expense-workflow.md
+++ b/docs/expense-workflow.md
@@ -22,3 +22,15 @@
 - `Receipt` captures vendor, total, date, storage reference, file size, and a third-party flag.
 - `ExpenseItem` includes a `receipt_references` list, enabling multiple receipts per line item and third-party tracking.
 - `ExpenseReport.total_amount()` now returns the reimbursable total, omitting third-party covered expenses.
+
+## Portal review flow
+
+- The browser-facing expense portal lives at `/portal/expenses/new` and links every draft to an approved request identifier before export.
+- Reviewers can see three explicit states in one screen: receipt missing/incomplete vs attached, policy warnings from the approval engine, and the current reimbursement/accounting disposition.
+- Accounting handoff artifacts are generated through `ExportService.to_csv()` and `ExportService.to_excel()` so the portal reuses the existing export layer rather than producing ad hoc files.
+- OCR text is optional and advisory: extracted vendor/total/date are surfaced next to the manually entered receipt values so reviewers can spot mismatches before reimbursement.
+
+## Current boundary
+
+- This stage stops at export-ready accounting handoff artifacts and status tracking inside the portal UI.
+- Direct ERP or reimbursement-system writes remain out of scope until a later integration pass.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -37,3 +37,13 @@ Collecting Receipts → Employee Submit → Manager Review → Accounting Review
 → Reimbursed
 
 Branches: Missing Receipt, Policy Warning (manager override allowed), Reject.
+
+### Expense portal contract
+
+The Stage 2 browser portal now exposes a separate expense and reimbursement flow:
+
+- `GET /portal/expenses/new` renders `templates/portal_expense.html`
+- `POST /portal/expenses/review` validates the current expense submission and saves a draft when the required fields are present
+- `GET /portal/expenses/{draft_id}` renders the linked receipt, manager/accounting disposition, and accounting export handoff
+
+The expense portal intentionally reuses the existing approval and export services. It does not write directly into an external reimbursement or ERP system yet.

--- a/src/travel_plan_permission/approval.py
+++ b/src/travel_plan_permission/approval.py
@@ -6,6 +6,7 @@ import os
 from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from importlib import resources
 from pathlib import Path
 
 import yaml
@@ -35,6 +36,16 @@ def _default_rules_path() -> Path | None:
     return None
 
 
+def _package_rules_resource() -> resources.abc.Traversable | None:
+    try:
+        resource = resources.files("travel_plan_permission").joinpath(
+            "config", "approval_rules.yaml"
+        )
+    except ModuleNotFoundError:
+        return None
+    return resource if resource.is_file() else None
+
+
 @dataclass
 class ApprovalEngine:
     """Evaluate expenses against configured approval rules."""
@@ -57,10 +68,13 @@ class ApprovalEngine:
 
         target_path = Path(path) if path is not None else _default_rules_path()
 
-        if target_path is None:
-            raise FileNotFoundError("No approval rules file found")
-
-        content = target_path.read_text(encoding="utf-8")
+        if target_path is None or not target_path.exists():
+            resource = _package_rules_resource()
+            if resource is None:
+                raise FileNotFoundError("No approval rules file found")
+            content = resource.read_text(encoding="utf-8")
+        else:
+            content = target_path.read_text(encoding="utf-8")
         return cls.from_yaml(content)
 
     @classmethod

--- a/src/travel_plan_permission/config/approval_rules.yaml
+++ b/src/travel_plan_permission/config/approval_rules.yaml
@@ -1,0 +1,14 @@
+rules:
+  - name: meals_manager_review
+    category: meals
+    threshold: 300
+    action: require_approval
+    approver: manager
+  - name: default_under_100
+    threshold: 100
+    action: auto_approve
+    approver: system
+  - name: high_amount_flag
+    threshold: 5000
+    action: require_approval
+    approver: manager

--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -1001,7 +1001,7 @@ def _expense_review_state(
                 draft_id=draft_id,
                 expense_report=expense_report,
             )
-        except (ValueError, ValidationError) as exc:
+        except (InvalidOperation, ValueError, ValidationError) as exc:
             if isinstance(exc, ValidationError):
                 validation_errors.extend(
                     f"{'.'.join(str(part) for part in error['loc'])}: {error['msg']}"
@@ -1207,8 +1207,11 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
                 status_code=status.HTTP_400_BAD_REQUEST,
             )
         draft = proposal_store.save_expense_draft(answers)
-        if review.artifacts:
-            proposal_store.cache_expense_artifacts(draft.draft_id, review.artifacts)
+        persisted_review = _expense_review_state(draft.draft_id, answers)
+        if persisted_review.artifacts:
+            proposal_store.cache_expense_artifacts(
+                draft.draft_id, persisted_review.artifacts
+            )
         return RedirectResponse(
             url=request.url_for("portal_expense_detail", draft_id=draft.draft_id),
             status_code=status.HTTP_303_SEE_OTHER,

--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 import sys
 from dataclasses import dataclass, field, replace
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from urllib.parse import parse_qs
@@ -26,7 +26,17 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel, Field, ValidationError
 
-from .models import ExceptionRequest, ExceptionType, TripPlan
+from .approval import ApprovalEngine
+from .export import ExportService
+from .models import (
+    ApprovalStatus,
+    ExceptionRequest,
+    ExceptionType,
+    ExpenseCategory,
+    ExpenseItem,
+    ExpenseReport,
+    TripPlan,
+)
 from .planner_auth import PlannerAuthConfig, PlannerAuthContext, authenticate_request
 from .policy_api import (
     PlannerPolicySnapshot,
@@ -48,6 +58,7 @@ from .portal_review import (
     portal_review_state,
     portal_validation_state,
 )
+from .receipts import Receipt, ReceiptExtractionResult, ReceiptProcessor
 from .review_workflow import ReviewAction, ReviewRequest, ReviewWorkflowStore
 from .security import (
     DEFAULT_ROLES,
@@ -166,6 +177,45 @@ _PORTAL_BOOLEAN_FIELDS = {
     "meal_per_diem_requested",
 }
 _PORTAL_MAX_DRAFTS = 64
+_EXPENSE_FIELDS: tuple[str, ...] = (
+    "approved_request_id",
+    "trip_id",
+    "traveler_name",
+    "cost_center",
+    "expense_description",
+    "expense_category",
+    "expense_amount",
+    "expense_date",
+    "expense_vendor",
+    "receipt_file_reference",
+    "receipt_file_size_bytes",
+    "receipt_total",
+    "receipt_date",
+    "receipt_vendor",
+    "receipt_paid_by_third_party",
+    "third_party_paid_explanation",
+    "receipt_ocr_text",
+    "manager_disposition",
+    "accounting_disposition",
+    "reimbursement_status",
+)
+_EXPENSE_REQUIRED_FIELDS: tuple[str, ...] = (
+    "approved_request_id",
+    "trip_id",
+    "traveler_name",
+    "expense_description",
+    "expense_category",
+    "expense_amount",
+    "expense_date",
+)
+_EXPENSE_BOOLEAN_FIELDS = {"receipt_paid_by_third_party"}
+_EXPENSE_STATUS_OPTIONS: tuple[str, ...] = (
+    "draft",
+    "manager_review",
+    "accounting_review",
+    "export_ready",
+    "reimbursed",
+)
 
 
 @dataclass(frozen=True)
@@ -196,6 +246,21 @@ class RoleView:
 
     role: RoleName
     permissions: tuple[Permission, ...]
+
+
+@dataclass(frozen=True)
+class ExpensePortalReviewState:
+    """Computed expense portal review context derived from a draft."""
+
+    draft_id: str
+    answers: dict[str, object]
+    missing_fields: list[str]
+    validation_errors: list[str]
+    receipt_state: str
+    receipt_extraction: ReceiptExtractionResult | None
+    expense_report: ExpenseReport | None
+    review_warnings: list[str]
+    artifacts: dict[str, PortalArtifact]
 
 
 class PlannerRuntimeConfigError(RuntimeError):
@@ -340,6 +405,7 @@ class PlannerProposalStore:
     plans_by_trip_id: dict[str, TripPlan] = field(default_factory=dict)
     proposals_by_execution_id: dict[str, StoredProposal] = field(default_factory=dict)
     portal_drafts_by_id: dict[str, PortalDraft] = field(default_factory=dict)
+    expense_drafts_by_id: dict[str, PortalDraft] = field(default_factory=dict)
     manager_reviews: ReviewWorkflowStore = field(default_factory=ReviewWorkflowStore)
     exception_requests_by_draft_id: dict[str, list[ExceptionRequest]] = field(
         default_factory=dict
@@ -438,6 +504,61 @@ class PlannerProposalStore:
         """Return a previously stored portal draft by identifier."""
 
         draft = self.portal_drafts_by_id.get(draft_id)
+        if draft is None:
+            return None
+        return PortalDraft(
+            draft_id=draft.draft_id,
+            answers=dict(draft.answers),
+            updated_at=draft.updated_at,
+            cached_artifacts=dict(draft.cached_artifacts),
+        )
+
+    def save_expense_draft(self, answers: dict[str, object]) -> PortalDraft:
+        """Persist expense portal answers so review and export can be revisited."""
+
+        if len(self.expense_drafts_by_id) >= _PORTAL_MAX_DRAFTS:
+            oldest_draft_id = min(
+                self.expense_drafts_by_id.items(),
+                key=lambda item: item[1].updated_at,
+            )[0]
+            del self.expense_drafts_by_id[oldest_draft_id]
+        draft = PortalDraft(
+            draft_id=uuid4().hex[:12],
+            answers=dict(answers),
+            updated_at=datetime.now(UTC),
+        )
+        self.expense_drafts_by_id[draft.draft_id] = draft
+        self.security.audit_log.record(
+            event_type=AuditEventType.REQUEST,
+            actor=str(answers.get("traveler_name") or "expense-portal-traveler"),
+            subject=draft.draft_id,
+            outcome="expense_draft_saved",
+            metadata={"surface": "expense-portal"},
+        )
+        return draft
+
+    def cache_expense_artifacts(
+        self,
+        draft_id: str,
+        artifacts: dict[str, PortalArtifact],
+    ) -> PortalDraft | None:
+        """Persist generated expense export artifacts for repeated downloads."""
+
+        draft = self.expense_drafts_by_id.get(draft_id)
+        if draft is None:
+            return None
+        updated = replace(
+            draft,
+            updated_at=datetime.now(UTC),
+            cached_artifacts=dict(artifacts),
+        )
+        self.expense_drafts_by_id[draft_id] = updated
+        return updated
+
+    def lookup_expense_draft(self, draft_id: str) -> PortalDraft | None:
+        """Return a previously stored expense portal draft by identifier."""
+
+        draft = self.expense_drafts_by_id.get(draft_id)
         if draft is None:
             return None
         return PortalDraft(
@@ -675,7 +796,7 @@ def _normalize_portal_value(field_name: str, raw_value: str) -> object | None:
     value = raw_value.strip()
     if not value:
         return None
-    if field_name in _PORTAL_BOOLEAN_FIELDS:
+    if field_name in _PORTAL_BOOLEAN_FIELDS or field_name in _EXPENSE_BOOLEAN_FIELDS:
         normalized = value.casefold()
         if normalized in {"true", "yes", "on", "1"}:
             return True
@@ -688,6 +809,20 @@ def _portal_answers_from_encoded_body(body: bytes) -> dict[str, object]:
     answers: dict[str, object] = {}
     parsed = parse_qs(body.decode("utf-8"), keep_blank_values=False)
     for field_name in _PORTAL_FIELDS:
+        values = parsed.get(field_name)
+        if not values:
+            continue
+        normalized = _normalize_portal_value(field_name, values[-1])
+        if normalized is None:
+            continue
+        answers[field_name] = normalized
+    return answers
+
+
+def _expense_answers_from_encoded_body(body: bytes) -> dict[str, object]:
+    answers: dict[str, object] = {}
+    parsed = parse_qs(body.decode("utf-8"), keep_blank_values=False)
+    for field_name in _EXPENSE_FIELDS:
         values = parsed.get(field_name)
         if not values:
             continue
@@ -737,6 +872,157 @@ def _canonical_payload_from_answers(answers: dict[str, object]) -> dict[str, obj
     return payload
 
 
+def _expense_export_artifacts(
+    *,
+    draft_id: str,
+    expense_report: ExpenseReport,
+) -> dict[str, PortalArtifact]:
+    service = ExportService()
+    csv_filename, csv_content = service.to_csv([expense_report], batch_id=draft_id)
+    excel_filename, excel_content = service.to_excel([expense_report], batch_id=draft_id)
+    return {
+        "expense-csv": PortalArtifact(
+            filename=csv_filename,
+            content=csv_content.encode("utf-8"),
+            media_type="text/csv; charset=utf-8",
+        ),
+        "expense-xlsx": PortalArtifact(
+            filename=excel_filename,
+            content=excel_content,
+            media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        ),
+    }
+
+
+def _expense_review_state(
+    draft_id: str,
+    answers: dict[str, object],
+) -> ExpensePortalReviewState:
+    missing_fields = [
+        field_name for field_name in _EXPENSE_REQUIRED_FIELDS if not answers.get(field_name)
+    ]
+    validation_errors: list[str] = []
+    review_warnings: list[str] = []
+    receipt_state = "missing"
+    receipt_extraction: ReceiptExtractionResult | None = None
+    expense_report: ExpenseReport | None = None
+    artifacts: dict[str, PortalArtifact] = {}
+
+    ocr_text = answers.get("receipt_ocr_text")
+    if isinstance(ocr_text, str) and ocr_text.strip():
+        receipt_extraction = ReceiptProcessor.extract_from_text(ocr_text)
+
+    if not missing_fields:
+        try:
+            category = ExpenseCategory(str(answers["expense_category"]))
+            expense_amount = Decimal(str(answers["expense_amount"]))
+            expense_date = date.fromisoformat(str(answers["expense_date"]))
+            receipt_reference = answers.get("receipt_file_reference")
+            receipt: Receipt | None = None
+            if receipt_reference:
+                if not all(
+                    (
+                        answers.get("receipt_file_size_bytes"),
+                        answers.get("receipt_total"),
+                        answers.get("receipt_date"),
+                        answers.get("receipt_vendor"),
+                    )
+                ):
+                    validation_errors.append(
+                        "Receipt uploads require file size, total, date, and vendor details."
+                    )
+                    receipt_state = "incomplete"
+                else:
+                    receipt = Receipt.from_manual_entry(
+                        total=Decimal(str(answers["receipt_total"])),
+                        date=date.fromisoformat(str(answers["receipt_date"])),
+                        vendor=str(answers["receipt_vendor"]),
+                        file_reference=str(receipt_reference),
+                        file_size_bytes=int(str(answers["receipt_file_size_bytes"])),
+                        paid_by_third_party=bool(answers.get("receipt_paid_by_third_party")),
+                    )
+                    receipt_state = "attached"
+                    if receipt_extraction is not None:
+                        mismatches: list[str] = []
+                        if (
+                            receipt_extraction.vendor is not None
+                            and receipt_extraction.vendor != receipt.vendor
+                        ):
+                            mismatches.append("vendor")
+                        if (
+                            receipt_extraction.total is not None
+                            and receipt_extraction.total != receipt.total
+                        ):
+                            mismatches.append("total")
+                        if (
+                            receipt_extraction.date is not None
+                            and receipt_extraction.date != receipt.date
+                        ):
+                            mismatches.append("date")
+                        if mismatches:
+                            review_warnings.append(
+                                "Manual receipt entry overrides OCR values for "
+                                + ", ".join(mismatches)
+                                + "."
+                            )
+            else:
+                review_warnings.append(
+                    "Receipt missing: reviewers should hold reimbursement until the traveler uploads support."
+                )
+
+            expense = ExpenseItem(
+                category=category,
+                description=str(answers["expense_description"]),
+                vendor=str(answers.get("expense_vendor") or "") or None,
+                amount=expense_amount,
+                expense_date=expense_date,
+                receipt_attached=receipt is not None,
+                receipt_url=str(receipt_reference) if receipt_reference else None,
+                receipt_references=[receipt] if receipt is not None else [],
+                third_party_paid_explanation=(
+                    str(answers["third_party_paid_explanation"])
+                    if answers.get("third_party_paid_explanation")
+                    else None
+                ),
+            )
+            expense_report = ExpenseReport(
+                report_id=f"EXP-{draft_id.upper()}",
+                trip_id=str(answers["trip_id"]),
+                traveler_name=str(answers["traveler_name"]),
+                cost_center=str(answers.get("cost_center") or "") or None,
+                expenses=[expense],
+            )
+            expense_report = ApprovalEngine.from_file().evaluate_report(expense_report)
+            if expense_report.approval_status == ApprovalStatus.FLAGGED:
+                review_warnings.append(
+                    "Policy warning: manager or accounting review is required before reimbursement."
+                )
+            artifacts = _expense_export_artifacts(
+                draft_id=draft_id,
+                expense_report=expense_report,
+            )
+        except (ValueError, ValidationError) as exc:
+            if isinstance(exc, ValidationError):
+                validation_errors.extend(
+                    f"{'.'.join(str(part) for part in error['loc'])}: {error['msg']}"
+                    for error in exc.errors()
+                )
+            else:
+                validation_errors.append(str(exc))
+
+    return ExpensePortalReviewState(
+        draft_id=draft_id,
+        answers=answers,
+        missing_fields=missing_fields,
+        validation_errors=validation_errors,
+        receipt_state=receipt_state,
+        receipt_extraction=receipt_extraction,
+        expense_report=expense_report,
+        review_warnings=review_warnings,
+        artifacts=artifacts,
+    )
+
+
 def _portal_template_context(
     request: Request,
     review: PortalReviewState | None = None,
@@ -759,6 +1045,20 @@ def _portal_template_context(
         ),
         "optional_fields": _PORTAL_OPTIONAL_FIELDS,
         "error_message": error_message,
+    }
+
+
+def _expense_template_context(
+    request: Request,
+    review: ExpensePortalReviewState | None = None,
+) -> dict[str, object]:
+    answers = review.answers if review is not None else {}
+    return {
+        "request": request,
+        "answers": answers,
+        "review": review,
+        "expense_categories": tuple(category.value for category in ExpenseCategory),
+        "reimbursement_status_options": _EXPENSE_STATUS_OPTIONS,
     }
 
 
@@ -856,6 +1156,14 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
             },
         )
 
+    @app.get("/portal/expenses/new", response_class=HTMLResponse)
+    def portal_expense_form(request: Request) -> HTMLResponse:
+        return _TEMPLATES.TemplateResponse(
+            request=request,
+            name="portal_expense.html",
+            context=_expense_template_context(request, None),
+        )
+
     @app.get("/portal/draft/new", response_class=HTMLResponse)
     def portal_draft_form(request: Request) -> HTMLResponse:
         return _TEMPLATES.TemplateResponse(
@@ -884,6 +1192,25 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
             proposal_store.cache_portal_artifacts(draft.draft_id, review.artifacts)
         return RedirectResponse(
             url=request.url_for("portal_review_detail", draft_id=draft.draft_id),
+            status_code=status.HTTP_303_SEE_OTHER,
+        )
+
+    @app.post("/portal/expenses/review")
+    async def portal_expense_review(request: Request) -> Response:
+        answers = _expense_answers_from_encoded_body(await request.body())
+        review = _expense_review_state("preview", answers)
+        if review.missing_fields or review.validation_errors:
+            return _TEMPLATES.TemplateResponse(
+                request=request,
+                name="portal_expense.html",
+                context=_expense_template_context(request, review),
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
+        draft = proposal_store.save_expense_draft(answers)
+        if review.artifacts:
+            proposal_store.cache_expense_artifacts(draft.draft_id, review.artifacts)
+        return RedirectResponse(
+            url=request.url_for("portal_expense_detail", draft_id=draft.draft_id),
             status_code=status.HTTP_303_SEE_OTHER,
         )
 
@@ -918,6 +1245,27 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
                 review,
                 exceptions=proposal_store.list_exception_requests(draft_id),
             ),
+        )
+
+    @app.get(
+        "/portal/expenses/{draft_id}",
+        response_class=HTMLResponse,
+        name="portal_expense_detail",
+    )
+    def portal_expense_detail(request: Request, draft_id: str) -> HTMLResponse:
+        draft = proposal_store.lookup_expense_draft(draft_id)
+        if draft is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"No expense portal draft found for '{draft_id}'.",
+            )
+        review = _expense_review_state(draft.draft_id, draft.answers)
+        if review.artifacts and not draft.cached_artifacts:
+            proposal_store.cache_expense_artifacts(draft.draft_id, review.artifacts)
+        return _TEMPLATES.TemplateResponse(
+            request=request,
+            name="portal_expense.html",
+            context=_expense_template_context(request, review),
         )
 
     @app.post("/portal/review/{draft_id}/exceptions")
@@ -1316,6 +1664,44 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         proposal_store.security.audit_log.record(
             event_type=AuditEventType.EXPORT,
             actor="workflow-portal",
+            subject=draft_id,
+            outcome="artifact_downloaded",
+            metadata={"artifact": artifact_name},
+        )
+        return Response(
+            content=artifact.content,
+            media_type=artifact.media_type,
+            headers={
+                "Content-Disposition": f'attachment; filename="{artifact.filename}"'
+            },
+        )
+
+    @app.get("/portal/expenses/{draft_id}/artifacts/{artifact_name}")
+    def portal_expense_artifact(
+        draft_id: str,
+        artifact_name: str,
+    ) -> Response:
+        draft = proposal_store.lookup_expense_draft(draft_id)
+        if draft is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"No expense portal draft found for '{draft_id}'.",
+            )
+        artifacts = draft.cached_artifacts
+        if not artifacts:
+            review = _expense_review_state(draft.draft_id, draft.answers)
+            artifacts = review.artifacts
+            if artifacts:
+                proposal_store.cache_expense_artifacts(draft.draft_id, artifacts)
+        artifact = artifacts.get(artifact_name)
+        if artifact is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"No artifact named '{artifact_name}' for expense draft '{draft_id}'.",
+            )
+        proposal_store.security.audit_log.record(
+            event_type=AuditEventType.EXPORT,
+            actor="expense-portal",
             subject=draft_id,
             outcome="artifact_downloaded",
             metadata={"artifact": artifact_name},

--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -1001,14 +1001,21 @@ def _expense_review_state(
                 draft_id=draft_id,
                 expense_report=expense_report,
             )
-        except (InvalidOperation, ValueError, ValidationError) as exc:
-            if isinstance(exc, ValidationError):
-                validation_errors.extend(
-                    f"{'.'.join(str(part) for part in error['loc'])}: {error['msg']}"
-                    for error in exc.errors()
-                )
-            else:
-                validation_errors.append(str(exc))
+        except ValidationError as exc:
+            validation_errors.extend(
+                f"{'.'.join(str(part) for part in error['loc'])}: {error['msg']}"
+                for error in exc.errors()
+            )
+        except FileNotFoundError:
+            validation_errors.append(
+                "Approval rules configuration is unavailable; expense policy review cannot be completed."
+            )
+        except InvalidOperation:
+            validation_errors.append(
+                "One or more currency amounts are not valid decimal values."
+            )
+        except ValueError as exc:
+            validation_errors.append(str(exc))
 
     return ExpensePortalReviewState(
         draft_id=draft_id,

--- a/src/travel_plan_permission/templates/portal_expense.html
+++ b/src/travel_plan_permission/templates/portal_expense.html
@@ -1,0 +1,201 @@
+{% extends "portal_base.html" %}
+
+{% block title %}Expense Portal{% endblock %}
+
+{% block topbar_badge %}
+  {% if review %}
+    <span class="badge">Expense draft {{ review.draft_id }}</span>
+  {% endif %}
+{% endblock %}
+
+{% block content %}
+  <div class="layout">
+    <section class="panel">
+      <div class="intro">
+        <h1>Prepare an expense report from an approved request.</h1>
+        <p>
+          Link the expense draft to an approved request, capture receipt metadata with optional OCR
+          text, and generate the accounting handoff from the repo's current approval and export services.
+        </p>
+      </div>
+
+      <form method="post" action="/portal/expenses/review">
+        <div class="section-grid">
+          <section class="section-card">
+            <h2>Report linkage</h2>
+            <div class="fields">
+              <label><div class="label-row"><span>Approved request ID</span></div><input name="approved_request_id" value="{{ answers.get('approved_request_id', '') }}" /></label>
+              <label><div class="label-row"><span>Trip ID</span></div><input name="trip_id" value="{{ answers.get('trip_id', '') }}" /></label>
+              <label><div class="label-row"><span>Traveler name</span></div><input name="traveler_name" value="{{ answers.get('traveler_name', '') }}" /></label>
+              <label><div class="label-row"><span>Cost center</span><span class="optional">Optional</span></div><input name="cost_center" value="{{ answers.get('cost_center', '') }}" /></label>
+            </div>
+          </section>
+
+          <section class="section-card">
+            <h2>Expense line</h2>
+            <div class="fields">
+              <label><div class="label-row"><span>Description</span></div><input name="expense_description" value="{{ answers.get('expense_description', '') }}" /></label>
+              <label>
+                <div class="label-row"><span>Category</span></div>
+                <select name="expense_category">
+                  <option value="">Select</option>
+                  {% for option in expense_categories %}
+                    <option value="{{ option }}" {% if answers.get('expense_category') == option %}selected{% endif %}>{{ option }}</option>
+                  {% endfor %}
+                </select>
+              </label>
+              <label><div class="label-row"><span>Amount</span></div><input type="number" step="0.01" name="expense_amount" value="{{ answers.get('expense_amount', '') }}" /></label>
+              <label><div class="label-row"><span>Expense date</span></div><input type="date" name="expense_date" value="{{ answers.get('expense_date', '') }}" /></label>
+              <label><div class="label-row"><span>Vendor</span><span class="optional">Optional</span></div><input name="expense_vendor" value="{{ answers.get('expense_vendor', '') }}" /></label>
+            </div>
+          </section>
+
+          <section class="section-card">
+            <h2>Receipt intake</h2>
+            <div class="fields">
+              <label><div class="label-row"><span>Receipt file reference</span><span class="optional">Optional</span></div><input name="receipt_file_reference" value="{{ answers.get('receipt_file_reference', '') }}" /></label>
+              <label><div class="label-row"><span>Receipt size bytes</span><span class="optional">Optional</span></div><input type="number" step="1" name="receipt_file_size_bytes" value="{{ answers.get('receipt_file_size_bytes', '') }}" /></label>
+              <label><div class="label-row"><span>Manual receipt total</span><span class="optional">Optional</span></div><input type="number" step="0.01" name="receipt_total" value="{{ answers.get('receipt_total', '') }}" /></label>
+              <label><div class="label-row"><span>Manual receipt date</span><span class="optional">Optional</span></div><input type="date" name="receipt_date" value="{{ answers.get('receipt_date', '') }}" /></label>
+              <label><div class="label-row"><span>Manual receipt vendor</span><span class="optional">Optional</span></div><input name="receipt_vendor" value="{{ answers.get('receipt_vendor', '') }}" /></label>
+              <label>
+                <div class="label-row"><span>Paid by third party</span><span class="optional">Optional</span></div>
+                <select name="receipt_paid_by_third_party">
+                  <option value="">Select</option>
+                  <option value="true" {% if answers.get('receipt_paid_by_third_party') in [True, 'true'] %}selected{% endif %}>Yes</option>
+                  <option value="false" {% if answers.get('receipt_paid_by_third_party') in [False, 'false'] %}selected{% endif %}>No</option>
+                </select>
+              </label>
+              <label><div class="label-row"><span>Third-party explanation</span><span class="optional">Optional</span></div><textarea name="third_party_paid_explanation">{{ answers.get('third_party_paid_explanation', '') }}</textarea></label>
+              <label style="grid-column: 1 / -1;"><div class="label-row"><span>OCR text preview</span><span class="optional">Optional</span></div><textarea name="receipt_ocr_text">{{ answers.get('receipt_ocr_text', '') }}</textarea></label>
+            </div>
+          </section>
+
+          <section class="section-card">
+            <h2>Review disposition</h2>
+            <div class="fields">
+              <label>
+                <div class="label-row"><span>Reimbursement status</span><span class="optional">Optional</span></div>
+                <select name="reimbursement_status">
+                  <option value="">Select</option>
+                  {% for option in reimbursement_status_options %}
+                    <option value="{{ option }}" {% if answers.get('reimbursement_status') == option %}selected{% endif %}>{{ option }}</option>
+                  {% endfor %}
+                </select>
+              </label>
+              <label><div class="label-row"><span>Manager disposition</span><span class="optional">Optional</span></div><textarea name="manager_disposition">{{ answers.get('manager_disposition', '') }}</textarea></label>
+              <label><div class="label-row"><span>Accounting disposition</span><span class="optional">Optional</span></div><textarea name="accounting_disposition">{{ answers.get('accounting_disposition', '') }}</textarea></label>
+            </div>
+          </section>
+        </div>
+
+        <div class="actions">
+          <button class="primary" type="submit">Review expense report</button>
+          <a class="button secondary" href="/portal">Back to portal home</a>
+        </div>
+      </form>
+    </section>
+
+    <aside class="stack">
+      <section class="panel">
+        <h2>Review status</h2>
+        {% if review %}
+          {% if review.missing_fields %}
+            <p style="margin-top: 10px;"><span class="badge warn">Missing required inputs</span></p>
+            <ul>
+              {% for field in review.missing_fields %}
+                <li><code>{{ field }}</code></li>
+              {% endfor %}
+            </ul>
+          {% else %}
+            <p style="margin-top: 10px;"><span class="badge">Expense report assembled</span></p>
+          {% endif %}
+
+          {% if review.validation_errors %}
+            <div class="callout" style="margin-top: 16px;">
+              <h3>Validation notes</h3>
+              <ul>
+                {% for error in review.validation_errors %}
+                  <li>{{ error }}</li>
+                {% endfor %}
+              </ul>
+            </div>
+          {% endif %}
+
+          <div class="callout" style="margin-top: 16px;">
+            <h3>Receipt state</h3>
+            <p><span class="badge {% if review.receipt_state != 'attached' %}warn{% endif %}">{{ review.receipt_state }}</span></p>
+            {% if review.receipt_extraction %}
+              <dl style="margin-top: 12px;">
+                <dt>Extracted vendor</dt>
+                <dd>{{ review.receipt_extraction.vendor or 'None' }}</dd>
+                <dt>Extracted total</dt>
+                <dd>{{ review.receipt_extraction.total or 'None' }}</dd>
+                <dt>Extracted date</dt>
+                <dd>{{ review.receipt_extraction.date or 'None' }}</dd>
+              </dl>
+            {% endif %}
+          </div>
+
+          {% if review.review_warnings %}
+            <div class="callout" style="margin-top: 16px;">
+              <h3>Reviewer warnings</h3>
+              <ul>
+                {% for warning in review.review_warnings %}
+                  <li>{{ warning }}</li>
+                {% endfor %}
+              </ul>
+            </div>
+          {% endif %}
+        {% else %}
+          <p style="margin-top: 10px;">Save a draft to see receipt coverage, policy warnings, and accounting handoff artifacts.</p>
+        {% endif %}
+      </section>
+
+      {% if review and review.expense_report %}
+        <section class="panel">
+          <h2>Manager and accounting review</h2>
+          <p style="margin-top: 10px;">
+            <span class="badge {% if review.expense_report.approval_status == 'flagged' %}warn{% endif %}">
+              {{ review.expense_report.approval_status }}
+            </span>
+          </p>
+          <div class="callout" style="margin-top: 16px;">
+            <h3>Current disposition</h3>
+            <dl>
+              <dt>Linked request</dt>
+              <dd>{{ answers.get('approved_request_id') }}</dd>
+              <dt>Reimbursement status</dt>
+              <dd>{{ answers.get('reimbursement_status', 'draft') }}</dd>
+              <dt>Manager disposition</dt>
+              <dd>{{ answers.get('manager_disposition', 'Awaiting review') }}</dd>
+              <dt>Accounting disposition</dt>
+              <dd>{{ answers.get('accounting_disposition', 'Awaiting export handoff') }}</dd>
+            </dl>
+          </div>
+          <div class="callout" style="margin-top: 16px;">
+            <h3>Decision log</h3>
+            <ul>
+              {% for decision in review.expense_report.approval_decisions %}
+                <li>{{ decision.rule_name }}: {{ decision.reason }}</li>
+              {% else %}
+                <li>No approval rules triggered.</li>
+              {% endfor %}
+            </ul>
+          </div>
+        </section>
+      {% endif %}
+
+      {% if review and review.artifacts %}
+        <section class="panel">
+          <h2>Accounting handoff</h2>
+          <p style="margin-top: 10px;">Export the current report through the existing accounting CSV and spreadsheet services.</p>
+          <div class="actions">
+            <a class="button primary" href="/portal/expenses/{{ review.draft_id }}/artifacts/expense-csv">Download CSV</a>
+            <a class="button secondary" href="/portal/expenses/{{ review.draft_id }}/artifacts/expense-xlsx">Download spreadsheet</a>
+          </div>
+        </section>
+      {% endif %}
+    </aside>
+  </div>
+{% endblock %}

--- a/src/travel_plan_permission/templates/portal_home.html
+++ b/src/travel_plan_permission/templates/portal_home.html
@@ -120,6 +120,7 @@
         </p>
         <div class="actions">
           <a class="button primary" href="/portal/draft/new">Start a new request</a>
+          <a class="button secondary" href="/portal/expenses/new">Open expense portal</a>
           <a class="button secondary" href="/readyz">Check runtime readiness</a>
           <a class="button secondary" href="/portal/admin">Open admin console</a>
         </div>
@@ -133,6 +134,7 @@
             <li>Canonical trip fields and missing-input guidance.</li>
             <li>Planner policy snapshot and policy-lite posture.</li>
             <li>Spreadsheet and summary artifact generation.</li>
+            <li>Expense receipt intake, review warnings, and accounting export handoff.</li>
           </ul>
         </article>
         <article class="panel">

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -393,8 +393,41 @@ def test_expense_portal_generates_exports_and_policy_warning() -> None:
 
     assert csv_export.status_code == 200
     assert b"date,vendor,amount,category,cost_center,receipt_link" in csv_export.content
+    assert f"{draft_id}.csv" in csv_export.headers["content-disposition"]
     assert excel_export.status_code == 200
     assert excel_export.content.startswith(b"PK")
+    assert f"{draft_id}.xlsx" in excel_export.headers["content-disposition"]
+
+
+def test_expense_portal_invalid_amount_returns_validation_error() -> None:
+    client = TestClient(create_app())
+    payload = _expense_form_payload()
+    payload["expense_amount"] = "not-a-decimal"
+
+    response = client.post("/portal/expenses/review", data=payload)
+
+    assert response.status_code == 400
+    assert "One or more currency amounts are not valid decimal values." in response.text
+
+
+def test_expense_portal_missing_approval_rules_returns_validation_error(
+    monkeypatch,
+) -> None:
+    client = TestClient(create_app())
+    payload = _expense_form_payload()
+
+    monkeypatch.setattr("travel_plan_permission.approval._default_rules_path", lambda: None)
+    monkeypatch.setattr(
+        "travel_plan_permission.approval._package_rules_resource", lambda: None
+    )
+
+    response = client.post("/portal/expenses/review", data=payload)
+
+    assert response.status_code == 400
+    assert (
+        "Approval rules configuration is unavailable; expense policy review cannot be completed."
+        in response.text
+    )
 
 
 def test_expense_portal_caches_artifacts_with_persisted_draft_id() -> None:

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -397,6 +397,47 @@ def test_expense_portal_generates_exports_and_policy_warning() -> None:
     assert excel_export.content.startswith(b"PK")
 
 
+def test_expense_portal_caches_artifacts_with_persisted_draft_id() -> None:
+    store = PlannerProposalStore()
+    client = TestClient(create_app(store))
+
+    response = client.post(
+        "/portal/expenses/review",
+        data=_expense_form_payload(),
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    match = re.search(r"/portal/expenses/([^/]+)/artifacts/expense-csv", response.text)
+    assert match is not None
+    draft_id = match.group(1)
+
+    draft = store.lookup_expense_draft(draft_id)
+    assert draft is not None
+    assert draft_id in draft.cached_artifacts["expense-csv"].filename
+    assert draft_id in draft.cached_artifacts["expense-xlsx"].filename
+    assert "preview" not in draft.cached_artifacts["expense-csv"].filename.lower()
+    assert "preview" not in draft.cached_artifacts["expense-xlsx"].filename.lower()
+    assert b"EXP-PREVIEW" not in draft.cached_artifacts["expense-csv"].content
+
+
+def test_expense_portal_rejects_invalid_decimal_input_without_saving() -> None:
+    store = PlannerProposalStore()
+    client = TestClient(create_app(store))
+    payload = _expense_form_payload()
+    payload["expense_amount"] = "not-a-decimal"
+
+    response = client.post(
+        "/portal/expenses/review",
+        data=payload,
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 400
+    assert "not-a-decimal" in response.text
+    assert not store.expense_drafts_by_id
+
+
 def test_portal_draft_validation_returns_bad_request_without_saving() -> None:
     store = PlannerProposalStore()
     client = TestClient(create_app(store))

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -81,6 +81,29 @@ def _portal_form_payload() -> dict[str, str]:
     }
 
 
+def _expense_form_payload() -> dict[str, str]:
+    return {
+        "approved_request_id": "REQ-410",
+        "trip_id": "TRIP-410",
+        "traveler_name": "Alex Rivera",
+        "cost_center": "OPS-410",
+        "expense_description": "Conference hotel folio",
+        "expense_category": "lodging",
+        "expense_amount": "640.00",
+        "expense_date": "2025-10-09",
+        "expense_vendor": "Pine Street Suites",
+        "receipt_file_reference": "receipts/hotel-folio.pdf",
+        "receipt_file_size_bytes": "2048",
+        "receipt_total": "640.00",
+        "receipt_date": "2025-10-09",
+        "receipt_vendor": "Pine Street Suites",
+        "receipt_ocr_text": "Pine Street Suites\nTotal: 640.00\n2025-10-09",
+        "reimbursement_status": "manager_review",
+        "manager_disposition": "Need lodging policy confirmation",
+        "accounting_disposition": "Queue next export batch",
+    }
+
+
 def test_readyz_reports_missing_runtime_config(monkeypatch) -> None:
     monkeypatch.delenv("TPP_BASE_URL", raising=False)
     monkeypatch.delenv("TPP_ACCESS_TOKEN", raising=False)
@@ -309,6 +332,69 @@ def test_portal_request_form_get_stays_lightweight() -> None:
     assert 'value="Alex Rivera"' not in response.text
     assert "Generated artifacts" not in response.text
     assert "Policy-lite posture" not in response.text
+
+
+def test_expense_portal_form_renders() -> None:
+    client = TestClient(create_app())
+
+    response = client.get("/portal/expenses/new")
+
+    assert response.status_code == 200
+    assert "Prepare an expense report from an approved request." in response.text
+    assert "Receipt intake" in response.text
+
+
+def test_expense_portal_review_surfaces_missing_receipt_warning() -> None:
+    store = PlannerProposalStore()
+    client = TestClient(create_app(store))
+    payload = _expense_form_payload()
+    payload.pop("receipt_file_reference")
+    payload.pop("receipt_file_size_bytes")
+    payload.pop("receipt_total")
+    payload.pop("receipt_date")
+    payload.pop("receipt_vendor")
+    payload.pop("receipt_ocr_text")
+
+    response = client.post(
+        "/portal/expenses/review",
+        data=payload,
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert "Receipt missing: reviewers should hold reimbursement until the traveler uploads support." in response.text
+    assert "Download CSV" in response.text
+    assert store.expense_drafts_by_id
+
+
+def test_expense_portal_generates_exports_and_policy_warning() -> None:
+    store = PlannerProposalStore()
+    client = TestClient(create_app(store))
+    payload = _expense_form_payload()
+    payload["expense_amount"] = "7500.00"
+    payload["receipt_total"] = "7500.00"
+
+    response = client.post(
+        "/portal/expenses/review",
+        data=payload,
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert "Policy warning: manager or accounting review is required before reimbursement." in response.text
+    assert "Manual receipt entry overrides OCR values for total." in response.text
+
+    match = re.search(r"/portal/expenses/([^/]+)/artifacts/expense-csv", response.text)
+    assert match is not None
+    draft_id = match.group(1)
+
+    csv_export = client.get(f"/portal/expenses/{draft_id}/artifacts/expense-csv")
+    excel_export = client.get(f"/portal/expenses/{draft_id}/artifacts/expense-xlsx")
+
+    assert csv_export.status_code == 200
+    assert b"date,vendor,amount,category,cost_center,receipt_link" in csv_export.content
+    assert excel_export.status_code == 200
+    assert excel_export.content.startswith(b"PK")
 
 
 def test_portal_draft_validation_returns_bad_request_without_saving() -> None:
@@ -1081,6 +1167,9 @@ def test_portal_routes_do_not_leave_legacy_request_paths_active() -> None:
     assert "/portal/draft/new" in paths
     assert "/portal/draft" in paths
     assert "/portal/review/{draft_id}" in paths
+    assert "/portal/expenses/new" in paths
+    assert "/portal/expenses/review" in paths
+    assert "/portal/expenses/{draft_id}" in paths
     assert all(not path.startswith("/portal/requests") for path in paths)
 
 

--- a/tests/python/test_package_data.py
+++ b/tests/python/test_package_data.py
@@ -9,6 +9,14 @@ def test_mapping_resource_exists() -> None:
     assert "templates" in mapping.read_text(encoding="utf-8")
 
 
+def test_approval_rules_resource_exists() -> None:
+    rules = resources.files("travel_plan_permission").joinpath(
+        "config", "approval_rules.yaml"
+    )
+    assert rules.is_file()
+    assert "default_under_100" in rules.read_text(encoding="utf-8")
+
+
 def test_template_resource_exists() -> None:
     template = resources.files("travel_plan_permission").joinpath(
         "templates", "travel_request_template.xlsx"

--- a/tests/python/test_package_data.py
+++ b/tests/python/test_package_data.py
@@ -20,12 +20,18 @@ def test_template_resource_exists() -> None:
 def test_portal_template_resources_exist() -> None:
     templates = resources.files("travel_plan_permission").joinpath("templates")
     home = templates.joinpath("portal_home.html")
+    expense = templates.joinpath("portal_expense.html")
     request = templates.joinpath("portal_request.html")
     queue = templates.joinpath("manager_review_queue.html")
     detail = templates.joinpath("manager_review_detail.html")
 
     assert home.is_file()
     assert "Travel Request Portal" in home.read_text(encoding="utf-8")
+    assert expense.is_file()
+    assert (
+        "Prepare an expense report from an approved request."
+        in expense.read_text(encoding="utf-8")
+    )
     assert request.is_file()
     assert (
         "Draft a travel request through the real service runtime."


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #801

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The repo already has receipts, expense-report modeling, spreadsheet/export
support, and policy checks, but the broader workflow plan still lacks a user-
visible expense/reimbursement experience. Without that layer, the repo stops at
request preparation instead of covering the end-to-end travel workflow.

#### Tasks
- [x] Add expense-report and receipt submission UI linked to an approved travel request
- [x] Surface manual-entry and extracted receipt details with clear validation and policy-warning states
- [x] Add manager/accounting review views for missing receipts, policy warnings, and reimbursement disposition
- [x] Reuse the existing export and spreadsheet services for accounting handoff artifacts
- [x] Add tests for receipt submission, expense validation, review-state rendering, and export generation
- [x] Update docs to describe the delivered expense workflow and remaining accounting integration boundaries

#### Acceptance criteria
- [x] Users can attach receipts and prepare an expense submission through a real UI flow
- [x] Reviewers can see missing receipt and policy warning states in the portal
- [x] Accounting handoff artifacts are generated from the current service layer rather than ad hoc exports
- [x] Tests cover the main receipt, expense, and review paths

<!-- auto-status-summary:end -->
