### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Workflow Source
+
+Started from:
+- [ ] GitHub issue: #
+- [ ] Direct PR / remote GitHub work
+- [ ] Local Codex/user request
+- [ ] Automation run
+- [ ] Review follow-up from PR #
+- [ ] Sync / maintenance campaign
+- [ ] Dependabot or dependency update
+- [ ] Do not automate
+
+Automation intent:
+- [ ] Verifier should review this
+- [ ] Keepalive may manage this PR
+- [ ] Human-only unless checks fail
+
+Notes:
+<!-- If there is no linked issue, briefly describe the source. Automation also accepts workflow source labels such as workflow:source-direct-pr. -->
+
+## Summary
+
+
+## Testing

--- a/.github/scripts/agents_pr_meta_keepalive.js
+++ b/.github/scripts/agents_pr_meta_keepalive.js
@@ -3,6 +3,10 @@
 const { createGithubApiCache } = require('./github-api-cache-client');
 const { makeTrace } = require('./keepalive_contract.js');
 const { ensureRateLimitWrapped } = require('./github-rate-limited-wrapper.js');
+const {
+  formatSourceContextForLog,
+  resolvePrSourceContext,
+} = require('./source_context.js');
 
 const DEFAULT_INSTRUCTION_SIGNATURE =
   'keepalive workflow continues nudging until everything is complete';
