### PR TITLE
Codex bootstrap for #821

### DIFF
--- a/agents/codex-821.md
+++ b/agents/codex-821.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #821 -->

--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -80,9 +80,7 @@ __all__ = [
 ]
 
 _OPTIONAL_SNAPSHOT_BODY = Body(default=None)
-_TEMPLATES = Jinja2Templates(
-    directory=str(Path(__file__).resolve().parent / "templates")
-)
+_TEMPLATES = Jinja2Templates(directory=str(Path(__file__).resolve().parent / "templates"))
 _PORTAL_CANONICAL_FIELDS: tuple[str, ...] = (
     "traveler_name",
     "business_purpose",
@@ -407,9 +405,7 @@ class PlannerProposalStore:
     portal_drafts_by_id: dict[str, PortalDraft] = field(default_factory=dict)
     expense_drafts_by_id: dict[str, PortalDraft] = field(default_factory=dict)
     manager_reviews: ReviewWorkflowStore = field(default_factory=ReviewWorkflowStore)
-    exception_requests_by_draft_id: dict[str, list[ExceptionRequest]] = field(
-        default_factory=dict
-    )
+    exception_requests_by_draft_id: dict[str, list[ExceptionRequest]] = field(default_factory=dict)
     security: SecurityModel = field(default_factory=SecurityModel)
 
     def remember_plan(self, trip_plan: TripPlan) -> None:
@@ -436,9 +432,7 @@ class PlannerProposalStore:
         self.remember_plan(trip_plan)
         execution_id = response.result_payload.get("execution_id")
         if not isinstance(execution_id, str):
-            raise ValueError(
-                "Planner proposal response missing required string execution_id"
-            )
+            raise ValueError("Planner proposal response missing required string execution_id")
         self.proposals_by_execution_id[execution_id] = StoredProposal(
             trip_plan=trip_plan.model_copy(deep=True),
             request=request.model_copy(deep=True),
@@ -680,9 +674,7 @@ class PlannerProposalStore:
 
         requests = self.exception_requests_by_draft_id.get(draft_id)
         if requests is None or exception_index < 0 or exception_index >= len(requests):
-            raise KeyError(
-                f"No exception request {exception_index} found for draft '{draft_id}'."
-            )
+            raise KeyError(f"No exception request {exception_index} found for draft '{draft_id}'.")
         target = requests[exception_index]
         if approved:
             target.approve(approver_id=actor_id, notes=notes)
@@ -1011,9 +1003,7 @@ def _expense_review_state(
                 "Approval rules configuration is unavailable; expense policy review cannot be completed."
             )
         except InvalidOperation:
-            validation_errors.append(
-                "One or more currency amounts are not valid decimal values."
-            )
+            validation_errors.append("One or more currency amounts are not valid decimal values.")
         except ValueError as exc:
             validation_errors.append(str(exc))
 
@@ -1034,6 +1024,7 @@ def _portal_template_context(
     request: Request,
     review: PortalReviewState | None = None,
     *,
+    auth_context: PlannerAuthContext | None = None,
     exceptions: list[ExceptionRequest] | None = None,
     error_message: str | None = None,
 ) -> dict[str, object]:
@@ -1042,6 +1033,13 @@ def _portal_template_context(
         "request": request,
         "answers": answers,
         "review": review,
+        "auth_context": auth_context,
+        "auth_permissions": (
+            tuple(sorted(auth_context.permissions, key=lambda item: item.value))
+            if auth_context is not None
+            else ()
+        ),
+        "can_submit": auth_context.can(Permission.CREATE) if auth_context is not None else False,
         "exceptions": exceptions or [],
         "exception_types": tuple(ExceptionType),
         "ground_transport_options": (
@@ -1080,9 +1078,7 @@ def _manager_review_queue_context(
         "request": request,
         "reviews": reviews,
         "role_view": role_view,
-        "actor_permissions": tuple(
-            sorted(auth_context.permissions, key=lambda item: item.value)
-        ),
+        "actor_permissions": tuple(sorted(auth_context.permissions, key=lambda item: item.value)),
         "role_can_approve": auth_context.can(Permission.APPROVE),
     }
 
@@ -1101,9 +1097,7 @@ def _manager_review_detail_context(
         "request": request,
         "review": review,
         "role_view": role_view,
-        "actor_permissions": tuple(
-            sorted(auth_context.permissions, key=lambda item: item.value)
-        ),
+        "actor_permissions": tuple(sorted(auth_context.permissions, key=lambda item: item.value)),
         "role_can_approve": auth_context.can(Permission.APPROVE),
         "exceptions": exceptions or [],
         "audit_events": audit_events or [],
@@ -1125,9 +1119,7 @@ def _admin_dashboard_context(
     return {
         "request": request,
         "role_view": role_view,
-        "actor_permissions": tuple(
-            sorted(auth_context.permissions, key=lambda item: item.value)
-        ),
+        "actor_permissions": tuple(sorted(auth_context.permissions, key=lambda item: item.value)),
         "role_can_approve": auth_context.can(Permission.APPROVE),
         "role_can_configure": auth_context.can(Permission.CONFIGURE),
         "available_roles": tuple(RoleName),
@@ -1216,9 +1208,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         draft = proposal_store.save_expense_draft(answers)
         persisted_review = _expense_review_state(draft.draft_id, answers)
         if persisted_review.artifacts:
-            proposal_store.cache_expense_artifacts(
-                draft.draft_id, persisted_review.artifacts
-            )
+            proposal_store.cache_expense_artifacts(draft.draft_id, persisted_review.artifacts)
         return RedirectResponse(
             url=request.url_for("portal_expense_detail", draft_id=draft.draft_id),
             status_code=status.HTTP_303_SEE_OTHER,
@@ -1229,7 +1219,15 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         response_class=HTMLResponse,
         name="portal_review_detail",
     )
-    def portal_review_detail(request: Request, draft_id: str) -> HTMLResponse:
+    def portal_review_detail(
+        request: Request,
+        draft_id: str,
+        authorization: str | None = Header(default=None),
+    ) -> HTMLResponse:
+        auth_context = _authorize_request(
+            authorization,
+            required_permission=Permission.VIEW,
+        )
         draft = proposal_store.lookup_portal_draft(draft_id)
         if draft is None:
             raise HTTPException(
@@ -1241,9 +1239,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
             draft.answers,
             required_fields=_PORTAL_REQUIRED_FIELDS,
             canonical_payload_builder=_canonical_payload_from_answers,
-            manager_review=proposal_store.lookup_manager_review_for_draft(
-                draft.draft_id
-            ),
+            manager_review=proposal_store.lookup_manager_review_for_draft(draft.draft_id),
         )
         if review.artifacts and not draft.cached_artifacts:
             proposal_store.cache_portal_artifacts(draft.draft_id, review.artifacts)
@@ -1253,6 +1249,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
             context=_portal_template_context(
                 request,
                 review,
+                auth_context=auth_context,
                 exceptions=proposal_store.list_exception_requests(draft_id),
             ),
         )
@@ -1294,9 +1291,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
             keep_blank_values=True,
         )
         try:
-            exception_type = ExceptionType(
-                parsed.get("exception_type", [""])[-1].strip()
-            )
+            exception_type = ExceptionType(parsed.get("exception_type", [""])[-1].strip())
         except ValueError as exc:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -1337,9 +1332,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
                 supporting_docs=[supporting_doc] if supporting_doc else [],
             )
         except ValidationError as exc:
-            messages = "; ".join(
-                error["msg"] for error in exc.errors() if error.get("msg")
-            )
+            messages = "; ".join(error["msg"] for error in exc.errors() if error.get("msg"))
             return _TEMPLATES.TemplateResponse(
                 request=request,
                 name="review_summary.html",
@@ -1363,7 +1356,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         draft_id: str,
         authorization: str | None = Header(default=None),
     ) -> HTMLResponse:
-        _authorize_request(
+        auth_context = _authorize_request(
             authorization,
             required_permission=Permission.CREATE,
         )
@@ -1379,11 +1372,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
             required_fields=_PORTAL_REQUIRED_FIELDS,
             canonical_payload_builder=_canonical_payload_from_answers,
         )
-        if (
-            review.trip_plan is None
-            or review.missing_fields
-            or review.validation_errors
-        ):
+        if review.trip_plan is None or review.missing_fields or review.validation_errors:
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="Complete the request review before submitting the portal draft.",
@@ -1419,6 +1408,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
             context=_portal_template_context(
                 request,
                 review,
+                auth_context=auth_context,
                 exceptions=proposal_store.list_exception_requests(draft_id),
             ),
         )
@@ -1496,9 +1486,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
             required_permission=Permission.APPROVE,
         )
         role_view = _resolve_role_view(actor_role)
-        parsed = parse_qs(
-            (await request.body()).decode("utf-8"), keep_blank_values=True
-        )
+        parsed = parse_qs((await request.body()).decode("utf-8"), keep_blank_values=True)
         action_name = parsed.get("action", [""])[-1].strip()
         actor_id = parsed.get("actor_id", [""])[-1].strip()
         rationale = parsed.get("rationale", [""])[-1].strip()
@@ -1600,17 +1588,12 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         resolved_role = _resolve_role_view(actor_role).role.value
         if review is not None:
             return RedirectResponse(
-                url=str(
-                    request.url_for(
-                        "portal_manager_review_detail", review_id=review.review_id
-                    )
-                )
+                url=str(request.url_for("portal_manager_review_detail", review_id=review.review_id))
                 + f"?actor_role={resolved_role}",
                 status_code=status.HTTP_303_SEE_OTHER,
             )
         return RedirectResponse(
-            url=str(request.url_for("portal_admin_dashboard"))
-            + f"?actor_role={resolved_role}",
+            url=str(request.url_for("portal_admin_dashboard")) + f"?actor_role={resolved_role}",
             status_code=status.HTTP_303_SEE_OTHER,
         )
 
@@ -1647,7 +1630,12 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
     def portal_artifact(
         draft_id: str,
         artifact_name: str,
+        authorization: str | None = Header(default=None),
     ) -> Response:
+        auth_context = _authorize_request(
+            authorization,
+            required_permission=Permission.VIEW,
+        )
         draft = proposal_store.lookup_portal_draft(draft_id)
         if draft is None:
             raise HTTPException(
@@ -1673,7 +1661,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
             )
         proposal_store.security.audit_log.record(
             event_type=AuditEventType.EXPORT,
-            actor="workflow-portal",
+            actor=auth_context.subject,
             subject=draft_id,
             outcome="artifact_downloaded",
             metadata={"artifact": artifact_name},
@@ -1681,9 +1669,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         return Response(
             content=artifact.content,
             media_type=artifact.media_type,
-            headers={
-                "Content-Disposition": f'attachment; filename="{artifact.filename}"'
-            },
+            headers={"Content-Disposition": f'attachment; filename="{artifact.filename}"'},
         )
 
     @app.get("/portal/expenses/{draft_id}/artifacts/{artifact_name}")
@@ -1719,9 +1705,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         return Response(
             content=artifact.content,
             media_type=artifact.media_type,
-            headers={
-                "Content-Disposition": f'attachment; filename="{artifact.filename}"'
-            },
+            headers={"Content-Disposition": f'attachment; filename="{artifact.filename}"'},
         )
 
     @app.get(
@@ -1825,9 +1809,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
         if stored.request.proposal_id != proposal_id:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail=(
-                    f"Execution '{execution_id}' does not belong to proposal '{proposal_id}'."
-                ),
+                detail=(f"Execution '{execution_id}' does not belong to proposal '{proposal_id}'."),
             )
         status_request = _submission_status_request(
             stored,

--- a/src/travel_plan_permission/templates/review_summary.html
+++ b/src/travel_plan_permission/templates/review_summary.html
@@ -53,6 +53,25 @@
     <aside class="stack">
       <section class="panel">
         <h2>Review status</h2>
+        {% if auth_context %}
+          <div class="callout" style="margin-top: 16px;">
+            <h3>Authenticated caller</h3>
+            <dl>
+              <div>
+                <dt>Subject</dt>
+                <dd>{{ auth_context.subject }}</dd>
+              </div>
+              <div>
+                <dt>Provider</dt>
+                <dd>{{ auth_context.provider }}</dd>
+              </div>
+              <div>
+                <dt>Permissions</dt>
+                <dd>{{ auth_permissions | map(attribute='value') | join(', ') }}</dd>
+              </div>
+            </dl>
+          </div>
+        {% endif %}
         {% if review.missing_fields %}
           <p style="margin-top: 10px;"><span class="badge warn">Missing required inputs</span></p>
           <ul>
@@ -178,9 +197,13 @@
               Submission reuses the existing proposal submission seam and records the resulting
               execution contract alongside the draft.
             </p>
-            <form method="post" action="/portal/review/{{ review.draft_id }}/submit" style="margin-top: 14px;">
-              <button class="primary" type="submit">Submit request</button>
-            </form>
+            {% if can_submit %}
+              <form method="post" action="/portal/review/{{ review.draft_id }}/submit" style="margin-top: 14px;">
+                <button class="primary" type="submit">Submit request</button>
+              </form>
+            {% else %}
+              <p style="margin-top: 14px;">Review-only access can inspect this draft but cannot submit it.</p>
+            {% endif %}
           </div>
         </section>
       {% endif %}

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -81,6 +81,21 @@ def _portal_form_payload() -> dict[str, str]:
     }
 
 
+def _bootstrap_auth_header(
+    *,
+    permissions: tuple[Permission, ...],
+    subject: str = "portal-reviewer",
+) -> dict[str, str]:
+    token = mint_bootstrap_token(
+        subject=subject,
+        permissions=permissions,
+        provider="google",
+        secret="bootstrap-secret-123",
+        expires_in_seconds=600,
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
 def _expense_form_payload() -> dict[str, str]:
     return {
         "approved_request_id": "REQ-410",
@@ -362,7 +377,10 @@ def test_expense_portal_review_surfaces_missing_receipt_warning() -> None:
     )
 
     assert response.status_code == 200
-    assert "Receipt missing: reviewers should hold reimbursement until the traveler uploads support." in response.text
+    assert (
+        "Receipt missing: reviewers should hold reimbursement until the traveler uploads support."
+        in response.text
+    )
     assert "Download CSV" in response.text
     assert store.expense_drafts_by_id
 
@@ -381,7 +399,10 @@ def test_expense_portal_generates_exports_and_policy_warning() -> None:
     )
 
     assert response.status_code == 200
-    assert "Policy warning: manager or accounting review is required before reimbursement." in response.text
+    assert (
+        "Policy warning: manager or accounting review is required before reimbursement."
+        in response.text
+    )
     assert "Manual receipt entry overrides OCR values for total." in response.text
 
     match = re.search(r"/portal/expenses/([^/]+)/artifacts/expense-csv", response.text)
@@ -417,9 +438,7 @@ def test_expense_portal_missing_approval_rules_returns_validation_error(
     payload = _expense_form_payload()
 
     monkeypatch.setattr("travel_plan_permission.approval._default_rules_path", lambda: None)
-    monkeypatch.setattr(
-        "travel_plan_permission.approval._package_rules_resource", lambda: None
-    )
+    monkeypatch.setattr("travel_plan_permission.approval._package_rules_resource", lambda: None)
 
     response = client.post("/portal/expenses/review", data=payload)
 
@@ -482,9 +501,7 @@ def test_portal_draft_validation_returns_bad_request_without_saving() -> None:
 
     assert response.status_code == 400
     assert 'data-template="validation-feedback"' in response.text
-    assert (
-        "Complete the missing details before this draft can be saved." in response.text
-    )
+    assert "Complete the missing details before this draft can be saved." in response.text
     assert store.portal_drafts_by_id == {}
     assert re.search(
         r'<ul class="missing-fields">.*?<li><code>destination_zip</code></li>',
@@ -494,9 +511,7 @@ def test_portal_draft_validation_returns_bad_request_without_saving() -> None:
     assert "Where are you headed and what" in response.text
 
 
-def test_portal_draft_validation_rejects_invalid_present_payload_without_saving() -> (
-    None
-):
+def test_portal_draft_validation_rejects_invalid_present_payload_without_saving() -> None:
     store = PlannerProposalStore()
     client = TestClient(create_app(store))
     payload = _portal_form_payload()
@@ -540,6 +555,7 @@ def test_portal_review_allows_optional_fields_to_remain_blank(monkeypatch) -> No
     response = client.post(
         "/portal/draft",
         data=payload,
+        headers=AUTH_HEADER,
         follow_redirects=True,
     )
 
@@ -556,6 +572,7 @@ def test_portal_review_persists_policy_readiness_answers(monkeypatch) -> None:
     response = client.post(
         "/portal/draft",
         data=_portal_form_payload(),
+        headers=AUTH_HEADER,
         follow_redirects=True,
     )
 
@@ -570,12 +587,17 @@ def test_portal_review_persists_policy_readiness_answers(monkeypatch) -> None:
 
 
 def test_portal_generates_review_artifacts_and_submission(monkeypatch) -> None:
-    _set_runtime_env(monkeypatch)
+    _set_bootstrap_runtime_env(monkeypatch)
     client = TestClient(create_app(PlannerProposalStore()))
+    auth_header = _bootstrap_auth_header(
+        permissions=(Permission.VIEW, Permission.CREATE),
+        subject="portal-owner",
+    )
 
     response = client.post(
         "/portal/draft",
         data=_portal_form_payload(),
+        headers=auth_header,
         follow_redirects=True,
     )
 
@@ -583,16 +605,20 @@ def test_portal_generates_review_artifacts_and_submission(monkeypatch) -> None:
     assert 'data-template="review-summary"' in response.text
     assert "Policy-lite posture" in response.text
     assert "Generated artifacts" in response.text
+    assert "portal-owner" in response.text
+    assert "google" in response.text
+    assert "view" in response.text
+    assert "create" in response.text
 
     match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
     assert match is not None
     draft_id = match.group(1)
 
-    itinerary = client.get(f"/portal/review/{draft_id}/artifacts/itinerary")
-    summary = client.get(f"/portal/review/{draft_id}/artifacts/summary")
+    itinerary = client.get(f"/portal/review/{draft_id}/artifacts/itinerary", headers=auth_header)
+    summary = client.get(f"/portal/review/{draft_id}/artifacts/summary", headers=auth_header)
     submit = client.post(
         f"/portal/review/{draft_id}/submit",
-        headers=AUTH_HEADER,
+        headers=auth_header,
         follow_redirects=True,
     )
 
@@ -622,6 +648,69 @@ def test_portal_draft_submission_redirects_without_authorization_header(
     assert "/portal/review/" in location
 
 
+def test_portal_review_detail_requires_bearer_token(monkeypatch) -> None:
+    _set_runtime_env(monkeypatch)
+    client = TestClient(create_app(PlannerProposalStore()))
+
+    response = client.post(
+        "/portal/draft",
+        data=_portal_form_payload(),
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    detail = client.get(response.headers["location"])
+
+    assert detail.status_code == 401
+    assert detail.json()["detail"] == "Missing bearer token."
+
+
+def test_portal_view_only_review_hides_submit_and_shows_auth_posture(
+    monkeypatch,
+) -> None:
+    _set_bootstrap_runtime_env(monkeypatch)
+    client = TestClient(create_app(PlannerProposalStore()))
+    auth_header = _bootstrap_auth_header(
+        permissions=(Permission.VIEW,),
+        subject="review-only-user",
+    )
+
+    response = client.post(
+        "/portal/draft",
+        data=_portal_form_payload(),
+        headers=auth_header,
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert "review-only-user" in response.text
+    assert "google" in response.text
+    assert "view" in response.text
+    assert "Submit request" not in response.text
+    assert "Review-only access can inspect this draft but cannot submit it." in response.text
+
+
+def test_portal_artifacts_require_view_permission(monkeypatch) -> None:
+    _set_bootstrap_runtime_env(monkeypatch)
+    client = TestClient(create_app(PlannerProposalStore()))
+    auth_header = _bootstrap_auth_header(permissions=(Permission.VIEW,))
+
+    response = client.post(
+        "/portal/draft",
+        data=_portal_form_payload(),
+        headers=auth_header,
+        follow_redirects=True,
+    )
+    match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
+    assert match is not None
+    draft_id = match.group(1)
+
+    itinerary = client.get(f"/portal/review/{draft_id}/artifacts/itinerary")
+
+    assert itinerary.status_code == 401
+    assert itinerary.json()["detail"] == "Missing bearer token."
+
+
 def test_submission_creates_manager_review_queue_entry(monkeypatch) -> None:
     _set_runtime_env(monkeypatch)
     store = PlannerProposalStore()
@@ -630,11 +719,10 @@ def test_submission_creates_manager_review_queue_entry(monkeypatch) -> None:
     response = client.post(
         "/portal/draft",
         data=_portal_form_payload(),
+        headers=AUTH_HEADER,
         follow_redirects=True,
     )
-    draft_match = re.search(
-        r"/portal/review/([^/]+)/artifacts/itinerary", response.text
-    )
+    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
     assert draft_match is not None
     draft_id = draft_match.group(1)
 
@@ -666,15 +754,15 @@ def test_manager_review_decision_updates_status_and_history(monkeypatch) -> None
     _set_bootstrap_runtime_env(monkeypatch)
     store = PlannerProposalStore()
     client = TestClient(create_app(store))
+    viewer_header = _bootstrap_auth_header(permissions=(Permission.VIEW,))
 
     response = client.post(
         "/portal/draft",
         data=_portal_form_payload(),
+        headers=viewer_header,
         follow_redirects=True,
     )
-    draft_match = re.search(
-        r"/portal/review/([^/]+)/artifacts/itinerary", response.text
-    )
+    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
     assert draft_match is not None
     draft_id = draft_match.group(1)
 
@@ -731,11 +819,10 @@ def test_manager_review_routes_require_authorization(monkeypatch) -> None:
     response = client.post(
         "/portal/draft",
         data=_portal_form_payload(),
+        headers=AUTH_HEADER,
         follow_redirects=True,
     )
-    draft_match = re.search(
-        r"/portal/review/([^/]+)/artifacts/itinerary", response.text
-    )
+    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
     assert draft_match is not None
     draft_id = draft_match.group(1)
     client.post(
@@ -766,15 +853,15 @@ def test_manager_review_decision_requires_approve_permission(monkeypatch) -> Non
     _set_bootstrap_runtime_env(monkeypatch)
     store = PlannerProposalStore()
     client = TestClient(create_app(store))
+    viewer_header = _bootstrap_auth_header(permissions=(Permission.VIEW,))
 
     response = client.post(
         "/portal/draft",
         data=_portal_form_payload(),
+        headers=viewer_header,
         follow_redirects=True,
     )
-    draft_match = re.search(
-        r"/portal/review/([^/]+)/artifacts/itinerary", response.text
-    )
+    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
     assert draft_match is not None
     draft_id = draft_match.group(1)
     client.post(
@@ -825,11 +912,10 @@ def test_manager_review_detail_hides_decision_form_for_read_only_role(
     response = client.post(
         "/portal/draft",
         data=_portal_form_payload(),
+        headers=AUTH_HEADER,
         follow_redirects=True,
     )
-    draft_match = re.search(
-        r"/portal/review/([^/]+)/artifacts/itinerary", response.text
-    )
+    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
     assert draft_match is not None
     draft_id = draft_match.group(1)
     client.post(
@@ -860,11 +946,10 @@ def test_portal_admin_console_surfaces_permissions_runtime_and_audit_history(
     review_response = client.post(
         "/portal/draft",
         data=_portal_form_payload(),
+        headers=AUTH_HEADER,
         follow_redirects=True,
     )
-    draft_match = re.search(
-        r"/portal/review/([^/]+)/artifacts/itinerary", review_response.text
-    )
+    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", review_response.text)
     assert draft_match is not None
     draft_id = draft_match.group(1)
     client.post(
@@ -884,7 +969,7 @@ def test_portal_admin_console_surfaces_permissions_runtime_and_audit_history(
     )
     review = store.lookup_manager_review_for_draft(draft_id)
     assert review is not None
-    client.get(f"/portal/review/{draft_id}/artifacts/summary")
+    client.get(f"/portal/review/{draft_id}/artifacts/summary", headers=AUTH_HEADER)
 
     console = client.get(
         "/portal/admin?actor_role=finance_admin",
@@ -911,11 +996,10 @@ def test_manager_review_detail_uses_authenticated_permissions_for_actions(
     response = client.post(
         "/portal/draft",
         data=_portal_form_payload(),
+        headers=_bootstrap_auth_header(permissions=(Permission.VIEW,)),
         follow_redirects=True,
     )
-    draft_match = re.search(
-        r"/portal/review/([^/]+)/artifacts/itinerary", response.text
-    )
+    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
     assert draft_match is not None
     draft_id = draft_match.group(1)
     client.post(
@@ -962,11 +1046,10 @@ def test_exception_decision_updates_review_detail_and_audit_log(monkeypatch) -> 
     review_response = client.post(
         "/portal/draft",
         data=_portal_form_payload(),
+        headers=_bootstrap_auth_header(permissions=(Permission.VIEW,)),
         follow_redirects=True,
     )
-    draft_match = re.search(
-        r"/portal/review/([^/]+)/artifacts/itinerary", review_response.text
-    )
+    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", review_response.text)
     assert draft_match is not None
     draft_id = draft_match.group(1)
     client.post(
@@ -1025,15 +1108,15 @@ def test_exception_rejection_keeps_notes_in_audit_log(monkeypatch) -> None:
     _set_bootstrap_runtime_env(monkeypatch)
     store = PlannerProposalStore()
     client = TestClient(create_app(store))
+    viewer_header = _bootstrap_auth_header(permissions=(Permission.VIEW,))
 
     review_response = client.post(
         "/portal/draft",
         data=_portal_form_payload(),
+        headers=viewer_header,
         follow_redirects=True,
     )
-    draft_match = re.search(
-        r"/portal/review/([^/]+)/artifacts/itinerary", review_response.text
-    )
+    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", review_response.text)
     assert draft_match is not None
     draft_id = draft_match.group(1)
     client.post(
@@ -1081,18 +1164,15 @@ def test_portal_submit_exception_request_returns_400_for_invalid_payload(
     monkeypatch,
 ) -> None:
     _set_runtime_env(monkeypatch)
-    client = TestClient(
-        create_app(PlannerProposalStore()), raise_server_exceptions=False
-    )
+    client = TestClient(create_app(PlannerProposalStore()), raise_server_exceptions=False)
 
     review_response = client.post(
         "/portal/draft",
         data=_portal_form_payload(),
+        headers=AUTH_HEADER,
         follow_redirects=True,
     )
-    draft_match = re.search(
-        r"/portal/review/([^/]+)/artifacts/itinerary", review_response.text
-    )
+    draft_match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", review_response.text)
     assert draft_match is not None
     draft_id = draft_match.group(1)
 
@@ -1189,6 +1269,7 @@ def test_portal_artifact_downloads_use_cached_review_artifacts(monkeypatch) -> N
     response = client.post(
         "/portal/draft",
         data=_portal_form_payload(),
+        headers=AUTH_HEADER,
         follow_redirects=True,
     )
 
@@ -1203,8 +1284,14 @@ def test_portal_artifact_downloads_use_cached_review_artifacts(monkeypatch) -> N
     monkeypatch.setattr(portal_review, "render_travel_spreadsheet_bytes", fail_render)
     monkeypatch.setattr(portal_review, "build_output_bundle", fail_render)
 
-    itinerary = client.get(f"/portal/review/{draft_id}/artifacts/itinerary")
-    summary = client.get(f"/portal/review/{draft_id}/artifacts/summary")
+    itinerary = client.get(
+        f"/portal/review/{draft_id}/artifacts/itinerary",
+        headers=AUTH_HEADER,
+    )
+    summary = client.get(
+        f"/portal/review/{draft_id}/artifacts/summary",
+        headers=AUTH_HEADER,
+    )
 
     assert itinerary.status_code == 200
     assert itinerary.content.startswith(b"PK")
@@ -1219,6 +1306,7 @@ def test_portal_submit_requires_bearer_token(monkeypatch) -> None:
     response = client.post(
         "/portal/draft",
         data=_portal_form_payload(),
+        headers=AUTH_HEADER,
         follow_redirects=True,
     )
     match = re.search(r"/portal/review/([^/]+)/artifacts/itinerary", response.text)
@@ -1251,9 +1339,7 @@ def test_portal_artifacts_raise_runtime_error_without_bundle_mappings(
     monkeypatch,
 ) -> None:
     _set_runtime_env(monkeypatch)
-    client = TestClient(
-        create_app(PlannerProposalStore()), raise_server_exceptions=False
-    )
+    client = TestClient(create_app(PlannerProposalStore()), raise_server_exceptions=False)
 
     def invalid_bundle(**_kwargs):
         return {"itinerary_excel": "bad", "summary_pdf": "bad"}
@@ -1263,6 +1349,7 @@ def test_portal_artifacts_raise_runtime_error_without_bundle_mappings(
     response = client.post(
         "/portal/draft",
         data=_portal_form_payload(),
+        headers=AUTH_HEADER,
     )
 
     assert response.status_code == 500


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
- the workflow portal review surface currently treats every viewer as if they can submit requests
- generated review artifacts are exposed without confirming the caller has planner view access

#### Tasks
- [ ] require planner `view` permission before rendering saved portal draft review details and artifact downloads
- [ ] surface authenticated caller provider and permission posture inside the portal review UI
- [ ] keep submit affordances visible only for callers that also hold planner `create` permission

#### Acceptance criteria
- [ ] `/portal/requests/{draft_id}` and portal artifact downloads reject missing bearer tokens
- [ ] authenticated review pages show the caller subject plus provider/permission posture for reviewer-facing flows
- [ ] review-only callers can inspect the draft without seeing a submit action, while create-capable callers can still submit successfully

<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why
- the workflow portal review surface currently treats every viewer as if they can submit requests
- generated review artifacts are exposed without confirming the caller has planner view access

## Tasks
- require planner `view` permission before rendering saved portal draft review details and artifact downloads
- surface authenticated caller provider and permission posture inside the portal review UI
- keep submit affordances visible only for callers that also hold planner `create` permission

## Acceptance Criteria
- `/portal/requests/{draft_id}` and portal artifact downloads reject missing bearer tokens
- authenticated review pages show the caller subject plus provider/permission posture for reviewer-facing flows
- review-only callers can inspect the draft without seeing a submit action, while create-capable callers can still submit successfully



</details>

—
PR created automatically to engage Codex.

<!-- pr-preamble:start -->
> **Source:** Issue #821

<!-- pr-preamble:end -->