### PR TITLE
Codex bootstrap for #820

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ capture draft trip details, see missing canonical inputs before submission,
 review policy-lite posture, and download the generated itinerary and summary
 artifacts before triggering the existing proposal submission seam.
 
+Portal draft and submission state now persist to
+`var/portal-runtime-state.json` by default. Set `TPP_PORTAL_STATE_PATH` when
+you need a different local or preview-safe path. For restart verification,
+create a draft, copy the `/portal/review/{draft_id}` URL, restart the service,
+and reopen the same page to confirm the review state, submission result, and
+follow-on review link still render intentionally before rechecking artifacts.
+
 Run the repo-native live smoke command against a running service with:
 
 ```bash

--- a/agents/codex-820.md
+++ b/agents/codex-820.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #820 -->

--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -44,12 +44,12 @@ from .planner_auth import PlannerAuthConfig, PlannerAuthContext, authenticate_re
 from .policy_api import (
     PlannerPolicySnapshot,
     PlannerPolicySnapshotRequest,
-    PolicyCheckResult,
     PlannerProposalEvaluationRequest,
     PlannerProposalEvaluationResult,
     PlannerProposalOperationResponse,
     PlannerProposalStatusRequest,
     PlannerProposalSubmissionRequest,
+    PolicyCheckResult,
     check_trip_plan,
     get_evaluation_result,
     get_policy_snapshot,

--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import argparse
+import base64
+import json
+import os
 import sys
 from dataclasses import dataclass, field, replace
 from datetime import UTC, date, datetime
@@ -41,6 +44,7 @@ from .planner_auth import PlannerAuthConfig, PlannerAuthContext, authenticate_re
 from .policy_api import (
     PlannerPolicySnapshot,
     PlannerPolicySnapshotRequest,
+    PolicyCheckResult,
     PlannerProposalEvaluationRequest,
     PlannerProposalEvaluationResult,
     PlannerProposalOperationResponse,
@@ -59,7 +63,13 @@ from .portal_review import (
     portal_validation_state,
 )
 from .receipts import Receipt, ReceiptExtractionResult, ReceiptProcessor
-from .review_workflow import ReviewAction, ReviewRequest, ReviewWorkflowStore
+from .review_workflow import (
+    ReviewAction,
+    ReviewHistoryEvent,
+    ReviewRequest,
+    ReviewStatus,
+    ReviewWorkflowStore,
+)
 from .security import (
     DEFAULT_ROLES,
     AuditEventType,
@@ -80,9 +90,7 @@ __all__ = [
 ]
 
 _OPTIONAL_SNAPSHOT_BODY = Body(default=None)
-_TEMPLATES = Jinja2Templates(
-    directory=str(Path(__file__).resolve().parent / "templates")
-)
+_TEMPLATES = Jinja2Templates(directory=str(Path(__file__).resolve().parent / "templates"))
 _PORTAL_CANONICAL_FIELDS: tuple[str, ...] = (
     "traveler_name",
     "business_purpose",
@@ -177,6 +185,8 @@ _PORTAL_BOOLEAN_FIELDS = {
     "meal_per_diem_requested",
 }
 _PORTAL_MAX_DRAFTS = 64
+_PORTAL_STATE_ENV_VAR = "TPP_PORTAL_STATE_PATH"
+_PORTAL_STATE_DEFAULT_PATH = Path("var") / "portal-runtime-state.json"
 _EXPENSE_FIELDS: tuple[str, ...] = (
     "approved_request_id",
     "trip_id",
@@ -226,6 +236,7 @@ class PortalDraft:
     answers: dict[str, object]
     updated_at: datetime
     cached_artifacts: dict[str, PortalArtifact] = field(default_factory=dict)
+    submission_response: PlannerProposalOperationResponse | None = None
 
 
 @dataclass(frozen=True)
@@ -398,6 +409,13 @@ class StoredProposal:
     response: PlannerProposalOperationResponse
 
 
+def _default_portal_state_path() -> Path:
+    configured_path = os.getenv(_PORTAL_STATE_ENV_VAR)
+    if configured_path:
+        return Path(configured_path).expanduser()
+    return Path.cwd() / _PORTAL_STATE_DEFAULT_PATH
+
+
 @dataclass
 class PlannerProposalStore:
     """In-memory proposal store for local and preview live testing."""
@@ -407,15 +425,21 @@ class PlannerProposalStore:
     portal_drafts_by_id: dict[str, PortalDraft] = field(default_factory=dict)
     expense_drafts_by_id: dict[str, PortalDraft] = field(default_factory=dict)
     manager_reviews: ReviewWorkflowStore = field(default_factory=ReviewWorkflowStore)
-    exception_requests_by_draft_id: dict[str, list[ExceptionRequest]] = field(
-        default_factory=dict
-    )
+    exception_requests_by_draft_id: dict[str, list[ExceptionRequest]] = field(default_factory=dict)
     security: SecurityModel = field(default_factory=SecurityModel)
+    state_path: Path | None = None
+
+    def __post_init__(self) -> None:
+        if self.state_path is None:
+            return
+        self.state_path = Path(self.state_path).expanduser()
+        self._load_state()
 
     def remember_plan(self, trip_plan: TripPlan) -> None:
         """Store the latest planner trip payload by trip identifier."""
 
         self.plans_by_trip_id[trip_plan.trip_id] = trip_plan.model_copy(deep=True)
+        self._persist_state()
 
     def lookup_trip_plan(self, trip_id: str) -> TripPlan | None:
         """Return a previously stored plan by trip identifier."""
@@ -436,14 +460,13 @@ class PlannerProposalStore:
         self.remember_plan(trip_plan)
         execution_id = response.result_payload.get("execution_id")
         if not isinstance(execution_id, str):
-            raise ValueError(
-                "Planner proposal response missing required string execution_id"
-            )
+            raise ValueError("Planner proposal response missing required string execution_id")
         self.proposals_by_execution_id[execution_id] = StoredProposal(
             trip_plan=trip_plan.model_copy(deep=True),
             request=request.model_copy(deep=True),
             response=response.model_copy(deep=True),
         )
+        self._persist_state()
 
     def lookup_submission(self, execution_id: str) -> StoredProposal | None:
         """Return a previously stored proposal submission by execution identifier."""
@@ -480,6 +503,7 @@ class PlannerProposalStore:
             outcome="draft_saved",
             metadata={"surface": "workflow-portal"},
         )
+        self._persist_state()
         return draft
 
     def cache_portal_artifacts(
@@ -498,6 +522,26 @@ class PlannerProposalStore:
             cached_artifacts=dict(artifacts),
         )
         self.portal_drafts_by_id[draft_id] = updated
+        self._persist_state()
+        return updated
+
+    def record_portal_submission(
+        self,
+        draft_id: str,
+        response: PlannerProposalOperationResponse,
+    ) -> PortalDraft | None:
+        """Persist the latest submission result for a saved portal draft."""
+
+        draft = self.portal_drafts_by_id.get(draft_id)
+        if draft is None:
+            return None
+        updated = replace(
+            draft,
+            updated_at=datetime.now(UTC),
+            submission_response=response.model_copy(deep=True),
+        )
+        self.portal_drafts_by_id[draft_id] = updated
+        self._persist_state()
         return updated
 
     def lookup_portal_draft(self, draft_id: str) -> PortalDraft | None:
@@ -511,6 +555,11 @@ class PlannerProposalStore:
             answers=dict(draft.answers),
             updated_at=draft.updated_at,
             cached_artifacts=dict(draft.cached_artifacts),
+            submission_response=(
+                draft.submission_response.model_copy(deep=True)
+                if draft.submission_response is not None
+                else None
+            ),
         )
 
     def save_expense_draft(self, answers: dict[str, object]) -> PortalDraft:
@@ -535,6 +584,7 @@ class PlannerProposalStore:
             outcome="expense_draft_saved",
             metadata={"surface": "expense-portal"},
         )
+        self._persist_state()
         return draft
 
     def cache_expense_artifacts(
@@ -553,6 +603,7 @@ class PlannerProposalStore:
             cached_artifacts=dict(artifacts),
         )
         self.expense_drafts_by_id[draft_id] = updated
+        self._persist_state()
         return updated
 
     def lookup_expense_draft(self, draft_id: str) -> PortalDraft | None:
@@ -566,6 +617,11 @@ class PlannerProposalStore:
             answers=dict(draft.answers),
             updated_at=draft.updated_at,
             cached_artifacts=dict(draft.cached_artifacts),
+            submission_response=(
+                draft.submission_response.model_copy(deep=True)
+                if draft.submission_response is not None
+                else None
+            ),
         )
 
     def create_manager_review(self, review: PortalReviewState) -> ReviewRequest:
@@ -592,6 +648,7 @@ class PlannerProposalStore:
             outcome="submitted_for_manager_review",
             metadata={"draft_id": review.draft_id, "trip_id": trip_plan.trip_id},
         )
+        self._persist_state()
         return manager_review
 
     def lookup_manager_review(self, review_id: str) -> ReviewRequest | None:
@@ -632,6 +689,7 @@ class PlannerProposalStore:
             outcome=action.value,
             metadata={"draft_id": updated.draft_id, "status": updated.status.value},
         )
+        self._persist_state()
         return updated
 
     def list_exception_requests(self, draft_id: str) -> list[ExceptionRequest]:
@@ -665,6 +723,7 @@ class PlannerProposalStore:
                 ),
             },
         )
+        self._persist_state()
         return self.list_exception_requests(draft_id)
 
     def decide_exception_request(
@@ -680,9 +739,7 @@ class PlannerProposalStore:
 
         requests = self.exception_requests_by_draft_id.get(draft_id)
         if requests is None or exception_index < 0 or exception_index >= len(requests):
-            raise KeyError(
-                f"No exception request {exception_index} found for draft '{draft_id}'."
-            )
+            raise KeyError(f"No exception request {exception_index} found for draft '{draft_id}'.")
         target = requests[exception_index]
         if approved:
             target.approve(approver_id=actor_id, notes=notes)
@@ -704,6 +761,7 @@ class PlannerProposalStore:
             outcome=outcome,
             metadata=metadata,
         )
+        self._persist_state()
         return _copy_exception_request(target)
 
     def list_exception_entries(self) -> list[DraftExceptionEntry]:
@@ -750,6 +808,156 @@ class PlannerProposalStore:
             key=lambda event: event.timestamp,
             reverse=True,
         )
+
+    def _persist_state(self) -> None:
+        if self.state_path is None:
+            return
+        self.state_path.parent.mkdir(parents=True, exist_ok=True)
+        temp_path = self.state_path.with_suffix(f"{self.state_path.suffix}.tmp")
+        temp_path.write_text(
+            json.dumps(self._serialize_state(), sort_keys=True),
+            encoding="utf-8",
+        )
+        temp_path.replace(self.state_path)
+
+    def _load_state(self) -> None:
+        if self.state_path is None or not self.state_path.exists():
+            return
+        payload = json.loads(self.state_path.read_text(encoding="utf-8"))
+        self.plans_by_trip_id = {
+            trip_id: TripPlan.model_validate(serialized)
+            for trip_id, serialized in payload.get("plans_by_trip_id", {}).items()
+        }
+        self.proposals_by_execution_id = {
+            execution_id: StoredProposal(
+                trip_plan=TripPlan.model_validate(serialized["trip_plan"]),
+                request=PlannerProposalSubmissionRequest.model_validate(serialized["request"]),
+                response=PlannerProposalOperationResponse.model_validate(serialized["response"]),
+            )
+            for execution_id, serialized in payload.get("proposals_by_execution_id", {}).items()
+        }
+        self.portal_drafts_by_id = {
+            draft_id: PortalDraft(
+                draft_id=draft_id,
+                answers=dict(serialized["answers"]),
+                updated_at=datetime.fromisoformat(serialized["updated_at"]),
+                cached_artifacts={
+                    artifact_name: PortalArtifact(
+                        filename=artifact_payload["filename"],
+                        content=base64.b64decode(artifact_payload["content"]),
+                        media_type=artifact_payload["media_type"],
+                    )
+                    for artifact_name, artifact_payload in serialized.get(
+                        "cached_artifacts", {}
+                    ).items()
+                },
+                submission_response=(
+                    PlannerProposalOperationResponse.model_validate(
+                        serialized["submission_response"]
+                    )
+                    if serialized.get("submission_response") is not None
+                    else None
+                ),
+            )
+            for draft_id, serialized in payload.get("portal_drafts_by_id", {}).items()
+        }
+        self.manager_reviews = ReviewWorkflowStore(
+            reviews_by_id={
+                review_id: ReviewRequest(
+                    review_id=review_id,
+                    draft_id=serialized["draft_id"],
+                    trip_plan=TripPlan.model_validate(serialized["trip_plan"]),
+                    policy_snapshot=PlannerPolicySnapshot.model_validate(
+                        serialized["policy_snapshot"]
+                    ),
+                    policy_result=PolicyCheckResult.model_validate(serialized["policy_result"]),
+                    status=ReviewStatus(serialized["status"]),
+                    submitted_at=datetime.fromisoformat(serialized["submitted_at"]),
+                    updated_at=datetime.fromisoformat(serialized["updated_at"]),
+                    history=tuple(
+                        ReviewHistoryEvent(
+                            event_type=event_payload["event_type"],
+                            actor_id=event_payload["actor_id"],
+                            timestamp=datetime.fromisoformat(event_payload["timestamp"]),
+                            status=ReviewStatus(event_payload["status"]),
+                            rationale=event_payload.get("rationale"),
+                        )
+                        for event_payload in serialized.get("history", [])
+                    ),
+                )
+                for review_id, serialized in payload.get("manager_reviews", {}).items()
+            },
+            review_ids_by_draft_id=dict(payload.get("review_ids_by_draft_id", {})),
+        )
+        self.exception_requests_by_draft_id = {
+            draft_id: [ExceptionRequest.model_validate(item) for item in serialized_requests]
+            for draft_id, serialized_requests in payload.get(
+                "exception_requests_by_draft_id", {}
+            ).items()
+        }
+
+    def _serialize_state(self) -> dict[str, object]:
+        return {
+            "plans_by_trip_id": {
+                trip_id: trip_plan.model_dump(mode="json")
+                for trip_id, trip_plan in self.plans_by_trip_id.items()
+            },
+            "proposals_by_execution_id": {
+                execution_id: {
+                    "trip_plan": stored.trip_plan.model_dump(mode="json"),
+                    "request": stored.request.model_dump(mode="json"),
+                    "response": stored.response.model_dump(mode="json"),
+                }
+                for execution_id, stored in self.proposals_by_execution_id.items()
+            },
+            "portal_drafts_by_id": {
+                draft_id: {
+                    "answers": dict(draft.answers),
+                    "updated_at": draft.updated_at.isoformat(),
+                    "cached_artifacts": {
+                        artifact_name: {
+                            "filename": artifact.filename,
+                            "content": base64.b64encode(artifact.content).decode("ascii"),
+                            "media_type": artifact.media_type,
+                        }
+                        for artifact_name, artifact in draft.cached_artifacts.items()
+                    },
+                    "submission_response": (
+                        draft.submission_response.model_dump(mode="json")
+                        if draft.submission_response is not None
+                        else None
+                    ),
+                }
+                for draft_id, draft in self.portal_drafts_by_id.items()
+            },
+            "manager_reviews": {
+                review_id: {
+                    "draft_id": review.draft_id,
+                    "trip_plan": review.trip_plan.model_dump(mode="json"),
+                    "policy_snapshot": review.policy_snapshot.model_dump(mode="json"),
+                    "policy_result": review.policy_result.model_dump(mode="json"),
+                    "status": review.status.value,
+                    "submitted_at": review.submitted_at.isoformat(),
+                    "updated_at": review.updated_at.isoformat(),
+                    "history": [
+                        {
+                            "event_type": event.event_type,
+                            "actor_id": event.actor_id,
+                            "timestamp": event.timestamp.isoformat(),
+                            "status": event.status.value,
+                            "rationale": event.rationale,
+                        }
+                        for event in review.history
+                    ],
+                }
+                for review_id, review in self.manager_reviews.reviews_by_id.items()
+            },
+            "review_ids_by_draft_id": dict(self.manager_reviews.review_ids_by_draft_id),
+            "exception_requests_by_draft_id": {
+                draft_id: [request.model_dump(mode="json") for request in requests]
+                for draft_id, requests in self.exception_requests_by_draft_id.items()
+            },
+        }
 
 
 def _readiness_response() -> PlannerReadinessResponse:
@@ -1011,9 +1219,7 @@ def _expense_review_state(
                 "Approval rules configuration is unavailable; expense policy review cannot be completed."
             )
         except InvalidOperation:
-            validation_errors.append(
-                "One or more currency amounts are not valid decimal values."
-            )
+            validation_errors.append("One or more currency amounts are not valid decimal values.")
         except ValueError as exc:
             validation_errors.append(str(exc))
 
@@ -1080,9 +1286,7 @@ def _manager_review_queue_context(
         "request": request,
         "reviews": reviews,
         "role_view": role_view,
-        "actor_permissions": tuple(
-            sorted(auth_context.permissions, key=lambda item: item.value)
-        ),
+        "actor_permissions": tuple(sorted(auth_context.permissions, key=lambda item: item.value)),
         "role_can_approve": auth_context.can(Permission.APPROVE),
     }
 
@@ -1101,9 +1305,7 @@ def _manager_review_detail_context(
         "request": request,
         "review": review,
         "role_view": role_view,
-        "actor_permissions": tuple(
-            sorted(auth_context.permissions, key=lambda item: item.value)
-        ),
+        "actor_permissions": tuple(sorted(auth_context.permissions, key=lambda item: item.value)),
         "role_can_approve": auth_context.can(Permission.APPROVE),
         "exceptions": exceptions or [],
         "audit_events": audit_events or [],
@@ -1125,9 +1327,7 @@ def _admin_dashboard_context(
     return {
         "request": request,
         "role_view": role_view,
-        "actor_permissions": tuple(
-            sorted(auth_context.permissions, key=lambda item: item.value)
-        ),
+        "actor_permissions": tuple(sorted(auth_context.permissions, key=lambda item: item.value)),
         "role_can_approve": auth_context.can(Permission.APPROVE),
         "role_can_configure": auth_context.can(Permission.CONFIGURE),
         "available_roles": tuple(RoleName),
@@ -1141,7 +1341,7 @@ def _admin_dashboard_context(
 def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
     """Create the planner-facing ASGI application."""
 
-    proposal_store = store or PlannerProposalStore()
+    proposal_store = store or PlannerProposalStore(state_path=_default_portal_state_path())
     app = FastAPI(
         title="Travel Plan Permission Planner Service",
         version="0.1.0",
@@ -1216,9 +1416,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         draft = proposal_store.save_expense_draft(answers)
         persisted_review = _expense_review_state(draft.draft_id, answers)
         if persisted_review.artifacts:
-            proposal_store.cache_expense_artifacts(
-                draft.draft_id, persisted_review.artifacts
-            )
+            proposal_store.cache_expense_artifacts(draft.draft_id, persisted_review.artifacts)
         return RedirectResponse(
             url=request.url_for("portal_expense_detail", draft_id=draft.draft_id),
             status_code=status.HTTP_303_SEE_OTHER,
@@ -1241,9 +1439,8 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
             draft.answers,
             required_fields=_PORTAL_REQUIRED_FIELDS,
             canonical_payload_builder=_canonical_payload_from_answers,
-            manager_review=proposal_store.lookup_manager_review_for_draft(
-                draft.draft_id
-            ),
+            submission_response=draft.submission_response,
+            manager_review=proposal_store.lookup_manager_review_for_draft(draft.draft_id),
         )
         if review.artifacts and not draft.cached_artifacts:
             proposal_store.cache_portal_artifacts(draft.draft_id, review.artifacts)
@@ -1294,9 +1491,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
             keep_blank_values=True,
         )
         try:
-            exception_type = ExceptionType(
-                parsed.get("exception_type", [""])[-1].strip()
-            )
+            exception_type = ExceptionType(parsed.get("exception_type", [""])[-1].strip())
         except ValueError as exc:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -1337,9 +1532,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
                 supporting_docs=[supporting_doc] if supporting_doc else [],
             )
         except ValidationError as exc:
-            messages = "; ".join(
-                error["msg"] for error in exc.errors() if error.get("msg")
-            )
+            messages = "; ".join(error["msg"] for error in exc.errors() if error.get("msg"))
             return _TEMPLATES.TemplateResponse(
                 request=request,
                 name="review_summary.html",
@@ -1379,11 +1572,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
             required_fields=_PORTAL_REQUIRED_FIELDS,
             canonical_payload_builder=_canonical_payload_from_answers,
         )
-        if (
-            review.trip_plan is None
-            or review.missing_fields
-            or review.validation_errors
-        ):
+        if review.trip_plan is None or review.missing_fields or review.validation_errors:
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="Complete the request review before submitting the portal draft.",
@@ -1404,6 +1593,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
             submission_request,
             submission_response,
         )
+        proposal_store.record_portal_submission(draft.draft_id, submission_response)
         manager_review = proposal_store.create_manager_review(review)
         review = portal_review_state(
             draft.draft_id,
@@ -1496,9 +1686,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
             required_permission=Permission.APPROVE,
         )
         role_view = _resolve_role_view(actor_role)
-        parsed = parse_qs(
-            (await request.body()).decode("utf-8"), keep_blank_values=True
-        )
+        parsed = parse_qs((await request.body()).decode("utf-8"), keep_blank_values=True)
         action_name = parsed.get("action", [""])[-1].strip()
         actor_id = parsed.get("actor_id", [""])[-1].strip()
         rationale = parsed.get("rationale", [""])[-1].strip()
@@ -1600,17 +1788,12 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         resolved_role = _resolve_role_view(actor_role).role.value
         if review is not None:
             return RedirectResponse(
-                url=str(
-                    request.url_for(
-                        "portal_manager_review_detail", review_id=review.review_id
-                    )
-                )
+                url=str(request.url_for("portal_manager_review_detail", review_id=review.review_id))
                 + f"?actor_role={resolved_role}",
                 status_code=status.HTTP_303_SEE_OTHER,
             )
         return RedirectResponse(
-            url=str(request.url_for("portal_admin_dashboard"))
-            + f"?actor_role={resolved_role}",
+            url=str(request.url_for("portal_admin_dashboard")) + f"?actor_role={resolved_role}",
             status_code=status.HTTP_303_SEE_OTHER,
         )
 
@@ -1681,9 +1864,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         return Response(
             content=artifact.content,
             media_type=artifact.media_type,
-            headers={
-                "Content-Disposition": f'attachment; filename="{artifact.filename}"'
-            },
+            headers={"Content-Disposition": f'attachment; filename="{artifact.filename}"'},
         )
 
     @app.get("/portal/expenses/{draft_id}/artifacts/{artifact_name}")
@@ -1719,9 +1900,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         return Response(
             content=artifact.content,
             media_type=artifact.media_type,
-            headers={
-                "Content-Disposition": f'attachment; filename="{artifact.filename}"'
-            },
+            headers={"Content-Disposition": f'attachment; filename="{artifact.filename}"'},
         )
 
     @app.get(
@@ -1825,9 +2004,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         if stored.request.proposal_id != proposal_id:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail=(
-                    f"Execution '{execution_id}' does not belong to proposal '{proposal_id}'."
-                ),
+                detail=(f"Execution '{execution_id}' does not belong to proposal '{proposal_id}'."),
             )
         status_request = _submission_status_request(
             stored,

--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -1242,8 +1242,19 @@ def _portal_template_context(
     *,
     exceptions: list[ExceptionRequest] | None = None,
     error_message: str | None = None,
+    auth_context: PlannerAuthContext | None = None,
 ) -> dict[str, object]:
     answers = review.answers if review is not None else {}
+    viewer_permissions = (
+        tuple(
+            permission.value
+            for permission in sorted(
+                auth_context.permissions, key=lambda permission: permission.value
+            )
+        )
+        if auth_context is not None
+        else ()
+    )
     return {
         "request": request,
         "answers": answers,
@@ -1258,6 +1269,17 @@ def _portal_template_context(
         ),
         "optional_fields": _PORTAL_OPTIONAL_FIELDS,
         "error_message": error_message,
+        "viewer": auth_context,
+        "viewer_permissions": viewer_permissions,
+        "viewer_can_view": (
+            auth_context.can(Permission.VIEW) if auth_context is not None else False
+        ),
+        "viewer_can_create": (
+            auth_context.can(Permission.CREATE) if auth_context is not None else False
+        ),
+        "viewer_can_approve": (
+            auth_context.can(Permission.APPROVE) if auth_context is not None else False
+        ),
     }
 
 
@@ -1427,7 +1449,15 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         response_class=HTMLResponse,
         name="portal_review_detail",
     )
-    def portal_review_detail(request: Request, draft_id: str) -> HTMLResponse:
+    def portal_review_detail(
+        request: Request,
+        draft_id: str,
+        authorization: str | None = Header(default=None),
+    ) -> HTMLResponse:
+        auth_context = _authorize_request(
+            authorization,
+            required_permission=Permission.VIEW,
+        )
         draft = proposal_store.lookup_portal_draft(draft_id)
         if draft is None:
             raise HTTPException(
@@ -1451,6 +1481,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
                 request,
                 review,
                 exceptions=proposal_store.list_exception_requests(draft_id),
+                auth_context=auth_context,
             ),
         )
 
@@ -1556,7 +1587,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         draft_id: str,
         authorization: str | None = Header(default=None),
     ) -> HTMLResponse:
-        _authorize_request(
+        auth_context = _authorize_request(
             authorization,
             required_permission=Permission.CREATE,
         )
@@ -1610,6 +1641,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
                 request,
                 review,
                 exceptions=proposal_store.list_exception_requests(draft_id),
+                auth_context=auth_context,
             ),
         )
 
@@ -1830,7 +1862,12 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
     def portal_artifact(
         draft_id: str,
         artifact_name: str,
+        authorization: str | None = Header(default=None),
     ) -> Response:
+        _authorize_request(
+            authorization,
+            required_permission=Permission.VIEW,
+        )
         draft = proposal_store.lookup_portal_draft(draft_id)
         if draft is None:
             raise HTTPException(

--- a/src/travel_plan_permission/templates/review_summary.html
+++ b/src/travel_plan_permission/templates/review_summary.html
@@ -52,6 +52,49 @@
 
     <aside class="stack">
       <section class="panel">
+        <h2>Access posture</h2>
+        {% if viewer %}
+          <p style="margin-top: 10px;"><span class="badge">{{ viewer.provider }} / {{ viewer.auth_mode.value }}</span></p>
+          <div class="callout" style="margin-top: 16px;">
+            <h3>Authenticated caller</h3>
+            <dl>
+              <div>
+                <dt>Subject</dt>
+                <dd>{{ viewer.subject }}</dd>
+              </div>
+              <div>
+                <dt>Permissions</dt>
+                <dd>{{ viewer_permissions | join(', ') }}</dd>
+              </div>
+            </dl>
+          </div>
+          <div class="callout" style="margin-top: 16px;">
+            <h3>Review surface</h3>
+            <ul>
+              {% if viewer_can_view %}
+                <li>This caller can download generated review artifacts.</li>
+              {% else %}
+                <li>This caller is viewing a saved draft without artifact download access.</li>
+              {% endif %}
+              {% if viewer_can_create %}
+                <li>This caller can submit the reviewed request.</li>
+              {% else %}
+                <li>This caller can review the draft, but submission still requires `create`.</li>
+              {% endif %}
+              {% if viewer_can_approve %}
+                <li>Approval-capable roles can inspect reviewer-facing posture without switching tools.</li>
+              {% endif %}
+            </ul>
+          </div>
+        {% else %}
+          <p style="margin-top: 10px;">
+            Connect with a planner-authenticated caller to unlock role-aware review posture,
+            artifact downloads, and submit controls.
+          </p>
+        {% endif %}
+      </section>
+
+      <section class="panel">
         <h2>Review status</h2>
         {% if review.missing_fields %}
           <p style="margin-top: 10px;"><span class="badge warn">Missing required inputs</span></p>
@@ -178,9 +221,13 @@
               Submission reuses the existing proposal submission seam and records the resulting
               execution contract alongside the draft.
             </p>
-            <form method="post" action="/portal/review/{{ review.draft_id }}/submit" style="margin-top: 14px;">
-              <button class="primary" type="submit">Submit request</button>
-            </form>
+            {% if viewer_can_create %}
+              <form method="post" action="/portal/review/{{ review.draft_id }}/submit" style="margin-top: 14px;">
+                <button class="primary" type="submit">Submit request</button>
+              </form>
+            {% else %}
+              <p style="margin-top: 14px;">Submission stays hidden until the caller has `create` permission.</p>
+            {% endif %}
           </div>
         </section>
       {% endif %}

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -81,6 +81,23 @@ def _portal_form_payload() -> dict[str, str]:
     }
 
 
+def _create_portal_draft(
+    client: TestClient,
+    *,
+    payload: dict[str, str] | None = None,
+) -> tuple[str, str]:
+    response = client.post(
+        "/portal/draft",
+        data=payload or _portal_form_payload(),
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+    location = response.headers["location"]
+    match = re.search(r"/portal/review/([^/]+)$", location)
+    assert match is not None
+    return match.group(1), location
+
+
 def _expense_form_payload() -> dict[str, str]:
     return {
         "approved_request_id": "REQ-410",
@@ -537,11 +554,8 @@ def test_portal_review_allows_optional_fields_to_remain_blank(monkeypatch) -> No
     ):
         payload.pop(field_name)
 
-    response = client.post(
-        "/portal/draft",
-        data=payload,
-        follow_redirects=True,
-    )
+    _draft_id, location = _create_portal_draft(client, payload=payload)
+    response = client.get(location, headers=AUTH_HEADER)
 
     assert response.status_code == 200
     assert 'data-template="review-summary"' in response.text
@@ -553,11 +567,8 @@ def test_portal_review_persists_policy_readiness_answers(monkeypatch) -> None:
     _set_runtime_env(monkeypatch)
     client = TestClient(create_app(PlannerProposalStore()))
 
-    response = client.post(
-        "/portal/draft",
-        data=_portal_form_payload(),
-        follow_redirects=True,
-    )
+    _draft_id, location = _create_portal_draft(client)
+    response = client.get(location, headers=AUTH_HEADER)
 
     assert response.status_code == 200
     assert 'data-template="review-summary"' in response.text
@@ -573,23 +584,22 @@ def test_portal_generates_review_artifacts_and_submission(monkeypatch) -> None:
     _set_runtime_env(monkeypatch)
     client = TestClient(create_app(PlannerProposalStore()))
 
-    response = client.post(
-        "/portal/draft",
-        data=_portal_form_payload(),
-        follow_redirects=True,
-    )
+    draft_id, location = _create_portal_draft(client)
+    response = client.get(location, headers=AUTH_HEADER)
 
     assert response.status_code == 200
     assert 'data-template="review-summary"' in response.text
     assert "Policy-lite posture" in response.text
     assert "Generated artifacts" in response.text
 
-    match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
-    assert match is not None
-    draft_id = match.group(1)
-
-    itinerary = client.get(f"/portal/review/{draft_id}/artifacts/itinerary")
-    summary = client.get(f"/portal/review/{draft_id}/artifacts/summary")
+    itinerary = client.get(
+        f"/portal/review/{draft_id}/artifacts/itinerary",
+        headers=AUTH_HEADER,
+    )
+    summary = client.get(
+        f"/portal/review/{draft_id}/artifacts/summary",
+        headers=AUTH_HEADER,
+    )
     submit = client.post(
         f"/portal/review/{draft_id}/submit",
         headers=AUTH_HEADER,
@@ -627,14 +637,7 @@ def test_submission_creates_manager_review_queue_entry(monkeypatch) -> None:
     store = PlannerProposalStore()
     client = TestClient(create_app(store))
 
-    response = client.post(
-        "/portal/draft",
-        data=_portal_form_payload(),
-        follow_redirects=True,
-    )
-    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
-    assert draft_match is not None
-    draft_id = draft_match.group(1)
+    draft_id, _location = _create_portal_draft(client)
 
     submit = client.post(
         f"/portal/review/{draft_id}/submit",
@@ -665,14 +668,7 @@ def test_manager_review_decision_updates_status_and_history(monkeypatch) -> None
     store = PlannerProposalStore()
     client = TestClient(create_app(store))
 
-    response = client.post(
-        "/portal/draft",
-        data=_portal_form_payload(),
-        follow_redirects=True,
-    )
-    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
-    assert draft_match is not None
-    draft_id = draft_match.group(1)
+    draft_id, _location = _create_portal_draft(client)
 
     traveler_token = mint_bootstrap_token(
         subject="traveler",
@@ -724,14 +720,7 @@ def test_manager_review_routes_require_authorization(monkeypatch) -> None:
     store = PlannerProposalStore()
     client = TestClient(create_app(store))
 
-    response = client.post(
-        "/portal/draft",
-        data=_portal_form_payload(),
-        follow_redirects=True,
-    )
-    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
-    assert draft_match is not None
-    draft_id = draft_match.group(1)
+    draft_id, _location = _create_portal_draft(client)
     client.post(
         f"/portal/review/{draft_id}/submit",
         headers=AUTH_HEADER,
@@ -761,14 +750,7 @@ def test_manager_review_decision_requires_approve_permission(monkeypatch) -> Non
     store = PlannerProposalStore()
     client = TestClient(create_app(store))
 
-    response = client.post(
-        "/portal/draft",
-        data=_portal_form_payload(),
-        follow_redirects=True,
-    )
-    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
-    assert draft_match is not None
-    draft_id = draft_match.group(1)
+    draft_id, _location = _create_portal_draft(client)
     client.post(
         f"/portal/review/{draft_id}/submit",
         headers={
@@ -814,14 +796,7 @@ def test_manager_review_detail_hides_decision_form_for_read_only_role(
     store = PlannerProposalStore()
     client = TestClient(create_app(store))
 
-    response = client.post(
-        "/portal/draft",
-        data=_portal_form_payload(),
-        follow_redirects=True,
-    )
-    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
-    assert draft_match is not None
-    draft_id = draft_match.group(1)
+    draft_id, _location = _create_portal_draft(client)
     client.post(
         f"/portal/review/{draft_id}/submit",
         headers=AUTH_HEADER,
@@ -847,14 +822,7 @@ def test_portal_admin_console_surfaces_permissions_runtime_and_audit_history(
     store = PlannerProposalStore()
     client = TestClient(create_app(store))
 
-    review_response = client.post(
-        "/portal/draft",
-        data=_portal_form_payload(),
-        follow_redirects=True,
-    )
-    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", review_response.text)
-    assert draft_match is not None
-    draft_id = draft_match.group(1)
+    draft_id, _location = _create_portal_draft(client)
     client.post(
         f"/portal/review/{draft_id}/exceptions",
         data={
@@ -872,7 +840,10 @@ def test_portal_admin_console_surfaces_permissions_runtime_and_audit_history(
     )
     review = store.lookup_manager_review_for_draft(draft_id)
     assert review is not None
-    client.get(f"/portal/review/{draft_id}/artifacts/summary")
+    client.get(
+        f"/portal/review/{draft_id}/artifacts/summary",
+        headers=AUTH_HEADER,
+    )
 
     console = client.get(
         "/portal/admin?actor_role=finance_admin",
@@ -896,14 +867,7 @@ def test_manager_review_detail_uses_authenticated_permissions_for_actions(
     store = PlannerProposalStore()
     client = TestClient(create_app(store))
 
-    response = client.post(
-        "/portal/draft",
-        data=_portal_form_payload(),
-        follow_redirects=True,
-    )
-    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
-    assert draft_match is not None
-    draft_id = draft_match.group(1)
+    draft_id, _location = _create_portal_draft(client)
     client.post(
         f"/portal/review/{draft_id}/submit",
         headers={
@@ -945,14 +909,7 @@ def test_exception_decision_updates_review_detail_and_audit_log(monkeypatch) -> 
     store = PlannerProposalStore()
     client = TestClient(create_app(store))
 
-    review_response = client.post(
-        "/portal/draft",
-        data=_portal_form_payload(),
-        follow_redirects=True,
-    )
-    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", review_response.text)
-    assert draft_match is not None
-    draft_id = draft_match.group(1)
+    draft_id, _location = _create_portal_draft(client)
     client.post(
         f"/portal/review/{draft_id}/exceptions",
         data={
@@ -1010,14 +967,7 @@ def test_exception_rejection_keeps_notes_in_audit_log(monkeypatch) -> None:
     store = PlannerProposalStore()
     client = TestClient(create_app(store))
 
-    review_response = client.post(
-        "/portal/draft",
-        data=_portal_form_payload(),
-        follow_redirects=True,
-    )
-    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", review_response.text)
-    assert draft_match is not None
-    draft_id = draft_match.group(1)
+    draft_id, _location = _create_portal_draft(client)
     client.post(
         f"/portal/review/{draft_id}/exceptions",
         data={
@@ -1065,14 +1015,7 @@ def test_portal_submit_exception_request_returns_400_for_invalid_payload(
     _set_runtime_env(monkeypatch)
     client = TestClient(create_app(PlannerProposalStore()), raise_server_exceptions=False)
 
-    review_response = client.post(
-        "/portal/draft",
-        data=_portal_form_payload(),
-        follow_redirects=True,
-    )
-    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", review_response.text)
-    assert draft_match is not None
-    draft_id = draft_match.group(1)
+    draft_id, _location = _create_portal_draft(client)
 
     response = client.post(
         f"/portal/review/{draft_id}/exceptions",
@@ -1164,16 +1107,9 @@ def test_portal_artifact_downloads_use_cached_review_artifacts(monkeypatch) -> N
     _set_runtime_env(monkeypatch)
     client = TestClient(create_app(PlannerProposalStore()))
 
-    response = client.post(
-        "/portal/draft",
-        data=_portal_form_payload(),
-        follow_redirects=True,
-    )
-
+    draft_id, location = _create_portal_draft(client)
+    response = client.get(location, headers=AUTH_HEADER)
     assert response.status_code == 200
-    match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
-    assert match is not None
-    draft_id = match.group(1)
 
     def fail_render(*_args, **_kwargs):
         raise AssertionError("artifact download should use cached payloads")
@@ -1181,8 +1117,14 @@ def test_portal_artifact_downloads_use_cached_review_artifacts(monkeypatch) -> N
     monkeypatch.setattr(portal_review, "render_travel_spreadsheet_bytes", fail_render)
     monkeypatch.setattr(portal_review, "build_output_bundle", fail_render)
 
-    itinerary = client.get(f"/portal/review/{draft_id}/artifacts/itinerary")
-    summary = client.get(f"/portal/review/{draft_id}/artifacts/summary")
+    itinerary = client.get(
+        f"/portal/review/{draft_id}/artifacts/itinerary",
+        headers=AUTH_HEADER,
+    )
+    summary = client.get(
+        f"/portal/review/{draft_id}/artifacts/summary",
+        headers=AUTH_HEADER,
+    )
 
     assert itinerary.status_code == 200
     assert itinerary.content.startswith(b"PK")
@@ -1194,14 +1136,7 @@ def test_portal_submit_requires_bearer_token(monkeypatch) -> None:
     _set_runtime_env(monkeypatch)
     client = TestClient(create_app(PlannerProposalStore()))
 
-    response = client.post(
-        "/portal/draft",
-        data=_portal_form_payload(),
-        follow_redirects=True,
-    )
-    match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
-    assert match is not None
-    draft_id = match.group(1)
+    draft_id, _location = _create_portal_draft(client)
 
     submit = client.post(
         f"/portal/review/{draft_id}/submit",
@@ -1212,25 +1147,30 @@ def test_portal_submit_requires_bearer_token(monkeypatch) -> None:
     assert submit.json()["detail"] == "Missing bearer token."
 
 
+def test_portal_review_surface_requires_bearer_token(monkeypatch) -> None:
+    _set_bootstrap_runtime_env(monkeypatch)
+    client = TestClient(create_app(PlannerProposalStore()))
+
+    _draft_id, location = _create_portal_draft(client)
+    review = client.get(location)
+
+    assert review.status_code == 401
+    assert review.json()["detail"] == "Missing bearer token."
+
+
 def test_portal_review_state_survives_restart(monkeypatch, tmp_path) -> None:
     _set_runtime_env(monkeypatch)
     state_path = tmp_path / "portal-runtime-state.json"
 
     first_client = TestClient(create_app(PlannerProposalStore(state_path=state_path)))
-    response = first_client.post(
-        "/portal/draft",
-        data=_portal_form_payload(),
-        follow_redirects=True,
-    )
+    draft_id, location = _create_portal_draft(first_client)
+    response = first_client.get(location, headers=AUTH_HEADER)
 
     assert response.status_code == 200
-    match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
-    assert match is not None
-    draft_id = match.group(1)
     assert state_path.exists()
 
     second_client = TestClient(create_app(PlannerProposalStore(state_path=state_path)))
-    restored = second_client.get(f"/portal/review/{draft_id}")
+    restored = second_client.get(f"/portal/review/{draft_id}", headers=AUTH_HEADER)
 
     assert restored.status_code == 200
     assert 'data-template="review-summary"' in restored.text
@@ -1243,15 +1183,7 @@ def test_portal_submission_result_survives_restart(monkeypatch, tmp_path) -> Non
     state_path = tmp_path / "portal-runtime-state.json"
 
     first_client = TestClient(create_app(PlannerProposalStore(state_path=state_path)))
-    response = first_client.post(
-        "/portal/draft",
-        data=_portal_form_payload(),
-        follow_redirects=True,
-    )
-    match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
-    assert match is not None
-    draft_id = match.group(1)
-
+    draft_id, _location = _create_portal_draft(first_client)
     submit = first_client.post(
         f"/portal/review/{draft_id}/submit",
         headers=AUTH_HEADER,
@@ -1262,7 +1194,7 @@ def test_portal_submission_result_survives_restart(monkeypatch, tmp_path) -> Non
     assert "Submission result" in submit.text
 
     second_client = TestClient(create_app(PlannerProposalStore(state_path=state_path)))
-    restored = second_client.get(f"/portal/review/{draft_id}")
+    restored = second_client.get(f"/portal/review/{draft_id}", headers=AUTH_HEADER)
 
     assert restored.status_code == 200
     assert "Submission result" in restored.text
@@ -1304,6 +1236,54 @@ def test_submission_status_lookup_survives_restart(monkeypatch, tmp_path) -> Non
     assert evaluation_response.status_code == 200
 
 
+def test_portal_artifact_download_requires_view_permission(monkeypatch) -> None:
+    _set_bootstrap_runtime_env(monkeypatch)
+    client = TestClient(create_app(PlannerProposalStore()))
+
+    draft_id, _location = _create_portal_draft(client)
+    artifact = client.get(f"/portal/review/{draft_id}/artifacts/itinerary")
+    create_only_token = mint_bootstrap_token(
+        subject="portal-submit-only",
+        permissions=(Permission.CREATE,),
+        provider="google",
+        secret="bootstrap-secret-123",
+        expires_in_seconds=600,
+    )
+    forbidden = client.get(
+        f"/portal/review/{draft_id}/artifacts/itinerary",
+        headers={"Authorization": f"Bearer {create_only_token}"},
+    )
+
+    assert artifact.status_code == 401
+    assert artifact.json()["detail"] == "Missing bearer token."
+    assert forbidden.status_code == 403
+    assert forbidden.json()["detail"] == "Bootstrap token does not grant 'view'."
+
+
+def test_portal_review_surface_hides_submit_for_view_only_token(monkeypatch) -> None:
+    _set_bootstrap_runtime_env(monkeypatch)
+    client = TestClient(create_app(PlannerProposalStore()))
+
+    _draft_id, location = _create_portal_draft(client)
+    token = mint_bootstrap_token(
+        subject="portal-reviewer",
+        permissions=(Permission.VIEW,),
+        provider="google",
+        secret="bootstrap-secret-123",
+        expires_in_seconds=600,
+    )
+
+    review = client.get(
+        location,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert review.status_code == 200
+    assert "portal-reviewer" in review.text
+    assert "submission still requires `create`." in review.text
+    assert "Submit request" not in review.text
+
+
 def test_portal_routes_do_not_leave_legacy_request_paths_active() -> None:
     app = create_app()
     paths = {route.path for route in app.routes}
@@ -1331,6 +1311,7 @@ def test_portal_artifacts_raise_runtime_error_without_bundle_mappings(
     response = client.post(
         "/portal/draft",
         data=_portal_form_payload(),
+        headers=AUTH_HEADER,
     )
 
     assert response.status_code == 500

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -362,7 +362,10 @@ def test_expense_portal_review_surfaces_missing_receipt_warning() -> None:
     )
 
     assert response.status_code == 200
-    assert "Receipt missing: reviewers should hold reimbursement until the traveler uploads support." in response.text
+    assert (
+        "Receipt missing: reviewers should hold reimbursement until the traveler uploads support."
+        in response.text
+    )
     assert "Download CSV" in response.text
     assert store.expense_drafts_by_id
 
@@ -381,7 +384,10 @@ def test_expense_portal_generates_exports_and_policy_warning() -> None:
     )
 
     assert response.status_code == 200
-    assert "Policy warning: manager or accounting review is required before reimbursement." in response.text
+    assert (
+        "Policy warning: manager or accounting review is required before reimbursement."
+        in response.text
+    )
     assert "Manual receipt entry overrides OCR values for total." in response.text
 
     match = re.search(r"/portal/expenses/([^/]+)/artifacts/expense-csv", response.text)
@@ -417,9 +423,7 @@ def test_expense_portal_missing_approval_rules_returns_validation_error(
     payload = _expense_form_payload()
 
     monkeypatch.setattr("travel_plan_permission.approval._default_rules_path", lambda: None)
-    monkeypatch.setattr(
-        "travel_plan_permission.approval._package_rules_resource", lambda: None
-    )
+    monkeypatch.setattr("travel_plan_permission.approval._package_rules_resource", lambda: None)
 
     response = client.post("/portal/expenses/review", data=payload)
 
@@ -482,9 +486,7 @@ def test_portal_draft_validation_returns_bad_request_without_saving() -> None:
 
     assert response.status_code == 400
     assert 'data-template="validation-feedback"' in response.text
-    assert (
-        "Complete the missing details before this draft can be saved." in response.text
-    )
+    assert "Complete the missing details before this draft can be saved." in response.text
     assert store.portal_drafts_by_id == {}
     assert re.search(
         r'<ul class="missing-fields">.*?<li><code>destination_zip</code></li>',
@@ -494,9 +496,7 @@ def test_portal_draft_validation_returns_bad_request_without_saving() -> None:
     assert "Where are you headed and what" in response.text
 
 
-def test_portal_draft_validation_rejects_invalid_present_payload_without_saving() -> (
-    None
-):
+def test_portal_draft_validation_rejects_invalid_present_payload_without_saving() -> None:
     store = PlannerProposalStore()
     client = TestClient(create_app(store))
     payload = _portal_form_payload()
@@ -632,9 +632,7 @@ def test_submission_creates_manager_review_queue_entry(monkeypatch) -> None:
         data=_portal_form_payload(),
         follow_redirects=True,
     )
-    draft_match = re.search(
-        r"/portal/review/([^/]+)/artifacts/itinerary", response.text
-    )
+    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
     assert draft_match is not None
     draft_id = draft_match.group(1)
 
@@ -672,9 +670,7 @@ def test_manager_review_decision_updates_status_and_history(monkeypatch) -> None
         data=_portal_form_payload(),
         follow_redirects=True,
     )
-    draft_match = re.search(
-        r"/portal/review/([^/]+)/artifacts/itinerary", response.text
-    )
+    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
     assert draft_match is not None
     draft_id = draft_match.group(1)
 
@@ -733,9 +729,7 @@ def test_manager_review_routes_require_authorization(monkeypatch) -> None:
         data=_portal_form_payload(),
         follow_redirects=True,
     )
-    draft_match = re.search(
-        r"/portal/review/([^/]+)/artifacts/itinerary", response.text
-    )
+    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
     assert draft_match is not None
     draft_id = draft_match.group(1)
     client.post(
@@ -772,9 +766,7 @@ def test_manager_review_decision_requires_approve_permission(monkeypatch) -> Non
         data=_portal_form_payload(),
         follow_redirects=True,
     )
-    draft_match = re.search(
-        r"/portal/review/([^/]+)/artifacts/itinerary", response.text
-    )
+    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
     assert draft_match is not None
     draft_id = draft_match.group(1)
     client.post(
@@ -827,9 +819,7 @@ def test_manager_review_detail_hides_decision_form_for_read_only_role(
         data=_portal_form_payload(),
         follow_redirects=True,
     )
-    draft_match = re.search(
-        r"/portal/review/([^/]+)/artifacts/itinerary", response.text
-    )
+    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
     assert draft_match is not None
     draft_id = draft_match.group(1)
     client.post(
@@ -862,9 +852,7 @@ def test_portal_admin_console_surfaces_permissions_runtime_and_audit_history(
         data=_portal_form_payload(),
         follow_redirects=True,
     )
-    draft_match = re.search(
-        r"/portal/review/([^/]+)/artifacts/itinerary", review_response.text
-    )
+    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", review_response.text)
     assert draft_match is not None
     draft_id = draft_match.group(1)
     client.post(
@@ -913,9 +901,7 @@ def test_manager_review_detail_uses_authenticated_permissions_for_actions(
         data=_portal_form_payload(),
         follow_redirects=True,
     )
-    draft_match = re.search(
-        r"/portal/review/([^/]+)/artifacts/itinerary", response.text
-    )
+    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
     assert draft_match is not None
     draft_id = draft_match.group(1)
     client.post(
@@ -964,9 +950,7 @@ def test_exception_decision_updates_review_detail_and_audit_log(monkeypatch) -> 
         data=_portal_form_payload(),
         follow_redirects=True,
     )
-    draft_match = re.search(
-        r"/portal/review/([^/]+)/artifacts/itinerary", review_response.text
-    )
+    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", review_response.text)
     assert draft_match is not None
     draft_id = draft_match.group(1)
     client.post(
@@ -1031,9 +1015,7 @@ def test_exception_rejection_keeps_notes_in_audit_log(monkeypatch) -> None:
         data=_portal_form_payload(),
         follow_redirects=True,
     )
-    draft_match = re.search(
-        r"/portal/review/([^/]+)/artifacts/itinerary", review_response.text
-    )
+    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", review_response.text)
     assert draft_match is not None
     draft_id = draft_match.group(1)
     client.post(
@@ -1081,18 +1063,14 @@ def test_portal_submit_exception_request_returns_400_for_invalid_payload(
     monkeypatch,
 ) -> None:
     _set_runtime_env(monkeypatch)
-    client = TestClient(
-        create_app(PlannerProposalStore()), raise_server_exceptions=False
-    )
+    client = TestClient(create_app(PlannerProposalStore()), raise_server_exceptions=False)
 
     review_response = client.post(
         "/portal/draft",
         data=_portal_form_payload(),
         follow_redirects=True,
     )
-    draft_match = re.search(
-        r"/portal/review/([^/]+)/artifacts/itinerary", review_response.text
-    )
+    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", review_response.text)
     assert draft_match is not None
     draft_id = draft_match.group(1)
 
@@ -1234,6 +1212,98 @@ def test_portal_submit_requires_bearer_token(monkeypatch) -> None:
     assert submit.json()["detail"] == "Missing bearer token."
 
 
+def test_portal_review_state_survives_restart(monkeypatch, tmp_path) -> None:
+    _set_runtime_env(monkeypatch)
+    state_path = tmp_path / "portal-runtime-state.json"
+
+    first_client = TestClient(create_app(PlannerProposalStore(state_path=state_path)))
+    response = first_client.post(
+        "/portal/draft",
+        data=_portal_form_payload(),
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
+    assert match is not None
+    draft_id = match.group(1)
+    assert state_path.exists()
+
+    second_client = TestClient(create_app(PlannerProposalStore(state_path=state_path)))
+    restored = second_client.get(f"/portal/review/{draft_id}")
+
+    assert restored.status_code == 200
+    assert 'data-template="review-summary"' in restored.text
+    assert f"Draft {draft_id}" in restored.text
+    assert "Generated artifacts" in restored.text
+
+
+def test_portal_submission_result_survives_restart(monkeypatch, tmp_path) -> None:
+    _set_runtime_env(monkeypatch)
+    state_path = tmp_path / "portal-runtime-state.json"
+
+    first_client = TestClient(create_app(PlannerProposalStore(state_path=state_path)))
+    response = first_client.post(
+        "/portal/draft",
+        data=_portal_form_payload(),
+        follow_redirects=True,
+    )
+    match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
+    assert match is not None
+    draft_id = match.group(1)
+
+    submit = first_client.post(
+        f"/portal/review/{draft_id}/submit",
+        headers=AUTH_HEADER,
+        follow_redirects=True,
+    )
+
+    assert submit.status_code == 200
+    assert "Submission result" in submit.text
+
+    second_client = TestClient(create_app(PlannerProposalStore(state_path=state_path)))
+    restored = second_client.get(f"/portal/review/{draft_id}")
+
+    assert restored.status_code == 200
+    assert "Submission result" in restored.text
+    assert "Open manager review" in restored.text
+
+
+def test_submission_status_lookup_survives_restart(monkeypatch, tmp_path) -> None:
+    _set_runtime_env(monkeypatch, provider="okta")
+    state_path = tmp_path / "portal-runtime-state.json"
+    first_client = TestClient(create_app(PlannerProposalStore(state_path=state_path)))
+    trip_plan = _load_fixture("proposal_submission.json")
+    request_payload = {
+        "trip_id": trip_plan["trip_id"],
+        "proposal_id": "proposal-123",
+        "proposal_version": "proposal-v1",
+        "payload": {"selected_options": ["flight-1", "hotel-3"]},
+    }
+
+    submit_response = first_client.post(
+        "/api/planner/proposals",
+        headers=AUTH_HEADER,
+        json={"trip_plan": trip_plan, "request": request_payload},
+    )
+
+    assert submit_response.status_code == 200
+    execution_id = str(submit_response.json()["result_payload"]["execution_id"])
+
+    second_client = TestClient(create_app(PlannerProposalStore(state_path=state_path)))
+    status_response = second_client.get(
+        f"/api/planner/proposals/proposal-123/executions/{execution_id}",
+        headers=AUTH_HEADER,
+    )
+    evaluation_response = second_client.get(
+        f"/api/planner/executions/{execution_id}/evaluation-result",
+        headers=AUTH_HEADER,
+    )
+
+    assert status_response.status_code == 200
+    assert evaluation_response.status_code == 200
+
+
 def test_portal_routes_do_not_leave_legacy_request_paths_active() -> None:
     app = create_app()
     paths = {route.path for route in app.routes}
@@ -1251,9 +1321,7 @@ def test_portal_artifacts_raise_runtime_error_without_bundle_mappings(
     monkeypatch,
 ) -> None:
     _set_runtime_env(monkeypatch)
-    client = TestClient(
-        create_app(PlannerProposalStore()), raise_server_exceptions=False
-    )
+    client = TestClient(create_app(PlannerProposalStore()), raise_server_exceptions=False)
 
     def invalid_bundle(**_kwargs):
         return {"itinerary_excel": "bad", "summary_pdf": "bad"}


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Portal request workflow state currently lives only in the running service process. Draft, review, and submission context should survive a service restart so the portal can support bounded local and preview validation without silently dropping active workflow state.

#### Tasks
- [ ] Persist portal request workflow state outside the in-memory service process so draft and review URLs can be reopened after a restart.
- [ ] Restore enough review and submission context after restart to preserve deliberate user-facing behavior for cached artifacts and workflow progress.
- [ ] Add automated coverage and local-testing guidance for restart-oriented portal workflow checks.

#### Acceptance criteria
- [ ] After creating a portal request draft and reaching the review state, restarting the service does not silently discard that workflow state when reopening the same portal URL.
- [ ] Previously generated workflow context needed for review, artifact download, or submission is either restored or surfaced with explicit intentional handling rather than ambiguous failure.
- [ ] Automated tests cover the persisted workflow-state path, and the local testing documentation explains the restart verification flow.

<!-- auto-status-summary:end -->

—
PR created automatically to engage Codex.

<!-- pr-preamble:start -->
> **Source:** Issue #820

<!-- pr-preamble:end -->