@@ -335,6 +339,8 @@ async function detectKeepalive({ core, github, context, env = process.env }) {
     instruction_bytes: '0',
     agent_alias: '',
     head_sha: '',
+    source_type: '',
+    source_ref: '',
   };
 
   const setBasicOutputs = () => {
@@ -359,6 +365,8 @@ async function detectKeepalive({ core, github, context, env = process.env }) {
     core.setOutput('instruction_bytes', outputs.instruction_bytes || '0');
     core.setOutput('agent_alias', outputs.agent_alias || '');
     core.setOutput('head_sha', outputs.head_sha || '');
+    core.setOutput('source_type', outputs.source_type || '');
+    core.setOutput('source_ref', outputs.source_ref || '');
   };
 
   const { comment, issue } = context.payload || {};
@@ -645,6 +653,13 @@ async function detectKeepalive({ core, github, context, env = process.env }) {
   if (issueNumber) {
     outputs.issue = String(issueNumber);
   }
+  const sourceContext = resolvePrSourceContext(pull);
+  if (sourceContext.isKnown) {
+    outputs.source_type = sourceContext.sourceType;
+  }
+  if (sourceContext.sourceRef) {
+    outputs.source_ref = sourceContext.sourceRef;
+  }
 
   let reactions = [];
   try {
@@ -741,9 +756,17 @@ async function detectKeepalive({ core, github, context, env = process.env }) {
   }
 
   if (!issueNumber) {
-    outputs.reason = 'missing-issue-reference';
-    core.info('Keepalive dispatch skipped: unable to determine linked issue number.');
-    return finalise();
+    if (sourceContext.isValid && !sourceContext.requiresIssue) {
+      core.info(
+        `Keepalive dispatch continuing with non-issue workflow source context (${formatSourceContextForLog(sourceContext)}).`,
+      );
+    } else {
+      outputs.reason = 'missing-source-context';
+      core.info(
+        'Keepalive dispatch skipped: unable to determine linked issue number or another valid workflow source context.',
+      );
+      return finalise();
+    }
   }
 
   // Add agents:activated label on first human activation per GoalsAndPlumbing.md Section 1

--- a/.github/scripts/agents_pr_meta_update_body.js
+++ b/.github/scripts/agents_pr_meta_update_body.js
@@ -15,6 +15,10 @@ const fs = require('fs');
 const os = require('os');
 const childProcess = require('child_process');
 const { ensureRateLimitWrapped } = require('./github-rate-limited-wrapper.js');
+const {
+  formatSourceContextForLog,
+  resolvePrSourceContext,
+} = require('./source_context.js');
 
 class RateLimitError extends Error {
   constructor(message, options = {}) {
@@ -930,6 +934,66 @@ function isCampaignIssue(issue = {}) {
   return labels.has('campaign:sync-dependabot') || labels.has('campaign:active');
 }
 
+function buildSourceContextRepairCommentBody(prNumber) {
+  return [
+    '<!-- missing-issue-warning -->',
+    '### Workflow source needed',
+    '',
+    `PR #${prNumber} does not need a GitHub issue, but Workflows needs one valid source context before PR metadata automation can manage it safely.`,
+    '',
+    'Please do one of:',
+    '',
+    '- Add `<!-- meta:issue:123 -->` or a normal `Closes #123` / `Related to #123` line.',
+    '- Check one `Workflow Source` option in the PR body.',
+    '- Add a hidden marker such as `<!-- workflow-source:local_request -->`, `<!-- workflow-source:manual_remote -->`, `<!-- workflow-source:review_followup -->`, `<!-- workflow-source:sync_campaign -->`, or `<!-- workflow-source:dependabot -->`.',
+    '- Add a workflow source label such as `workflow:source-direct-pr`, `workflow:source-local-request`, `workflow:source-review-followup`, `workflow:source-sync`, or `workflow:no-automation`.',
+    '',
+    'Once a valid source is present, this warning will not be reposted.',
+  ].join('\n');
+}
+
+function buildSourceContextResolvedCommentBody(prNumber, sourceContext) {
+  return [
+    '<!-- missing-issue-warning -->',
+    '### Workflow source detected',
+    '',
+    `PR #${prNumber} now has valid workflow source context (${formatSourceContextForLog(sourceContext)}).`,
+    '',
+    'No linked GitHub issue is required for this PR.',
+  ].join('\n');
+}
+
+async function resolveSourceContextRepairComment({
+  github,
+  owner,
+  repo,
+  prNumber,
+  comments,
+  sourceContext,
+  core,
+}) {
+  const marker = '<!-- missing-issue-warning -->';
+  const existingWarning = comments.find((c) => c.body && c.body.includes(marker));
+  if (!existingWarning) {
+    return false;
+  }
+
+  const resolvedBody = buildSourceContextResolvedCommentBody(prNumber, sourceContext);
+  if (existingWarning.body === resolvedBody) {
+    core?.info?.(`Workflow source repair comment already resolved (id: ${existingWarning.id})`);
+    return false;
+  }
+
+  await github.rest.issues.updateComment({
+    owner,
+    repo,
+    comment_id: existingWarning.id,
+    body: resolvedBody,
+  });
+  core?.info?.(`Resolved workflow source repair comment (id: ${existingWarning.id})`);
+  return true;
+}
+
 function buildPreamble(sections) {
   const lines = ['<!-- pr-preamble:start -->'];
   
@@ -1231,9 +1295,35 @@ async function run({github: rawGithub, context, core, inputs}) {
   }
 
   const issueNumber = extractIssueNumberFromPull(pr);
+  const sourceContext = resolvePrSourceContext(pr);
   if (!issueNumber) {
+    if (sourceContext.isValid && !sourceContext.requiresIssue) {
+      core.info(
+        `PR #${pr.number} has valid non-issue workflow source context (${formatSourceContextForLog(sourceContext)}); skipping issue-sourced body sync.`,
+      );
+      try {
+        const comments = await github.paginate(github.rest.issues.listComments, {
+          owner,
+          repo,
+          issue_number: pr.number,
+        });
+        await resolveSourceContextRepairComment({
+          github,
+          owner,
+          repo,
+          prNumber: pr.number,
+          comments,
+          sourceContext,
+          core,
+        });
+      } catch (error) {
+        core.warning(`Failed to resolve workflow source repair comment: ${error.message}`);
+      }
+      return;
+    }
+
     const marker = '<!-- missing-issue-warning -->';
-    const warningMsg = `Unable to determine source issue for PR #${pr.number}. The PR title, branch name, or body must contain the issue number (e.g. #123, branch: issue-123, or the hidden marker <!-- meta:issue:123 -->).`;
+    const warningMsg = `Unable to determine workflow source context for PR #${pr.number}. Add a GitHub issue reference or another valid Workflow Source entry.`;
     core.warning(warningMsg);
 
     try {
@@ -1244,11 +1334,20 @@ async function run({github: rawGithub, context, core, inputs}) {
       });
       // Find existing warning comment by marker to enable upsert pattern
       const existingWarning = comments.find((c) => c.body && c.body.includes(marker));
-      const commentBody = `${marker}\n⚠️ **Action Required**: ${warningMsg}`;
+      const commentBody = buildSourceContextRepairCommentBody(pr.number);
       
       if (existingWarning) {
-        // Update existing comment (avoids duplicates from race conditions)
-        core.info(`Warning comment already exists (id: ${existingWarning.id}), skipping duplicate`);
+        if (existingWarning.body !== commentBody) {
+          await github.rest.issues.updateComment({
+            owner,
+            repo,
+            comment_id: existingWarning.id,
+            body: commentBody,
+          });
+          core.info(`Updated workflow source repair comment (id: ${existingWarning.id})`);
+        } else {
+          core.info(`Workflow source repair comment already exists (id: ${existingWarning.id})`);
+        }
       } else {
         await github.rest.issues.createComment({
           owner,
@@ -1435,6 +1534,9 @@ module.exports = {
   filterWorkflowRunsForStatus,
   buildContextBlock,
   buildPreamble,
+  buildSourceContextRepairCommentBody,
+  buildSourceContextResolvedCommentBody,
+  resolveSourceContextRepairComment,
   isCampaignIssue,
   buildStatusBlock,
   withRetries,

--- a/.github/scripts/coverage_monitor_summary.js
+++ b/.github/scripts/coverage_monitor_summary.js
@@ -140,6 +140,11 @@ function buildCoverageMonitorSummary(options = {}) {
   const terminal = summarizeReport(readJsonReport(options.terminal_report, 'terminal-disposition'));
   const botAuth = summarizeReport(readJsonReport(options.bot_auth_report, 'bot-comment-auth'));
   const monitors = [terminal, botAuth];
+  if (cleanString(options.pr_source_context_report)) {
+    monitors.push(
+      summarizeReport(readJsonReport(options.pr_source_context_report, 'pr-source-context'))
+    );
+  }
   const status = overallStatus(monitors);
   const hardBlockActive = monitors.some((monitor) => monitor.hard_block_active);
   const shouldFail = monitors.some((monitor) => monitor.should_fail);
@@ -211,6 +216,8 @@ function parseArgs(argv = process.argv.slice(2)) {
       process.env.COVERAGE_MONITOR_TERMINAL_JSON || 'terminal-disposition-coverage.json',
     bot_auth_report:
       process.env.COVERAGE_MONITOR_BOT_AUTH_JSON || 'bot-comment-auth-coverage-summary.json',
+    pr_source_context_report:
+      process.env.COVERAGE_MONITOR_PR_SOURCE_CONTEXT_JSON || 'pr-source-context-coverage.json',
     output_json:
       process.env.COVERAGE_MONITOR_SUMMARY_JSON || 'coverage-monitor-summary.json',
     output_md:
@@ -225,6 +232,9 @@ function parseArgs(argv = process.argv.slice(2)) {
       index += 1;
     } else if (arg === '--bot-auth-report') {
       options.bot_auth_report = next;
+      index += 1;
+    } else if (arg === '--pr-source-context-report') {
+      options.pr_source_context_report = next;
       index += 1;
     } else if (arg === '--output-json') {
       options.output_json = next;

--- a/.github/scripts/source_context.js
+++ b/.github/scripts/source_context.js
@@ -1,0 +1,322 @@
+'use strict';
+
+const SOURCE_TYPES = Object.freeze({
+  GITHUB_ISSUE: 'github_issue',
+  LOCAL_REQUEST: 'local_request',
+  AUTOMATION_RUN: 'automation_run',
+  SYNC_CAMPAIGN: 'sync_campaign',
+  DEPENDABOT: 'dependabot',
+  REVIEW_FOLLOWUP: 'review_followup',
+  MANUAL_REMOTE: 'manual_remote',
+  UNKNOWN: 'unknown',
+});
+
+const VALID_SOURCE_TYPES = new Set(Object.values(SOURCE_TYPES).filter((type) => type !== SOURCE_TYPES.UNKNOWN));
+
+const SOURCE_LABELS = Object.freeze({
+  'workflow:source-issue': SOURCE_TYPES.GITHUB_ISSUE,
+  workflow_source_issue: SOURCE_TYPES.GITHUB_ISSUE,
+  'workflow:source-local-request': SOURCE_TYPES.LOCAL_REQUEST,
+  workflow_source_local_request: SOURCE_TYPES.LOCAL_REQUEST,
+  'workflow:source-automation': SOURCE_TYPES.AUTOMATION_RUN,
+  workflow_source_automation: SOURCE_TYPES.AUTOMATION_RUN,
+  'workflow:source-sync': SOURCE_TYPES.SYNC_CAMPAIGN,
+  workflow_source_sync: SOURCE_TYPES.SYNC_CAMPAIGN,
+  'workflow:source-maintenance': SOURCE_TYPES.SYNC_CAMPAIGN,
+  workflow_source_maintenance: SOURCE_TYPES.SYNC_CAMPAIGN,
+  'workflow:source-dependabot': SOURCE_TYPES.DEPENDABOT,
+  workflow_source_dependabot: SOURCE_TYPES.DEPENDABOT,
+  'workflow:source-review-followup': SOURCE_TYPES.REVIEW_FOLLOWUP,
+  workflow_source_review_followup: SOURCE_TYPES.REVIEW_FOLLOWUP,
+  'workflow:source-direct-pr': SOURCE_TYPES.MANUAL_REMOTE,
+  workflow_source_direct_pr: SOURCE_TYPES.MANUAL_REMOTE,
+  'workflow:no-automation': SOURCE_TYPES.MANUAL_REMOTE,
+  workflow_no_automation: SOURCE_TYPES.MANUAL_REMOTE,
+});
+
+const CHECKBOX_SOURCE_PATTERNS = Object.freeze([
+  [SOURCE_TYPES.GITHUB_ISSUE, /\bgithub\s+issue\b|\bsource\s+issue\b/i],
+  [
+    SOURCE_TYPES.MANUAL_REMOTE,
+    /\bdirect\s+pr\b|\bremote\s+github\s+work\b|\bstarted\s+directly\b|\bdo\s+not\s+automate\b|\bhuman[- ]only\b/i,
+  ],
+  [SOURCE_TYPES.LOCAL_REQUEST, /\blocal\s+(?:codex|user)\s+request\b|\blocal\s+request\b/i],
+  [SOURCE_TYPES.AUTOMATION_RUN, /\bautomation\s+run\b|\bworkflow\s+run\b/i],
+  [SOURCE_TYPES.REVIEW_FOLLOWUP, /\breview\s+follow[- ]?up\b|\bfollow[- ]?up\s+from\s+pr\b/i],
+  [SOURCE_TYPES.SYNC_CAMPAIGN, /\bsync\b|\bmaintenance\s+campaign\b|\bmaintenance\b/i],
+  [SOURCE_TYPES.DEPENDABOT, /\bdependabot\b|\bdependency\s+update\b/i],
+]);
+
+function cleanString(value) {
+  return String(value || '').trim();
+}
+
+function normalizeToken(value) {
+  return cleanString(value)
+    .toLowerCase()
+    .replace(/[`*~]/g, '')
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
+function normalizeSourceType(value) {
+  const token = normalizeToken(value);
+  if (!token) {
+    return SOURCE_TYPES.UNKNOWN;
+  }
+
+  const aliases = new Map([
+    ['issue', SOURCE_TYPES.GITHUB_ISSUE],
+    ['github_issue', SOURCE_TYPES.GITHUB_ISSUE],
+    ['source_issue', SOURCE_TYPES.GITHUB_ISSUE],
+    ['local', SOURCE_TYPES.LOCAL_REQUEST],
+    ['local_request', SOURCE_TYPES.LOCAL_REQUEST],
+    ['local_codex_request', SOURCE_TYPES.LOCAL_REQUEST],
+    ['local_user_request', SOURCE_TYPES.LOCAL_REQUEST],
+    ['automation', SOURCE_TYPES.AUTOMATION_RUN],
+    ['automation_run', SOURCE_TYPES.AUTOMATION_RUN],
+    ['workflow_run', SOURCE_TYPES.AUTOMATION_RUN],
+    ['sync', SOURCE_TYPES.SYNC_CAMPAIGN],
+    ['sync_campaign', SOURCE_TYPES.SYNC_CAMPAIGN],
+    ['maintenance', SOURCE_TYPES.SYNC_CAMPAIGN],
+    ['maintenance_sync', SOURCE_TYPES.SYNC_CAMPAIGN],
+    ['dependabot', SOURCE_TYPES.DEPENDABOT],
+    ['dependency_update', SOURCE_TYPES.DEPENDABOT],
+    ['review_followup', SOURCE_TYPES.REVIEW_FOLLOWUP],
+    ['review_follow_up', SOURCE_TYPES.REVIEW_FOLLOWUP],
+    ['followup', SOURCE_TYPES.REVIEW_FOLLOWUP],
+    ['follow_up', SOURCE_TYPES.REVIEW_FOLLOWUP],
+    ['manual', SOURCE_TYPES.MANUAL_REMOTE],
+    ['manual_remote', SOURCE_TYPES.MANUAL_REMOTE],
+    ['direct', SOURCE_TYPES.MANUAL_REMOTE],
+    ['direct_pr', SOURCE_TYPES.MANUAL_REMOTE],
+    ['remote', SOURCE_TYPES.MANUAL_REMOTE],
+    ['remote_github_work', SOURCE_TYPES.MANUAL_REMOTE],
+    ['no_automation', SOURCE_TYPES.MANUAL_REMOTE],
+  ]);
+
+  return aliases.get(token) || SOURCE_TYPES.UNKNOWN;
+}
+
+function labelNames(pull = {}) {
+  return Array.isArray(pull.labels)
+    ? pull.labels
+        .map((label) => cleanString(typeof label === 'string' ? label : label?.name || ''))
+        .filter(Boolean)
+    : [];
+}
+
+function extractIssueNumberFromText(text) {
+  const value = String(text || '');
+  for (const match of value.matchAll(/#([0-9]+)/g)) {
+    if (!match[1]) {
+      continue;
+    }
+    const before = value.slice(Math.max(0, match.index - 200), match.index);
+    const token = before.split(/\s/).pop() || '';
+    if (token.includes('/')) {
+      continue;
+    }
+    if (match.index > 0 && /\w/.test(value[match.index - 1])) {
+      continue;
+    }
+    const preceding = value.slice(Math.max(0, match.index - 20), match.index);
+    if (/\b(?:run|attempt|step|job|check|version|v)\s*$/i.test(preceding)) {
+      continue;
+    }
+    const parsed = Number.parseInt(match[1], 10);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+function extractIssueNumberFromPull(pull = {}) {
+  const bodyText = String(pull?.body || '');
+  const metaMatch = bodyText.match(/<!--\s*meta:issue:([0-9]+)\s*-->/i);
+  if (metaMatch) {
+    return Number.parseInt(metaMatch[1], 10);
+  }
+
+  const branch = String(pull?.head?.ref || '');
+  const branchMatch = branch.match(/issue-#?([0-9]+)/i) || branch.match(/-issue-#([0-9]+)(?:$|[^0-9])/i);
+  if (branchMatch) {
+    return Number.parseInt(branchMatch[1], 10);
+  }
+
+  const titleNumber = extractIssueNumberFromText(pull?.title || '');
+  if (titleNumber) {
+    return titleNumber;
+  }
+
+  return extractIssueNumberFromText(bodyText);
+}
+
+function parseHtmlMarker(body, name) {
+  const pattern = new RegExp(`<!--\\s*${name}\\s*:\\s*([\\s\\S]*?)\\s*-->`, 'i');
+  const match = String(body || '').match(pattern);
+  return match ? cleanString(match[1]) : '';
+}
+
+function parseWorkflowSourceBlock(body) {
+  const match = String(body || '').match(
+    /<!--\s*workflow-source:start\s*-->([\s\S]*?)<!--\s*workflow-source:end\s*-->/i,
+  );
+  if (!match) {
+    return {};
+  }
+
+  const result = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const fieldMatch = line.match(/^\s*[-*]?\s*([A-Za-z][A-Za-z0-9_-]*)\s*:\s*(.+?)\s*$/);
+    if (!fieldMatch) {
+      continue;
+    }
+    const key = normalizeToken(fieldMatch[1]);
+    const value = cleanString(fieldMatch[2]);
+    if (key && value) {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+function sourceTypeFromCheckedTemplate(body) {
+  const lines = String(body || '').split(/\r?\n/);
+  const start = lines.findIndex((line) => /^#{1,6}\s+Workflow Source\s*$/i.test(line));
+  if (start < 0) {
+    return SOURCE_TYPES.UNKNOWN;
+  }
+  const sectionLines = [];
+  for (const line of lines.slice(start + 1)) {
+    if (/^#{1,6}\s+\S/.test(line)) {
+      break;
+    }
+    sectionLines.push(line);
+  }
+  const text = sectionLines.join('\n');
+  for (const line of text.split(/\r?\n/)) {
+    const checkbox = line.match(/^\s*[-*]\s+\[[xX]\]\s+(.+?)\s*$/);
+    if (!checkbox) {
+      continue;
+    }
+    const label = checkbox[1];
+    for (const [sourceType, pattern] of CHECKBOX_SOURCE_PATTERNS) {
+      if (pattern.test(label)) {
+        return sourceType;
+      }
+    }
+  }
+  return SOURCE_TYPES.UNKNOWN;
+}
+
+function sourceTypeFromLabels(pull = {}) {
+  for (const label of labelNames(pull)) {
+    const sourceType = SOURCE_LABELS[label.toLowerCase()] || SOURCE_LABELS[normalizeToken(label)];
+    if (sourceType) {
+      return sourceType;
+    }
+  }
+  return SOURCE_TYPES.UNKNOWN;
+}
+
+function inferredSourceType(pull = {}) {
+  const branch = cleanString(pull?.head?.ref).toLowerCase();
+  const title = cleanString(pull?.title).toLowerCase();
+  const author = cleanString(pull?.user?.login).toLowerCase();
+  const labels = labelNames(pull).map((label) => label.toLowerCase());
+
+  if (author.startsWith('dependabot') || branch.startsWith('dependabot/')) {
+    return SOURCE_TYPES.DEPENDABOT;
+  }
+  if (
+    branch.startsWith('sync/') ||
+    branch.startsWith('sync-') ||
+    labels.includes('campaign:sync-dependabot') ||
+    /\bsync\b/.test(title)
+  ) {
+    return SOURCE_TYPES.SYNC_CAMPAIGN;
+  }
+  if (/review[-/ ]follow/.test(branch) || /\breview\s+follow[- ]?up\b/.test(title)) {
+    return SOURCE_TYPES.REVIEW_FOLLOWUP;
+  }
+  return SOURCE_TYPES.UNKNOWN;
+}
+
+function resolvePrSourceContext(pull = {}) {
+  const body = String(pull?.body || '');
+  const block = parseWorkflowSourceBlock(body);
+  const issueNumber = extractIssueNumberFromPull(pull);
+
+  const markerType = normalizeSourceType(parseHtmlMarker(body, 'workflow-source'));
+  const blockType = normalizeSourceType(block.origin || block.source || block.type);
+  const checkboxType = sourceTypeFromCheckedTemplate(body);
+  const labelType = sourceTypeFromLabels(pull);
+  const inferredType = inferredSourceType(pull);
+  const sourceType = issueNumber
+    ? SOURCE_TYPES.GITHUB_ISSUE
+    : [markerType, blockType, checkboxType, labelType, inferredType].find((type) => type !== SOURCE_TYPES.UNKNOWN)
+      || SOURCE_TYPES.UNKNOWN;
+
+  const sourceRef =
+    cleanString(parseHtmlMarker(body, 'workflow-source-ref')) ||
+    cleanString(block.source_ref || block.ref || block.reference) ||
+    (issueNumber ? `#${issueNumber}` : '');
+  const lifecycle =
+    cleanString(parseHtmlMarker(body, 'workflow-lifecycle')) ||
+    cleanString(block.lifecycle || block.intended_lifecycle);
+  const automation =
+    cleanString(parseHtmlMarker(body, 'workflow-automation')) ||
+    cleanString(block.automation || block.automation_intent);
+
+  return {
+    sourceType,
+    issueNumber,
+    sourceRef,
+    lifecycle,
+    automation,
+    isKnown: sourceType !== SOURCE_TYPES.UNKNOWN,
+    isValid: VALID_SOURCE_TYPES.has(sourceType),
+    isExplicit: Boolean(
+      issueNumber ||
+        markerType !== SOURCE_TYPES.UNKNOWN ||
+        blockType !== SOURCE_TYPES.UNKNOWN ||
+        checkboxType !== SOURCE_TYPES.UNKNOWN ||
+        labelType !== SOURCE_TYPES.UNKNOWN
+    ),
+    requiresIssue: sourceType === SOURCE_TYPES.GITHUB_ISSUE,
+  };
+}
+
+function hasValidNonIssueSourceContext(pull = {}) {
+  const context = resolvePrSourceContext(pull);
+  return context.isValid && !context.requiresIssue;
+}
+
+function formatSourceContextForLog(context = {}) {
+  const parts = [`origin=${context.sourceType || SOURCE_TYPES.UNKNOWN}`];
+  if (context.sourceRef) {
+    parts.push(`ref=${context.sourceRef}`);
+  }
+  if (context.lifecycle) {
+    parts.push(`lifecycle=${context.lifecycle}`);
+  }
+  if (context.automation) {
+    parts.push(`automation=${context.automation}`);
+  }
+  return parts.join(' ');
+}
+
+module.exports = {
+  SOURCE_TYPES,
+  VALID_SOURCE_TYPES,
+  normalizeSourceType,
+  extractIssueNumberFromPull,
+  parseWorkflowSourceBlock,
+  sourceTypeFromCheckedTemplate,
+  sourceTypeFromLabels,
+  resolvePrSourceContext,
+  hasValidNonIssueSourceContext,
+  formatSourceContextForLog,
+};

--- a/.github/scripts/terminal_disposition.js
+++ b/.github/scripts/terminal_disposition.js
@@ -24,6 +24,18 @@ function normalizeToken(value, fallback = 'unknown') {
   return normalized || fallback;
 }
 
+function normalizeCliVersion(value) {
+  const text = cleanString(value);
+  if (!text) return '';
+  const versionMatch = text.match(/(\d+\.\d+\.\d+(?:[-+][A-Za-z0-9._-]+)?)/);
+  const version = versionMatch ? versionMatch[1] : '';
+  const lower = text.toLowerCase().replace(/_/g, '-');
+  if (version && /\bcodex(?:-|\s+)cli\b|\bopenai\/codex\b|\bcodex\b/.test(lower)) {
+    return `codex-cli ${version}`;
+  }
+  return lower;
+}
+
 function normalizeSourceType(value) {
   const text = cleanString(value).toLowerCase();
   if (!text) return 'unknown';
@@ -46,6 +58,10 @@ function normalizeOptionalValue(key, value) {
   if (key === 'needs_human' || key === 'depth_limit_exceeded') {
     const parsed = cleanBool(value);
     return parsed === null ? undefined : parsed;
+  }
+  if (key === 'llm_cli_version' || key === 'codex_cli_version' || key === 'cli_version') {
+    const normalized = normalizeCliVersion(value);
+    return normalized || undefined;
   }
   const cleaned = typeof value === 'boolean' ? value : cleanString(value);
   if (cleaned === '') return undefined;
@@ -369,6 +385,7 @@ module.exports = {
   normalizeVerifierFollowupPolicy,
   normalizeLedgerDisposition,
   normalizeOptionalValue,
+  normalizeCliVersion,
   summarizeTerminalDispositionSources,
   formatTerminalDispositionMarkdown,
   sourceKey,

--- a/.github/scripts/terminal_disposition_coverage.js
+++ b/.github/scripts/terminal_disposition_coverage.js
@@ -161,6 +161,7 @@ function summarizeVerifierModelCompatibility(records = [], options = {}) {
   const unsupportedRecords = [];
   const missingModelRecords = [];
   const legacyMissingModelRecords = [];
+  let missingUnknownModeRecordCount = 0;
   let verifierRecordCount = 0;
 
   for (const raw of records) {
@@ -192,6 +193,7 @@ function summarizeVerifierModelCompatibility(records = [], options = {}) {
       if (isPreContractVerifierModelRecord(record, metadata, modelMetadataContract)) {
         legacyMissingModelRecords.push(missingRecord);
       } else {
+        if (!verifierMode) missingUnknownModeRecordCount += 1;
         missingModelRecords.push(missingRecord);
       }
     }
@@ -215,6 +217,7 @@ function summarizeVerifierModelCompatibility(records = [], options = {}) {
     unsupported_models: unsupportedModels,
     unsupported_record_count: unsupportedRecords.length,
     missing_model_record_count: missingModelRecords.length,
+    missing_model_unknown_mode_record_count: missingUnknownModeRecordCount,
     legacy_missing_model_record_count: legacyMissingModelRecords.length,
     selected_models: Object.fromEntries(
       Object.entries(selectedModels).sort((a, b) => a[0].localeCompare(b[0]))
@@ -615,6 +618,7 @@ function formatTerminalDispositionCoverageMarkdown(report) {
       `- Verifier model compatibility: ${modelCompatibility.status}`,
       `- Unsupported verifier model records: ${modelCompatibility.unsupported_record_count}`,
       `- Missing verifier model metadata records: ${modelCompatibility.missing_model_record_count}`,
+      `- Missing verifier model metadata records with unknown mode: ${modelCompatibility.missing_model_unknown_mode_record_count || 0}`,
       `- Legacy missing verifier model metadata records: ${modelCompatibility.legacy_missing_model_record_count || 0}`
     );
     if (modelCompatibility.model_metadata_contract?.required_after) {

--- a/.github/scripts/weekly_metrics_artifacts.js
+++ b/.github/scripts/weekly_metrics_artifacts.js
@@ -13,6 +13,7 @@ const EXACT_METRICS_ARTIFACTS = new Set([
   'agents-verifier-metrics',
   'agents-verifier-disposition-metrics',
   'codex-cli-freshness',
+  'pr-source-context',
 ]);
 
 const PREFIXED_METRICS_ARTIFACTS = [
@@ -41,6 +42,7 @@ const PRIORITY_METRICS_FAMILIES = [
   'review-thread-terminal-disposition',
   'bot-comment-auth-coverage-wrapper',
   'bot-comment-auth-coverage-reusable',
+  'pr-source-context',
 ];
 
 function cleanString(value) {

--- a/WORKFLOW_USER_GUIDE.md
+++ b/WORKFLOW_USER_GUIDE.md
@@ -76,7 +76,32 @@ Issue: "Add user authentication"
 
 ---
 
-### 3. End-to-End Automation (Auto-Pilot)
+### 3. Start Work Directly From a PR
+
+**Use Case:** You are opening a PR without first creating a GitHub issue
+
+**Steps:**
+1. Fill out exactly one option in the PR template's `Workflow Source` section
+2. If the PR came from an issue, include `Closes #123` or `Related to #123`
+3. If there is no issue, choose the direct, local request, automation, review follow-up, sync/maintenance, or Dependabot source
+4. Use a `workflow:source-*` label if you need to classify an existing PR from the PR list
+
+**What Happens:**
+- Workflows treats valid non-issue sources as intentional work instead of missing process state
+- PR metadata automation avoids repeated missing-source repair comments
+- Keepalive still requires a linked issue before it dispatches follow-up agent work
+
+**Common labels:**
+- `workflow:source-direct-pr`
+- `workflow:source-local-request`
+- `workflow:source-review-followup`
+- `workflow:source-sync`
+- `workflow:source-dependabot`
+- `workflow:no-automation`
+
+---
+
+### 4. End-to-End Automation (Auto-Pilot)
 
 **Use Case:** You want complete hands-off automation from issue to merged PR
 

--- a/docs/LABELS.md
+++ b/docs/LABELS.md
@@ -212,6 +212,30 @@ To establish a single canonical TripPlan contract and eliminate inconsistencies.
 
 ---
 
+## Workflow Source Labels
+
+These labels let direct GitHub PRs and non-issue-origin PRs integrate with
+Workflows source classification without forcing a GitHub issue.
+
+| Label | Applies to | Effect |
+|-------|------------|--------|
+| `workflow:source-issue` | Pull Requests | PR source is a GitHub issue. |
+| `workflow:source-local-request` | Pull Requests | PR source is a local Codex/user request. |
+| `workflow:source-automation` | Pull Requests | PR source is an automation or workflow run. |
+| `workflow:source-sync` | Pull Requests | PR source is a sync or maintenance campaign. |
+| `workflow:source-dependabot` | Pull Requests | PR source is Dependabot or dependency automation. |
+| `workflow:source-review-followup` | Pull Requests | PR source is review feedback follow-up. |
+| `workflow:source-direct-pr` | Pull Requests | PR was started directly on GitHub without a source issue. |
+| `workflow:no-automation` | Pull Requests | Automation should not manage the PR unless checks fail. |
+| `workflow:source-needed` | Pull Requests | Source context is missing or ambiguous. |
+
+Use these labels as a backup to the PR template's Workflow Source section. If a
+PR has no linked issue and no valid Workflow Source, the PR metadata automation
+posts one repair comment instead of repeatedly treating the PR as issue-delivery
+work.
+
+---
+
 ## Verifier Labels
 
 These labels trigger the post-merge verifier workflow on a merged PR.

--- a/scripts/aggregate_agent_metrics.py
+++ b/scripts/aggregate_agent_metrics.py
@@ -102,6 +102,32 @@ def _parse_timestamp(value: Any) -> _dt.datetime | None:
     return None
 
 
+def _normalize_version_text(value: Any) -> str:
+    if value is None:
+        return ""
+    text = str(value).strip()
+    if not text:
+        return ""
+    match = re.search(r"(\d+\.\d+\.\d+(?:[-+][A-Za-z0-9._-]+)?)", text)
+    return match.group(1) if match else text
+
+
+def _normalize_cli_version(value: Any) -> str:
+    text = str(value).strip() if value is not None else ""
+    if not text:
+        return ""
+    version = _normalize_version_text(text)
+    lower = text.lower().replace("_", "-")
+    if version and re.search(r"\bcodex(?:-|\s+)cli\b|\bopenai/codex\b|\bcodex\b", lower):
+        return f"codex-cli {version}".lower()
+    return lower
+
+
+def _normalize_counter_token(value: Any, fallback: str = "unknown") -> str:
+    text = str(value).strip().lower().replace("_", "-") if value is not None else ""
+    return text or fallback
+
+
 def _gather_metrics_files(metrics_paths: list[str], metrics_dir: str) -> list[Path]:
     if metrics_paths:
         return [Path(path) for path in metrics_paths if path]
@@ -586,7 +612,7 @@ def _summarise_verifier(
         )
         cli_version_text = str(cli_version).strip() if cli_version is not None else ""
         if cli_version_text:
-            verifier_cli_versions[cli_version_text.lower()] += 1
+            verifier_cli_versions[_normalize_cli_version(cli_version_text)] += 1
         verifier_mode = str(entry.get("verifier_mode") or "").strip().lower()
         if verifier_mode:
             verifier_modes[verifier_mode] += 1
@@ -752,12 +778,12 @@ def _summarise_codex_cli_freshness(entries: list[dict[str, Any]]) -> dict[str, A
     max_patch_delta = 0
     update_targets = Counter()
     for entry in entries:
-        status = str(entry.get("status") or "unknown")
+        status = _normalize_counter_token(entry.get("status"))
         statuses[status] += 1
-        package = str(entry.get("package") or "unknown")
+        package = str(entry.get("package") or "unknown").strip() or "unknown"
         packages[package] += 1
-        pinned = str(entry.get("pinned_version") or "unknown")
-        latest = str(entry.get("latest_version") or "unknown")
+        pinned = _normalize_version_text(entry.get("pinned_version")) or "unknown"
+        latest = _normalize_version_text(entry.get("latest_version")) or "unknown"
         pinned_versions[pinned] += 1
         latest_versions[latest] += 1
         delta = entry.get("version_delta")


### PR DESCRIPTION
## Sync Summary

### Files Updated
- aggregate_agent_metrics.py: Aggregates downloaded weekly agent metrics - required by agents-weekly-metrics.yml
- source_context.js: Classifies PR workflow source context for issue, local, automation, sync, Dependabot, review follow-up, and direct GitHub work
- terminal_disposition.js: Machine-readable terminal disposition records and source summaries
- terminal_disposition_coverage.js: Warning-only terminal disposition source coverage preflight
- coverage_monitor_summary.js: Machine-readable weekly coverage monitor checkpoint
- weekly_metrics_artifacts.js: Bounded weekly metrics artifact selection contract
- agents_pr_meta_keepalive.js: PR metadata handling for keepalive
- agents_pr_meta_update_body.js: Updates PR body with agent metadata
- PULL_REQUEST_TEMPLATE.md: Pull request template with Workflow Source fields for direct GitHub and non-issue work
- LABELS.md: Label definitions and usage
- WORKFLOW_USER_GUIDE.md: Workflow user guide - explains the CI/agent system for repo consumers

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- dependabot.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `db4de6f93b8dd7c36fd8b14536e6404152430668`
**Template hash:** `863a67ed87f7`
**Sync branch:** `sync/workflows-863a67ed87f7`
**Consumer repo:** `stranske/Travel-Plan-Permission`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Travel-Plan-Permission","source_repository":"stranske/Workflows","source_sha":"db4de6f93b8dd7c36fd8b14536e6404152430668","template_hash":"863a67ed87f7","sync_branch":"sync/workflows-863a67ed87f7","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"24969576502","run_attempt":"1","changes_count":11} -->