### PR TITLE
Issue #821: harden portal auth review surfaces

### DIFF
--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -1246,7 +1246,12 @@ def _portal_template_context(
 ) -> dict[str, object]:
     answers = review.answers if review is not None else {}
     viewer_permissions = (
-        tuple(permission.value for permission in auth_context.permissions)
+        tuple(
+            permission.value
+            for permission in sorted(
+                auth_context.permissions, key=lambda permission: permission.value
+            )
+        )
         if auth_context is not None
         else ()
     )
@@ -1444,14 +1449,15 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         response_class=HTMLResponse,
         name="portal_review_detail",
     )
-    def portal_review_detail(request: Request, draft_id: str) -> HTMLResponse:
-        auth_context: PlannerAuthContext | None = None
-        authorization = request.headers.get("authorization")
-        if authorization is not None:
-            auth_context = _authorize_request(
-                authorization,
-                required_permission=Permission.VIEW,
-            )
+    def portal_review_detail(
+        request: Request,
+        draft_id: str,
+        authorization: str | None = Header(default=None),
+    ) -> HTMLResponse:
+        auth_context = _authorize_request(
+            authorization,
+            required_permission=Permission.VIEW,
+        )
         draft = proposal_store.lookup_portal_draft(draft_id)
         if draft is None:
             raise HTTPException(

--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -1242,8 +1242,14 @@ def _portal_template_context(
     *,
     exceptions: list[ExceptionRequest] | None = None,
     error_message: str | None = None,
+    auth_context: PlannerAuthContext | None = None,
 ) -> dict[str, object]:
     answers = review.answers if review is not None else {}
+    viewer_permissions = (
+        tuple(permission.value for permission in auth_context.permissions)
+        if auth_context is not None
+        else ()
+    )
     return {
         "request": request,
         "answers": answers,
@@ -1258,6 +1264,17 @@ def _portal_template_context(
         ),
         "optional_fields": _PORTAL_OPTIONAL_FIELDS,
         "error_message": error_message,
+        "viewer": auth_context,
+        "viewer_permissions": viewer_permissions,
+        "viewer_can_view": (
+            auth_context.can(Permission.VIEW) if auth_context is not None else False
+        ),
+        "viewer_can_create": (
+            auth_context.can(Permission.CREATE) if auth_context is not None else False
+        ),
+        "viewer_can_approve": (
+            auth_context.can(Permission.APPROVE) if auth_context is not None else False
+        ),
     }
 
 
@@ -1428,6 +1445,13 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         name="portal_review_detail",
     )
     def portal_review_detail(request: Request, draft_id: str) -> HTMLResponse:
+        auth_context: PlannerAuthContext | None = None
+        authorization = request.headers.get("authorization")
+        if authorization is not None:
+            auth_context = _authorize_request(
+                authorization,
+                required_permission=Permission.VIEW,
+            )
         draft = proposal_store.lookup_portal_draft(draft_id)
         if draft is None:
             raise HTTPException(
@@ -1451,6 +1475,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
                 request,
                 review,
                 exceptions=proposal_store.list_exception_requests(draft_id),
+                auth_context=auth_context,
             ),
         )
 
@@ -1556,7 +1581,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         draft_id: str,
         authorization: str | None = Header(default=None),
     ) -> HTMLResponse:
-        _authorize_request(
+        auth_context = _authorize_request(
             authorization,
             required_permission=Permission.CREATE,
         )
@@ -1610,6 +1635,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
                 request,
                 review,
                 exceptions=proposal_store.list_exception_requests(draft_id),
+                auth_context=auth_context,
             ),
         )
 
@@ -1830,7 +1856,12 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
     def portal_artifact(
         draft_id: str,
         artifact_name: str,
+        authorization: str | None = Header(default=None),
     ) -> Response:
