### PR TITLE
Issue #948: Persist planner runtime seam

### DIFF
--- a/docs/ORCHESTRATION_PLAN.md
+++ b/docs/ORCHESTRATION_PLAN.md
@@ -286,6 +286,25 @@ class TripState(BaseModel):
 
 This state is persisted so workflows can span multiple sessions and support audit.
 
+The current repo-local orchestration seam is implemented by
+`travel_plan_permission.orchestration.graph.TripState`. Broader orchestration
+work must carry planner-runtime data through this state model rather than
+parallel service or UI shortcuts:
+
+- `planner_turn` records the planner input turn that initiated the policy call.
+- `policy_result` and `policy_missing_inputs` record the TPP policy evaluation.
+- `checkpoint_metadata` names the persisted `TripState` checkpoint and policy
+  status used for resume/audit.
+- `planner_feedback` carries user feedback from the planner loop.
+- `follow_up_action` records whether the planner must revise the trip or can
+  continue.
+
+The smoke contract for this seam lives in
+`tests/python/test_orchestration_smoke.py::test_policy_graph_persists_planner_runtime_seam`.
+Future planner autonomy, tool-calling, checkpoint persistence, and business
+policy follow-up should extend that state object instead of creating a separate
+advisory-only policy path.
+
 ### 6.2 Pre-Trip Workflow (Graph)
 
 1. Initial Plan Capture

--- a/docs/contracts/planner-integration.md
+++ b/docs/contracts/planner-integration.md
@@ -158,6 +158,24 @@ current policy decision for a proposal.
   stable machine-readable join keys for UI copy, analytics, or follow-up
   handling.
 
+### 5. Persist planner-runtime follow-up state
+
+When `trip-planner` submits or replays a proposal through the orchestration
+smoke path, the policy result must be persisted in the shared
+`travel_plan_permission.orchestration.graph.TripState` model. That state is the
+canonical seam for broader orchestration work:
+
+- `planner_turn` carries the planner input turn.
+- `policy_result` carries the TPP policy evaluation.
+- `checkpoint_metadata` records the persisted checkpoint identity and policy
+  status.
+- `planner_feedback` carries user feedback from the planner adjustment loop.
+- `follow_up_action` records the planner-side next step.
+
+Future integration work should use this state model for checkpoint save/load
+and follow-up behavior; a policy call that only returns advisory output without
+updating this state is not sufficient for the planner-runtime lifecycle.
+
 ## Example Fixtures
 
 These fixtures are the repository-owned source of truth for planner integration

--- a/src/travel_plan_permission/orchestration/graph.py
+++ b/src/travel_plan_permission/orchestration/graph.py
@@ -32,6 +32,10 @@ class TripState(BaseModel):
     canonical_plan: dict[str, object] | None = None
     policy_result: dict[str, object] | None = None
     policy_missing_inputs: list[dict[str, object]] = Field(default_factory=list)
+    planner_turn: dict[str, object] | None = None
+    checkpoint_metadata: dict[str, object] | None = None
+    planner_feedback: dict[str, object] | None = None
+    follow_up_action: dict[str, object] | None = None
     unfilled_mapping_report: dict[str, list[dict[str, object]]] | None = None
     spreadsheet_path: str | None = None
     errors: list[str] = Field(default_factory=list)
@@ -91,6 +95,21 @@ class TripState(BaseModel):
             return normalized
         return value  # type: ignore[return-value]
 
