### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -5,7 +5,7 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.3.1
-RUFF_VERSION=0.15.10
+RUFF_VERSION=0.15.11
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.7
 MYPY_VERSION=1.20.1


### PR DESCRIPTION
## Sync Summary

### Files Updated
- autofix-versions.env: Autofix tool version pins - shared dev tool versions (synced)

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- dependabot.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Manifest:** `.github/sync-manifest.yml`