### PR TITLE
Standardize Python runtime on 3.12

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -9,7 +9,7 @@ For comprehensive documentation, see [docs/ci-system-guide.md](../../docs/ci-sys
 
 | File | Purpose | Description |
 |------|---------|-------------|
-| `ci.yml` | Main CI pipeline | Python testing (3.11, 3.12), linting with ruff, type checking with mypy |
+| `ci.yml` | Main CI pipeline | Python testing (3.12, 3.13), linting with ruff, type checking with mypy |
 | `lint.yml` | Additional linting | actionlint, JSON schema validation, docs link checking |
 | `agents-*.yml` | Agent automation | Issue intake and automation workflows |
 | `maint-*.yml` | Maintenance | Dependency refresh and other maintenance tasks |
@@ -28,7 +28,7 @@ The following workflows have been archived to `.github/workflows-archive/`:
 
 | Job | Description |
 |-----|-------------|
-| `test` | Matrix job running pytest on Python 3.11 and 3.12 with coverage |
+| `test` | Matrix job running pytest on Python 3.12 and 3.13 with coverage |
 | `lint` | Runs ruff to check code style |
 
 ### lint.yml

--- a/.github/workflows/agents-auto-label.yml
+++ b/.github/workflows/agents-auto-label.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -225,7 +225,7 @@ jobs:
         if: steps.check_enabled.outputs.enabled == 'true'
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Cache pip (LLM requirements)
         if: steps.check_enabled.outputs.enabled == 'true'

--- a/.github/workflows/agents-capability-check.yml
+++ b/.github/workflows/agents-capability-check.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/agents-decompose.yml
+++ b/.github/workflows/agents-decompose.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/agents-dedup.yml
+++ b/.github/workflows/agents-dedup.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/agents-issue-optimizer.yml
+++ b/.github/workflows/agents-issue-optimizer.yml
@@ -141,7 +141,7 @@ jobs:
         if: steps.check.outputs.should_run == 'true'
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install dependencies
         if: steps.check.outputs.should_run == 'true'

--- a/.github/workflows/agents-keepalive-loop.yml
+++ b/.github/workflows/agents-keepalive-loop.yml
@@ -629,7 +629,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install dependencies
         run: pip install pydantic langchain-openai langchain-anthropic

--- a/.github/workflows/agents-weekly-metrics.yml
+++ b/.github/workflows/agents-weekly-metrics.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Download metrics artifacts
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@
 # - Lint (Ruff)
 # - Format check (Black)
 # - Type checking (mypy)
-# - Tests (pytest) on Python 3.11 and 3.12
+# - Tests (pytest) on Python 3.12 and 3.13
 #
 # NOTE: Do NOT add a top-level 'permissions:' block here. It causes
 # startup_failure when calling reusable workflows. The reusable workflow
@@ -29,7 +29,7 @@ jobs:
     env:
       BLACK_VERSION: '26.1.0'
     with:
-      python-versions: '["3.11", "3.12"]'
+      python-versions: '["3.12", "3.13"]'
       typecheck: true
       coverage: true
       coverage-min: '80'

--- a/.github/workflows/maint-51-dependency-refresh.yml
+++ b/.github/workflows/maint-51-dependency-refresh.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install uv
         run: pip install uv

--- a/.github/workflows/maint-coverage-guard.yml
+++ b/.github/workflows/maint-coverage-guard.yml
@@ -227,7 +227,8 @@ jobs:
 
           # Check for coverage json
           for candidate in \
-            "coverage_artifacts/payload/artifacts/coverage/runtimes/3.11/coverage.json" \
+            "coverage_artifacts/payload/artifacts/coverage/runtimes/3.12/coverage.json" \
+            "coverage_artifacts/payload/artifacts/coverage/runtimes/3.13/coverage.json" \
             "coverage_artifacts/payload/coverage.json" \
             "coverage_artifacts/coverage.json"; do
             if [ -f "$candidate" ]; then

--- a/.github/workflows/maint-dependabot-auto-lock.yml
+++ b/.github/workflows/maint-dependabot-auto-lock.yml
@@ -26,9 +26,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       
       - name: Install uv
         run: pip install uv

--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -42,7 +42,7 @@ jobs:
     name: Python CI
     uses: stranske/Workflows/.github/workflows/reusable-10-ci-python.yml@main
     with:
-      python-versions: '["3.11", "3.12"]'
+      python-versions: '["3.12", "3.13"]'
       coverage-min: "80"
       format_check: false  # Using ruff for formatting
       working-directory: "."
@@ -61,7 +61,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: "pip"
 
       - name: Install dependencies with orchestration extra

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Automate and make reproducible the travel plan approval and reimbursement process"
 readme = "README.md"
 license = { text = "MIT" }
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 authors = [{ name = "stranske" }]
 keywords = ["travel", "expense", "workflow", "automation"]
 classifiers = [
@@ -12,8 +12,8 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 
 dependencies = [
@@ -108,7 +108,7 @@ fail_under = 80
 show_missing = true
 
 [tool.ruff]
-target-version = "py311"
+target-version = "py312"
 line-length = 100
 src = ["src", "tests"]
 
@@ -132,7 +132,7 @@ ignore = [
 known-first-party = ["travel_plan_permission"]
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.12"
 strict = true
 warn_return_any = true
 warn_unused_ignores = true

--- a/scripts/check_test_dependencies.sh
+++ b/scripts/check_test_dependencies.sh
@@ -22,10 +22,10 @@ python_version=$(python --version 2>&1 | awk '{print $2}')
 python_major=$(echo "$python_version" | cut -d. -f1)
 python_minor=$(echo "$python_version" | cut -d. -f2)
 
-if [[ "$python_major" -ge 3 ]] && [[ "$python_minor" -ge 11 ]]; then
-    echo -e "${GREEN}✓${NC} Python $python_version (>=3.11 required)"
+if [[ "$python_major" -gt 3 ]] || { [[ "$python_major" -eq 3 ]] && [[ "$python_minor" -ge 12 ]]; }; then
+    echo -e "${GREEN}✓${NC} Python $python_version (>=3.12 required)"
 else
-    echo -e "${RED}✗${NC} Python $python_version (>=3.11 required)"
+    echo -e "${RED}✗${NC} Python $python_version (>=3.12 required)"
     all_ok=false
 fi
 echo ""

--- a/scripts/langchain/injection_guard.py
+++ b/scripts/langchain/injection_guard.py
@@ -41,9 +41,9 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import Final, Literal, TypeAlias, TypedDict, cast
+from typing import Final, Literal, TypedDict, cast
 
-ReasonCode: TypeAlias = Literal[
+type ReasonCode = Literal[
     "INSTRUCTION_OVERRIDE",
     "SYSTEM_PROMPT_EXFILTRATION",
     "ROLE_CONFUSION",
@@ -51,7 +51,7 @@ ReasonCode: TypeAlias = Literal[
     "TOOL_INJECTION",
 ]
 
-GuardResult: TypeAlias = tuple[bool, str]
+type GuardResult = tuple[bool, str]
 
 
 class GuardCheckResultAllowed(TypedDict):
@@ -70,7 +70,7 @@ class GuardCheckResultBlocked(TypedDict):
     code: ReasonCode | Literal["GUARD_ERROR"] | None
 
 
-GuardCheckResult: TypeAlias = GuardCheckResultAllowed | GuardCheckResultBlocked
+type GuardCheckResult = GuardCheckResultAllowed | GuardCheckResultBlocked
 
 
 @dataclass(frozen=True)

--- a/scripts/langchain/structured_output.py
+++ b/scripts/langchain/structured_output.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Generic, TypeVar
+from typing import Any, TypeVar
 
 from pydantic import BaseModel, ValidationError
 
@@ -31,7 +31,7 @@ MAX_REPAIR_ATTEMPTS = 1
 
 
 @dataclass(frozen=True)
-class StructuredOutputResult(Generic[T]):
+class StructuredOutputResult[T: BaseModel]:
     payload: T | None
     raw_content: str | None
     error_stage: str | None
@@ -95,7 +95,7 @@ def clamp_repair_attempts(max_repair_attempts: int) -> int:
     )
 
 
-def _invoke_repair_loop(
+def _invoke_repair_loop[T: BaseModel](
     *,
     repair: Callable[[str, str, str], str | None] | None,
     attempts: int,
@@ -154,7 +154,7 @@ def _invoke_repair_loop(
     )
 
 
-def invoke_repair_loop(
+def invoke_repair_loop[T: BaseModel](
     *,
     repair: Callable[[str, str, str], str | None] | None,
     attempts: int,
@@ -171,7 +171,7 @@ def invoke_repair_loop(
     )
 
 
-def parse_structured_output(
+def parse_structured_output[T: BaseModel](
     content: str,
     model: type[T],
     *,

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,11 +12,12 @@ classifiers =
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
+
 
 [options]
-python_requires = >=3.11
+python_requires = >=3.12
 install_requires =
     pydantic>=2.0
     pyyaml>=6.0.2

--- a/tools/coverage_guard.py
+++ b/tools/coverage_guard.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Coverage guard script for maintaining baseline breach issues.
+
+This script compares current coverage against a baseline and creates/updates
+a tracking issue when coverage falls below the threshold.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    """Load JSON from a file, returning empty dict on error."""
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+
+def _get_hotspots(coverage_data: dict[str, Any], limit: int = 15) -> list[dict[str, Any]]:
+    """Extract files with lowest coverage from coverage.json."""
+    files = coverage_data.get("files", {})
+    hotspots = []
+
+    for filepath, data in files.items():
+        summary = data.get("summary", {})
+        percent = summary.get("percent_covered", 0.0)
+        missing = summary.get("missing_lines", 0)
+        hotspots.append(
+            {
+                "file": filepath,
+                "coverage": percent,
+                "missing_lines": missing,
+            }
+        )
+
+    # Sort by coverage ascending (lowest first)
+    hotspots.sort(key=lambda x: x["coverage"])
+    return hotspots[:limit]
+
+
+def _format_issue_body(
+    current: float,
+    baseline: float,
+    delta: float,
+    hotspots: list[dict[str, Any]],
+    run_url: str,
+) -> str:
+    """Format the issue body with coverage summary and hotspots."""
+    status_emoji = "✅" if current >= baseline else "❌"
+
+    body = f"""## Coverage Baseline Breach Report
+
+{status_emoji} **Current Coverage: {current:.2f}%** (baseline: {baseline:.2f}%, delta: {delta:+.2f}%)
+
+### Summary
+
+| Metric | Value |
+|--------|-------|
+| Current | {current:.2f}% |
+| Baseline | {baseline:.2f}% |
+| Delta | {delta:+.2f}% |
+| Status | {"Pass ✅" if current >= baseline else "Below baseline ❌"} |
+
+### Low Coverage Hotspots
+
+These files have the lowest coverage and are candidates for additional tests:
+
+| File | Coverage | Missing Lines |
+|------|----------|---------------|
+"""
+
+    for spot in hotspots:
+        body += f"| `{spot['file']}` | {spot['coverage']:.1f}% | {spot['missing_lines']} |\n"
+
+    if not hotspots:
+        body += "| _(no files with low coverage)_ | - | - |\n"
+
+    body += f"""
+
+### Actions
+
+- [ ] Review hotspot files and add tests for uncovered code
+- [ ] Update baseline once coverage improves
+
+### Source
+
+[Gate Workflow Run]({run_url})
+
+---
+_This issue is automatically updated by the coverage guard workflow._
+"""
+    return body
+
+
+def _find_or_create_issue(repo: str, title: str, body: str, labels: list[str]) -> None:
+    """Find existing issue or create a new one using gh CLI."""
+    import subprocess
+
+    # Search for existing issue
+    search_result = subprocess.run(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--search",
+            f'"{title}" in:title',
+            "--json",
+            "number,title",
+            "--limit",
+            "1",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    existing_issues = json.loads(search_result.stdout) if search_result.stdout.strip() else []
+
+    if existing_issues:
+        # Update existing issue
+        issue_number = existing_issues[0]["number"]
+        subprocess.run(
+            ["gh", "issue", "edit", str(issue_number), "--repo", repo, "--body", body],
+            check=True,
+        )
+        print(f"Updated issue #{issue_number}")
+    else:
+        # Create new issue
+        label_args = []
+        for label in labels:
+            label_args.extend(["--label", label])
+
+        subprocess.run(
+            [
+                "gh",
+                "issue",
+                "create",
+                "--repo",
+                repo,
+                "--title",
+                title,
+                "--body",
+                body,
+                *label_args,
+            ],
+            check=True,
+        )
+        print(f"Created new issue: {title}")
+
+
+def main(args: list[str] | None = None) -> int:
+    """Main entry point for coverage guard."""
+    parser = argparse.ArgumentParser(description="Coverage guard - maintain baseline breach issues")
+    parser.add_argument("--repo", required=True, help="Repository (owner/repo)")
+    parser.add_argument("--trend-path", type=Path, help="Path to coverage-trend.json")
+    parser.add_argument("--coverage-path", type=Path, help="Path to coverage.json")
+    parser.add_argument("--baseline-path", type=Path, help="Path to coverage-baseline.json")
+    parser.add_argument("--run-url", default="", help="URL to the workflow run")
+    parser.add_argument("--issue-title", default="[coverage] baseline breach", help="Issue title")
+    parser.add_argument("--dry-run", action="store_true", help="Print issue body without creating")
+    parsed = parser.parse_args(args)
+
+    # Load trend data
+    trend_data = {}
+    if parsed.trend_path and parsed.trend_path.exists():
+        trend_data = _load_json(parsed.trend_path)
+
+    # Load coverage data for hotspots
+    coverage_data = {}
+    if parsed.coverage_path and parsed.coverage_path.exists():
+        coverage_data = _load_json(parsed.coverage_path)
+
+    # Load baseline
+    baseline_data = {}
+    if parsed.baseline_path and parsed.baseline_path.exists():
+        baseline_data = _load_json(parsed.baseline_path)
+
+    # Extract values
+    current = trend_data.get("current", 0.0)
+    baseline = baseline_data.get("coverage", trend_data.get("baseline", 70.0))
+    delta = current - baseline
+
+    # Get hotspots
+    hotspots = _get_hotspots(coverage_data)
+
+    # Format issue body
+    body = _format_issue_body(current, baseline, delta, hotspots, parsed.run_url)
+
+    if parsed.dry_run:
+        print("=" * 60)
+        print(f"Issue Title: {parsed.issue_title}")
+        print("=" * 60)
+        print(body)
+        return 0
+
+    # Create or update issue
+    if current < baseline:
+        _find_or_create_issue(
+            repo=parsed.repo,
+            title=parsed.issue_title,
+            body=body,
+            labels=["coverage", "automated"],
+        )
+    else:
+        print(f"Coverage {current:.2f}% meets baseline {baseline:.2f}% - no issue needed")
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())

--- a/tools/resolve_mypy_pin.py
+++ b/tools/resolve_mypy_pin.py
@@ -74,7 +74,7 @@ def main() -> int:
         output_version = mypy_version
     else:
         # Default to the primary Python version (first in typical matrices)
-        output_version = matrix_version or "3.11"
+        output_version = matrix_version or "3.12"
 
     # Write to GITHUB_OUTPUT
     github_output = os.environ.get("GITHUB_OUTPUT")


### PR DESCRIPTION
## Summary
- standardize repo workflow/runtime references on Python 3.12
- move CI matrices from 3.11/3.12 to 3.12/3.13 where applicable
- update project/runtime metadata and dependency lock markers that encode the old 3.11 floor

## Verification
- YAML parsed successfully across audited workflow/action files for all patched repos
- pyproject metadata parsed successfully and now declares a 3.12 floor where present
- runtime audit has no remaining Python 3.11/py311 policy hits; residual 3.10/3.11 strings are package versions or wheel tags, not runtime targets

This pairs with stranske/Workflows#1777, which updated the Workflows source-of-truth and templates.