+    @field_validator(
+        "planner_turn",
+        "checkpoint_metadata",
+        "planner_feedback",
+        "follow_up_action",
+        mode="before",
+    )
+    @classmethod
+    def _coerce_runtime_record(cls, value: object) -> dict[str, object] | None:
+        if value is None:
+            return None
+        if isinstance(value, dict):
+            return value
+        return value  # type: ignore[return-value]
+
     @field_validator("unfilled_mapping_report", mode="before")
     @classmethod
     def _coerce_unfilled_mapping_report(
@@ -123,9 +142,7 @@ class TripState(BaseModel):
         return value  # type: ignore[return-value]
 
     @field_serializer("policy_missing_inputs", mode="plain")
-    def _serialize_policy_missing_inputs(
-        self, value: object
-    ) -> list[dict[str, object]]:
+    def _serialize_policy_missing_inputs(self, value: object) -> list[dict[str, object]]:
         if isinstance(value, list):
             serialized: list[dict[str, object]] = []
             for entry in value:
@@ -178,6 +195,42 @@ def _policy_check_node(state: TripState) -> TripState:
     return state
 
 
+def _planner_runtime_node(state: TripState) -> TripState:
+    plan = _load_plan(state)
+    policy_result = state.policy_result or {}
+    policy_status = policy_result.get("status")
+    policy_issues = policy_result.get("issues")
+    issue_count = len(policy_issues) if isinstance(policy_issues, list) else 0
+    missing_rule_ids = [
+        entry["rule_id"]
+        for entry in state.policy_missing_inputs
+        if isinstance(entry.get("rule_id"), str)
+    ]
+
+    state.planner_turn = state.planner_turn or {
+        "source": "trip_planner",
+        "trip_id": plan.trip_id,
+        "operation": "submit_trip_plan",
+        "input": state.plan_json,
+    }
+    state.checkpoint_metadata = {
+        "checkpoint_id": f"{plan.trip_id}:policy:{policy_status or 'unknown'}",
+        "trip_id": plan.trip_id,
+        "state_model": "TripState",
+        "policy_status": policy_status,
+        "policy_issue_count": issue_count,
+        "missing_input_rule_ids": missing_rule_ids,
+    }
+    state.follow_up_action = {
+        "required": policy_status != "pass",
+        "source": "policy_check",
+        "policy_status": policy_status,
+        "next_step": ("planner_revise_trip" if policy_status != "pass" else "planner_continue"),
+        "missing_input_rule_ids": missing_rule_ids,
+    }
+    return state
+
+
 def _spreadsheet_node(state: TripState) -> TripState:
     plan = _load_plan(state)
     canonical_plan = _load_canonical_plan(state)
@@ -221,11 +274,7 @@ def _serialize_unfilled_mapping_report(
     def serialize_entries(entries: Sequence[Any]) -> list[dict[str, object]]:
         serialized: list[dict[str, object]] = []
         for entry in entries:
-            if (
-                hasattr(entry, "field")
-                and hasattr(entry, "cell")
-                and hasattr(entry, "reason")
-            ):
+            if hasattr(entry, "field") and hasattr(entry, "cell") and hasattr(entry, "reason"):
                 serialized.append(
                     {
                         "field": entry.field,
@@ -247,6 +296,7 @@ def _serialize_unfilled_mapping_report(
 class _SimplePolicyGraph:
     def invoke(self, state: TripState) -> TripState:
         state = _policy_check_node(state)
+        state = _planner_runtime_node(state)
         state = _spreadsheet_node(state)
         return state
 
@@ -277,8 +327,10 @@ def _build_langgraph() -> PolicyGraph | None:
 
     graph = StateGraph(TripState)
     graph.add_node("policy_check", _policy_check_node)
+    graph.add_node("planner_runtime", _planner_runtime_node)
     graph.add_node("spreadsheet", _spreadsheet_node)
-    graph.add_edge("policy_check", "spreadsheet")
+    graph.add_edge("policy_check", "planner_runtime")
+    graph.add_edge("planner_runtime", "spreadsheet")
     graph.add_edge("spreadsheet", END)
     graph.set_entry_point("policy_check")
     compiled = graph.compile()
@@ -300,6 +352,8 @@ def run_policy_graph(
     *,
     canonical_plan: CanonicalTripPlan | None = None,
     output_path: Path | str | None = None,
+    planner_turn: dict[str, object] | None = None,
+    planner_feedback: dict[str, object] | None = None,
     prefer_langgraph: bool = True,
 ) -> TripState:
     """Run the policy graph over a trip plan and return the final state."""
@@ -309,10 +363,10 @@ def run_policy_graph(
     state = TripState(
         plan_json=plan.model_dump(mode="json"),
         canonical_plan=(
-            canonical_plan.model_dump(mode="json")
-            if canonical_plan is not None
-            else None
+            canonical_plan.model_dump(mode="json") if canonical_plan is not None else None
         ),
+        planner_turn=planner_turn,
+        planner_feedback=planner_feedback,
         spreadsheet_path=spreadsheet_path,
     )
     return graph.invoke(state)

--- a/tests/python/test_orchestration_smoke.py
+++ b/tests/python/test_orchestration_smoke.py
@@ -15,9 +15,7 @@ from travel_plan_permission.orchestration import graph as orchestration_graph
 
 def _fixture_trip_input() -> tuple[TripPlan, CanonicalTripPlan | None]:
     fixture_path = (
-        Path(__file__).resolve().parents[1]
-        / "fixtures"
-        / "sample_trip_plan_minimal.json"
+        Path(__file__).resolve().parents[1] / "fixtures" / "sample_trip_plan_minimal.json"
     )
     payload = json.loads(fixture_path.read_text(encoding="utf-8"))
     trip_input = load_trip_plan_input(payload)
@@ -68,12 +66,60 @@ def test_policy_graph_records_missing_policy_inputs(tmp_path: Path) -> None:
     assert missing
     rule_ids = {entry.get("rule_id") for entry in missing}
     assert "advance_booking" in rule_ids
-    advance_booking = next(
-        entry for entry in missing if entry.get("rule_id") == "advance_booking"
-    )
+    advance_booking = next(entry for entry in missing if entry.get("rule_id") == "advance_booking")
     assert "booking_date" in advance_booking.get("missing_fields", [])
     assert isinstance(advance_booking.get("missing_fields"), list)
     assert advance_booking.get("message", "").startswith("Missing required inputs:")
+
+
+def test_policy_graph_persists_planner_runtime_seam(tmp_path: Path) -> None:
+    plan, canonical = _fixture_trip_input()
+    output_path = tmp_path / "travel_request.xlsx"
+    planner_turn = {
+        "source": "trip_planner",
+        "turn_id": "turn-948",
+        "operation": "submit_business_trip",
+        "message": "Book the conference trip and check policy.",
+    }
+    planner_feedback = {
+        "turn_id": "turn-948",
+        "accepted_policy_guidance": False,
+        "comment": "Show the policy blockers before booking.",
+    }
+
+    state = run_policy_graph(
+        plan,
+        canonical_plan=canonical,
+        output_path=output_path,
+        planner_turn=planner_turn,
+        planner_feedback=planner_feedback,
+        prefer_langgraph=False,
+    )
+
+    assert state.policy_result is not None
+    assert state.planner_turn == planner_turn
+    assert state.planner_feedback == planner_feedback
+    assert state.checkpoint_metadata is not None
+    assert state.follow_up_action is not None
+    assert state.checkpoint_metadata["state_model"] == "TripState"
+    assert state.checkpoint_metadata["trip_id"] == plan.trip_id
+    assert state.checkpoint_metadata["policy_status"] == state.policy_result["status"]
+    assert state.follow_up_action["source"] == "policy_check"
+    assert state.follow_up_action["policy_status"] == state.policy_result["status"]
+    assert state.follow_up_action["required"] is True
+    assert state.follow_up_action["next_step"] == "planner_revise_trip"
+
+    checkpoint_path = tmp_path / "planner_runtime_checkpoint.json"
+    checkpoint_path.write_text(state.model_dump_json(indent=2), encoding="utf-8")
+    restored = orchestration_graph.TripState.model_validate_json(
+        checkpoint_path.read_text(encoding="utf-8")
+    )
+
+    assert restored.planner_turn == planner_turn
+    assert restored.planner_feedback == planner_feedback
+    assert restored.policy_result == state.policy_result
+    assert restored.checkpoint_metadata == state.checkpoint_metadata
+    assert restored.follow_up_action == state.follow_up_action
 
 
 @pytest.mark.filterwarnings("ignore:Pydantic serializer warnings.*:UserWarning")


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:948 -->
> **Source:** Issue #948

Closes #948

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Broader orchestration should be layered on top of a proven planner-runtime seam, not parallel UI/service shortcuts. The repo needs one explicit state model showing planner turns, tool calls, checkpoints, feedback, and business-policy follow-up moving through the same lifecycle.

#### Tasks
- [ ] Map the current planner-runtime state transitions and identify the canonical model or data structure that should carry them.
- [ ] Add or update orchestration tests that include planner turn input, TPP policy call, checkpoint save/load, user feedback, and follow-up action.
- [ ] Remove or clearly mark any shortcut path that skips the canonical state model in the smoke path.
- [ ] Document the seam as the prerequisite for broader orchestration work.

#### Acceptance criteria
- [ ] A test demonstrates one state object or persisted record carrying planner input, policy evaluation, checkpoint metadata, and follow-up state.
- [ ] The test fails if policy evaluation is advisory-only and not persisted into the planner/runtime lifecycle.
- [ ] The documented orchestration seam names the files/contracts future orchestration work must use.

**Head SHA:** eb4107e3548dd448331341ebe5e9900aa2d4641e
**Latest Runs:** ⏭️ skipped — Agents PR Event Hub
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24981278866) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24981278871) |
<!-- auto-status-summary:end -->