+        _authorize_request(
+            authorization,
+            required_permission=Permission.VIEW,
+        )
         draft = proposal_store.lookup_portal_draft(draft_id)
         if draft is None:
             raise HTTPException(

--- a/src/travel_plan_permission/templates/review_summary.html
+++ b/src/travel_plan_permission/templates/review_summary.html
@@ -52,6 +52,49 @@
 
     <aside class="stack">
       <section class="panel">
+        <h2>Access posture</h2>
+        {% if viewer %}
+          <p style="margin-top: 10px;"><span class="badge">{{ viewer.provider }} / {{ viewer.auth_mode.value }}</span></p>
+          <div class="callout" style="margin-top: 16px;">
+            <h3>Authenticated caller</h3>
+            <dl>
+              <div>
+                <dt>Subject</dt>
+                <dd>{{ viewer.subject }}</dd>
+              </div>
+              <div>
+                <dt>Permissions</dt>
+                <dd>{{ viewer_permissions | join(', ') }}</dd>
+              </div>
+            </dl>
+          </div>
+          <div class="callout" style="margin-top: 16px;">
+            <h3>Review surface</h3>
+            <ul>
+              {% if viewer_can_view %}
+                <li>This caller can download generated review artifacts.</li>
+              {% else %}
+                <li>This caller is viewing a saved draft without artifact download access.</li>
+              {% endif %}
+              {% if viewer_can_create %}
+                <li>This caller can submit the reviewed request.</li>
+              {% else %}
+                <li>This caller can review the draft, but submission still requires `create`.</li>
+              {% endif %}
+              {% if viewer_can_approve %}
+                <li>Approval-capable roles can inspect reviewer-facing posture without switching tools.</li>
+              {% endif %}
+            </ul>
+          </div>
+        {% else %}
+          <p style="margin-top: 10px;">
+            Connect with a planner-authenticated caller to unlock role-aware review posture,
+            artifact downloads, and submit controls.
+          </p>
+        {% endif %}
+      </section>
+
+      <section class="panel">
         <h2>Review status</h2>
         {% if review.missing_fields %}
           <p style="margin-top: 10px;"><span class="badge warn">Missing required inputs</span></p>
@@ -178,9 +221,13 @@
               Submission reuses the existing proposal submission seam and records the resulting
               execution contract alongside the draft.
             </p>
-            <form method="post" action="/portal/review/{{ review.draft_id }}/submit" style="margin-top: 14px;">
-              <button class="primary" type="submit">Submit request</button>
-            </form>
+            {% if viewer_can_create %}
+              <form method="post" action="/portal/review/{{ review.draft_id }}/submit" style="margin-top: 14px;">
+                <button class="primary" type="submit">Submit request</button>
+              </form>
+            {% else %}
+              <p style="margin-top: 14px;">Submission stays hidden until the caller has `create` permission.</p>
+            {% endif %}
           </div>
         </section>
       {% endif %}

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -588,8 +588,14 @@ def test_portal_generates_review_artifacts_and_submission(monkeypatch) -> None:
     assert match is not None
     draft_id = match.group(1)
 
-    itinerary = client.get(f"/portal/review/{draft_id}/artifacts/itinerary")
-    summary = client.get(f"/portal/review/{draft_id}/artifacts/summary")
+    itinerary = client.get(
+        f"/portal/review/{draft_id}/artifacts/itinerary",
+        headers=AUTH_HEADER,
+    )
+    summary = client.get(
+        f"/portal/review/{draft_id}/artifacts/summary",
+        headers=AUTH_HEADER,
+    )
     submit = client.post(
         f"/portal/review/{draft_id}/submit",
         headers=AUTH_HEADER,
@@ -872,7 +878,10 @@ def test_portal_admin_console_surfaces_permissions_runtime_and_audit_history(
     )
     review = store.lookup_manager_review_for_draft(draft_id)
     assert review is not None
-    client.get(f"/portal/review/{draft_id}/artifacts/summary")
+    client.get(
+        f"/portal/review/{draft_id}/artifacts/summary",
+        headers=AUTH_HEADER,
+    )
 
     console = client.get(
         "/portal/admin?actor_role=finance_admin",
@@ -1181,8 +1190,14 @@ def test_portal_artifact_downloads_use_cached_review_artifacts(monkeypatch) -> N
     monkeypatch.setattr(portal_review, "render_travel_spreadsheet_bytes", fail_render)
     monkeypatch.setattr(portal_review, "build_output_bundle", fail_render)
 
-    itinerary = client.get(f"/portal/review/{draft_id}/artifacts/itinerary")
-    summary = client.get(f"/portal/review/{draft_id}/artifacts/summary")
+    itinerary = client.get(
+        f"/portal/review/{draft_id}/artifacts/itinerary",
+        headers=AUTH_HEADER,
+    )
+    summary = client.get(
+        f"/portal/review/{draft_id}/artifacts/summary",
+        headers=AUTH_HEADER,
+    )
 
     assert itinerary.status_code == 200
     assert itinerary.content.startswith(b"PK")
@@ -1194,14 +1209,7 @@ def test_portal_submit_requires_bearer_token(monkeypatch) -> None:
     _set_runtime_env(monkeypatch)
     client = TestClient(create_app(PlannerProposalStore()))
 
-    response = client.post(
-        "/portal/draft",
-        data=_portal_form_payload(),
-        follow_redirects=True,
-    )
-    match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
-    assert match is not None
-    draft_id = match.group(1)
+    draft_id, _location = _create_portal_draft(client)
 
     submit = client.post(
         f"/portal/review/{draft_id}/submit",
@@ -1212,25 +1220,30 @@ def test_portal_submit_requires_bearer_token(monkeypatch) -> None:
     assert submit.json()["detail"] == "Missing bearer token."
 
 
+def test_portal_review_surface_requires_bearer_token(monkeypatch) -> None:
+    _set_bootstrap_runtime_env(monkeypatch)
+    client = TestClient(create_app(PlannerProposalStore()))
+
+    _draft_id, location = _create_portal_draft(client)
+    review = client.get(location)
+
+    assert review.status_code == 401
+    assert review.json()["detail"] == "Missing bearer token."
+
+
 def test_portal_review_state_survives_restart(monkeypatch, tmp_path) -> None:
     _set_runtime_env(monkeypatch)
     state_path = tmp_path / "portal-runtime-state.json"
 
     first_client = TestClient(create_app(PlannerProposalStore(state_path=state_path)))
-    response = first_client.post(
-        "/portal/draft",
-        data=_portal_form_payload(),
-        follow_redirects=True,
-    )
+    draft_id, location = _create_portal_draft(first_client)
+    response = first_client.get(location, headers=AUTH_HEADER)
 
     assert response.status_code == 200
-    match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
-    assert match is not None
-    draft_id = match.group(1)
     assert state_path.exists()
 
     second_client = TestClient(create_app(PlannerProposalStore(state_path=state_path)))
-    restored = second_client.get(f"/portal/review/{draft_id}")
+    restored = second_client.get(f"/portal/review/{draft_id}", headers=AUTH_HEADER)
 
     assert restored.status_code == 200
     assert 'data-template="review-summary"' in restored.text
@@ -1243,15 +1256,7 @@ def test_portal_submission_result_survives_restart(monkeypatch, tmp_path) -> Non
     state_path = tmp_path / "portal-runtime-state.json"
 
     first_client = TestClient(create_app(PlannerProposalStore(state_path=state_path)))
-    response = first_client.post(
-        "/portal/draft",
-        data=_portal_form_payload(),
-        follow_redirects=True,
-    )
-    match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
-    assert match is not None
-    draft_id = match.group(1)
-
+    draft_id, _location = _create_portal_draft(first_client)
     submit = first_client.post(
         f"/portal/review/{draft_id}/submit",
         headers=AUTH_HEADER,
@@ -1262,7 +1267,7 @@ def test_portal_submission_result_survives_restart(monkeypatch, tmp_path) -> Non
     assert "Submission result" in submit.text
 
     second_client = TestClient(create_app(PlannerProposalStore(state_path=state_path)))
-    restored = second_client.get(f"/portal/review/{draft_id}")
+    restored = second_client.get(f"/portal/review/{draft_id}", headers=AUTH_HEADER)
 
     assert restored.status_code == 200
     assert "Submission result" in restored.text
@@ -1302,6 +1307,54 @@ def test_submission_status_lookup_survives_restart(monkeypatch, tmp_path) -> Non
 
     assert status_response.status_code == 200
     assert evaluation_response.status_code == 200
+
+
+def test_portal_artifact_download_requires_view_permission(monkeypatch) -> None:
+    _set_bootstrap_runtime_env(monkeypatch)
+    client = TestClient(create_app(PlannerProposalStore()))
+
+    draft_id, _location = _create_portal_draft(client)
+    artifact = client.get(f"/portal/review/{draft_id}/artifacts/itinerary")
+    create_only_token = mint_bootstrap_token(
+        subject="portal-submit-only",
+        permissions=(Permission.CREATE,),
+        provider="google",
+        secret="bootstrap-secret-123",
+        expires_in_seconds=600,
+    )
+    forbidden = client.get(
+        f"/portal/review/{draft_id}/artifacts/itinerary",
+        headers={"Authorization": f"Bearer {create_only_token}"},
+    )
+
+    assert artifact.status_code == 401
+    assert artifact.json()["detail"] == "Missing bearer token."
+    assert forbidden.status_code == 403
+    assert forbidden.json()["detail"] == "Bootstrap token does not grant 'view'."
+
+
+def test_portal_review_surface_hides_submit_for_view_only_token(monkeypatch) -> None:
+    _set_bootstrap_runtime_env(monkeypatch)
+    client = TestClient(create_app(PlannerProposalStore()))
+
+    _draft_id, location = _create_portal_draft(client)
+    token = mint_bootstrap_token(
+        subject="portal-reviewer",
+        permissions=(Permission.VIEW,),
+        provider="google",
+        secret="bootstrap-secret-123",
+        expires_in_seconds=600,
+    )
+
+    review = client.get(
+        location,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert review.status_code == 200
+    assert "portal-reviewer" in review.text
+    assert "submission still requires `create`." in review.text
+    assert "Submit request" not in review.text
 
 
 def test_portal_routes_do_not_leave_legacy_request_paths_active() -> None:

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -81,6 +81,23 @@ def _portal_form_payload() -> dict[str, str]:
     }
 
 
+def _create_portal_draft(
+    client: TestClient,
+    *,
+    payload: dict[str, str] | None = None,
+) -> tuple[str, str]:
+    response = client.post(
+        "/portal/draft",
+        data=payload or _portal_form_payload(),
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+    location = response.headers["location"]
+    match = re.search(r"/portal/review/([^/]+)$", location)
+    assert match is not None
+    return match.group(1), location
+
+
 def _expense_form_payload() -> dict[str, str]:
     return {
         "approved_request_id": "REQ-410",
@@ -537,11 +554,8 @@ def test_portal_review_allows_optional_fields_to_remain_blank(monkeypatch) -> No
     ):
         payload.pop(field_name)
 
-    response = client.post(
-        "/portal/draft",
-        data=payload,
-        follow_redirects=True,
-    )
+    _draft_id, location = _create_portal_draft(client, payload=payload)
+    response = client.get(location, headers=AUTH_HEADER)
 
     assert response.status_code == 200
     assert 'data-template="review-summary"' in response.text
@@ -553,11 +567,8 @@ def test_portal_review_persists_policy_readiness_answers(monkeypatch) -> None:
     _set_runtime_env(monkeypatch)
     client = TestClient(create_app(PlannerProposalStore()))
 
-    response = client.post(
-        "/portal/draft",
-        data=_portal_form_payload(),
-        follow_redirects=True,
-    )
+    _draft_id, location = _create_portal_draft(client)
+    response = client.get(location, headers=AUTH_HEADER)
 
     assert response.status_code == 200
     assert 'data-template="review-summary"' in response.text
@@ -573,20 +584,13 @@ def test_portal_generates_review_artifacts_and_submission(monkeypatch) -> None:
     _set_runtime_env(monkeypatch)
     client = TestClient(create_app(PlannerProposalStore()))
 
-    response = client.post(
-        "/portal/draft",
-        data=_portal_form_payload(),
-        follow_redirects=True,
-    )
+    draft_id, location = _create_portal_draft(client)
+    response = client.get(location, headers=AUTH_HEADER)
 
     assert response.status_code == 200
     assert 'data-template="review-summary"' in response.text
     assert "Policy-lite posture" in response.text
     assert "Generated artifacts" in response.text
-
-    match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
-    assert match is not None
-    draft_id = match.group(1)
 
     itinerary = client.get(
         f"/portal/review/{draft_id}/artifacts/itinerary",
@@ -633,14 +637,7 @@ def test_submission_creates_manager_review_queue_entry(monkeypatch) -> None:
     store = PlannerProposalStore()
     client = TestClient(create_app(store))
 
-    response = client.post(
-        "/portal/draft",
-        data=_portal_form_payload(),
-        follow_redirects=True,
-    )
-    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
-    assert draft_match is not None
-    draft_id = draft_match.group(1)
+    draft_id, _location = _create_portal_draft(client)
 
     submit = client.post(
         f"/portal/review/{draft_id}/submit",
@@ -671,14 +668,7 @@ def test_manager_review_decision_updates_status_and_history(monkeypatch) -> None
     store = PlannerProposalStore()
     client = TestClient(create_app(store))
 
-    response = client.post(
-        "/portal/draft",
-        data=_portal_form_payload(),
-        follow_redirects=True,
-    )
-    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
-    assert draft_match is not None
-    draft_id = draft_match.group(1)
+    draft_id, _location = _create_portal_draft(client)
 
     traveler_token = mint_bootstrap_token(
         subject="traveler",
@@ -730,14 +720,7 @@ def test_manager_review_routes_require_authorization(monkeypatch) -> None:
     store = PlannerProposalStore()
     client = TestClient(create_app(store))
 
-    response = client.post(
-        "/portal/draft",
-        data=_portal_form_payload(),
-        follow_redirects=True,
-    )
-    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
-    assert draft_match is not None
-    draft_id = draft_match.group(1)
+    draft_id, _location = _create_portal_draft(client)
     client.post(
         f"/portal/review/{draft_id}/submit",
         headers=AUTH_HEADER,
@@ -767,14 +750,7 @@ def test_manager_review_decision_requires_approve_permission(monkeypatch) -> Non
     store = PlannerProposalStore()
     client = TestClient(create_app(store))
 
-    response = client.post(
-        "/portal/draft",
-        data=_portal_form_payload(),
-        follow_redirects=True,
-    )
-    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
-    assert draft_match is not None
-    draft_id = draft_match.group(1)
+    draft_id, _location = _create_portal_draft(client)
     client.post(
         f"/portal/review/{draft_id}/submit",
         headers={
@@ -820,14 +796,7 @@ def test_manager_review_detail_hides_decision_form_for_read_only_role(
     store = PlannerProposalStore()
     client = TestClient(create_app(store))
 
-    response = client.post(
-        "/portal/draft",
-        data=_portal_form_payload(),
-        follow_redirects=True,
-    )
-    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
-    assert draft_match is not None
-    draft_id = draft_match.group(1)
+    draft_id, _location = _create_portal_draft(client)
     client.post(
         f"/portal/review/{draft_id}/submit",
         headers=AUTH_HEADER,
@@ -853,14 +822,7 @@ def test_portal_admin_console_surfaces_permissions_runtime_and_audit_history(
     store = PlannerProposalStore()
     client = TestClient(create_app(store))
 
-    review_response = client.post(
-        "/portal/draft",
-        data=_portal_form_payload(),
-        follow_redirects=True,
-    )
-    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", review_response.text)
-    assert draft_match is not None
-    draft_id = draft_match.group(1)
+    draft_id, _location = _create_portal_draft(client)
     client.post(
         f"/portal/review/{draft_id}/exceptions",
         data={
@@ -905,14 +867,7 @@ def test_manager_review_detail_uses_authenticated_permissions_for_actions(
     store = PlannerProposalStore()
     client = TestClient(create_app(store))
 
-    response = client.post(
-        "/portal/draft",
-        data=_portal_form_payload(),
-        follow_redirects=True,
-    )
-    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
-    assert draft_match is not None
-    draft_id = draft_match.group(1)
+    draft_id, _location = _create_portal_draft(client)
     client.post(
         f"/portal/review/{draft_id}/submit",
         headers={
@@ -954,14 +909,7 @@ def test_exception_decision_updates_review_detail_and_audit_log(monkeypatch) -> 
     store = PlannerProposalStore()
     client = TestClient(create_app(store))
 
-    review_response = client.post(
-        "/portal/draft",
-        data=_portal_form_payload(),
-        follow_redirects=True,
-    )
-    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", review_response.text)
-    assert draft_match is not None
-    draft_id = draft_match.group(1)
+    draft_id, _location = _create_portal_draft(client)
     client.post(
         f"/portal/review/{draft_id}/exceptions",
         data={
@@ -1019,14 +967,7 @@ def test_exception_rejection_keeps_notes_in_audit_log(monkeypatch) -> None:
     store = PlannerProposalStore()
     client = TestClient(create_app(store))
 
-    review_response = client.post(
-        "/portal/draft",
-        data=_portal_form_payload(),
-        follow_redirects=True,
-    )
-    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", review_response.text)
-    assert draft_match is not None
-    draft_id = draft_match.group(1)
+    draft_id, _location = _create_portal_draft(client)
     client.post(
         f"/portal/review/{draft_id}/exceptions",
         data={
@@ -1074,14 +1015,7 @@ def test_portal_submit_exception_request_returns_400_for_invalid_payload(
     _set_runtime_env(monkeypatch)
     client = TestClient(create_app(PlannerProposalStore()), raise_server_exceptions=False)
 
-    review_response = client.post(
-        "/portal/draft",
-        data=_portal_form_payload(),
-        follow_redirects=True,
-    )
-    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", review_response.text)
-    assert draft_match is not None
-    draft_id = draft_match.group(1)
+    draft_id, _location = _create_portal_draft(client)
 
     response = client.post(
         f"/portal/review/{draft_id}/exceptions",
@@ -1173,16 +1107,9 @@ def test_portal_artifact_downloads_use_cached_review_artifacts(monkeypatch) -> N
     _set_runtime_env(monkeypatch)
     client = TestClient(create_app(PlannerProposalStore()))
 
-    response = client.post(
-        "/portal/draft",
-        data=_portal_form_payload(),
-        follow_redirects=True,
-    )
-
+    draft_id, location = _create_portal_draft(client)
+    response = client.get(location, headers=AUTH_HEADER)
     assert response.status_code == 200
-    match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
-    assert match is not None
-    draft_id = match.group(1)
 
     def fail_render(*_args, **_kwargs):
         raise AssertionError("artifact download should use cached payloads")
@@ -1384,6 +1311,7 @@ def test_portal_artifacts_raise_runtime_error_without_bundle_mappings(
     response = client.post(
         "/portal/draft",
         data=_portal_form_payload(),
+        headers=AUTH_HEADER,
     )
 
     assert response.status_code == 500


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #821

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
- the workflow portal review surface currently treats every viewer as if they can submit requests
- generated review artifacts are exposed without confirming the caller has planner view access

#### Tasks
- [x] require planner `view` permission before rendering saved portal draft review details and artifact downloads
- [x] surface authenticated caller provider and permission posture inside the portal review UI
- [x] keep submit affordances visible only for callers that also hold planner `create` permission

#### Acceptance criteria
- [x] `/portal/requests/{draft_id}` and portal artifact downloads reject missing bearer tokens
- [x] authenticated review pages show the caller subject plus provider/permission posture for reviewer-facing flows
- [x] review-only callers can inspect the draft without seeing a submit action, while create-capable callers can still submit successfully

**Head SHA:** 954f83bb8c8924224a82603e2fbb9f6cf519b50d
**Landing path:** merged via stacked PR #824 into `codex/issue-820`, then carried to `main` by merged parent PR #823 (`63fa55af29b3ab45a640161f01ee7b0c40ccacbb`).
**Latest verification evidence:** provider comparison PASS recorded on merged parent PR #823 at issuecomment-4267973600.
<!-- auto-status-summary:end -->
