### PR TITLE
Issue #790: avoid empty docs audit issues

### DIFF
--- a/.github/workflows/auto-merge-docs.yml
+++ b/.github/workflows/auto-merge-docs.yml
@@ -158,6 +158,8 @@ jobs:
                 continue;
               }
 
+              auditIssueNumber ??= await ensureAuditIssue();
+
               const mergeMessage = `Docs auto-merge: PR #${pr.number} (${pr.title})`;
 
               try {
@@ -173,22 +175,21 @@ jobs:
                 continue;
               }
 
+              const mergedAt = new Date().toISOString();
               mergedPrs.push({
                 number: pr.number,
                 title: pr.title,
                 changeCount,
-                mergedAt: new Date().toISOString()
+                mergedAt
               });
 
-              const confirmation = `Docs auto-merge workflow merged this PR on ${mergedPrs[mergedPrs.length - 1].mergedAt} after verifying docs-only scope (<50 lines), passing checks, and 1-hour delay.`;
+              const confirmation = `Docs auto-merge workflow merged this PR on ${mergedAt} after verifying docs-only scope (<50 lines), passing checks, and 1-hour delay.`;
               await github.rest.issues.createComment({
                 owner,
                 repo,
                 issue_number: pr.number,
                 body: confirmation
               });
-
-              auditIssueNumber ??= await ensureAuditIssue();
 
               await github.rest.issues.createComment({
                 owner,
@@ -197,7 +198,7 @@ jobs:
                 body: [
                   `### Docs auto-merge: #${pr.number} ${pr.title}`,
                   "",
-                  `- Merged at: ${mergedPrs[mergedPrs.length - 1].mergedAt}`,
+                  `- Merged at: ${mergedAt}`,
                   `- Changed lines: ${changeCount}`,
                   `- Merge method: squash`,
                   `- Confirmation comment posted on #${pr.number}`,

--- a/.github/workflows/auto-merge-docs.yml
+++ b/.github/workflows/auto-merge-docs.yml
@@ -67,7 +67,12 @@ jobs:
                 repo,
                 title: auditTitle,
                 labels: [auditLabel],
-                body: "This issue collects an audit trail of documentation auto-merges."
+                body: [
+                  "This issue collects an audit trail of documentation auto-merges.",
+                  "",
+                  "Entries are added only after the workflow successfully merges",
+                  "a qualifying documentation PR."
+                ].join("\n")
               });
 
               return created.data.number;
@@ -85,7 +90,7 @@ jobs:
               per_page: 50
             });
 
-            const auditIssueNumber = await ensureAuditIssue();
+            let auditIssueNumber = null;
             const mergedPrs = [];
 
             for (const pr of pulls) {
@@ -183,11 +188,20 @@ jobs:
                 body: confirmation
               });
 
+              auditIssueNumber ??= await ensureAuditIssue();
+
               await github.rest.issues.createComment({
                 owner,
                 repo,
                 issue_number: auditIssueNumber,
-                body: `Merged #${pr.number} (${pr.title}) at ${mergedPrs[mergedPrs.length - 1].mergedAt} with ${changeCount} changed lines.`
+                body: [
+                  `### Docs auto-merge: #${pr.number} ${pr.title}`,
+                  "",
+                  `- Merged at: ${mergedPrs[mergedPrs.length - 1].mergedAt}`,
+                  `- Changed lines: ${changeCount}`,
+                  `- Merge method: squash`,
+                  `- Confirmation comment posted on #${pr.number}`,
+                ].join("\n")
               });
             }
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ Small documentation-only pull requests can be automatically merged when they sat
 
 - A scheduled workflow (`.github/workflows/auto-merge-docs.yml`) inspects open pull requests every 30 minutes and can also be triggered manually.
 - Eligible pull requests are merged with a squash commit once all conditions are met.
-- Each automated merge is recorded in an audit log issue labeled `auto-merge-audit`, and a confirmation comment is added to the merged pull request.
+- Each automated merge is recorded in a lazily created audit log issue labeled `auto-merge-audit`, and a confirmation comment is added to the merged pull request.
+- The workflow does not leave behind an empty audit issue when no documentation PR was actually merged.
 
 If you want to prevent auto-merge for a documentation PR, add the `no-auto-merge` label. If your change includes more than Markdown or exceeds the line threshold, it will be skipped automatically.


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #790

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Avoid creating empty documentation audit issues when the auto-merge workflow runs
without any qualifying documentation PR to merge. Preserve the audit trail when a
qualifying merge does happen.

#### Tasks
- [x] Defer documentation audit issue creation until the first qualifying merge is about to be recorded
- [x] Reuse the merged timestamp for the confirmation message and audit entry instead of re-reading merge state
- [x] Keep the merged PR audit comment/body output structured and readable
- [x] Update contributor-facing docs to explain the lazy audit-issue creation behavior

#### Acceptance criteria
- [x] Auto-merge runs with no qualifying merge do not leave behind an empty audit issue
- [x] Qualifying documentation merges still create or reuse the audit issue and append the merge record
- [x] The documented workflow behavior matches the shipped lazy-creation implementation
<!-- auto-status-summary:end -->
