### PR TITLE
Issue #950: Define business policy scoring

### DIFF
--- a/docs/approval-workflow.md
+++ b/docs/approval-workflow.md
@@ -74,3 +74,24 @@ Approval packets package the trip summary, policy status, cost breakdown, and a 
 - PDFs include the justification column to preserve override rationale for auditing.
 - Manager review decisions captured through the browser queue require rationale so
   approval, rejection, and requested changes all leave an audit-ready explanation.
+
+## Business policy scoring
+
+Proposal evaluation treats business policy as the controlling layer above
+traveler preference. The planner-facing `PolicyCheckResult` includes a
+`business_policy_score` object so callers can explain whether policy or
+preference drove an outcome.
+
+- Hard policy constraints are rules configured as `blocking`. A failed hard
+  constraint sets `status` to `fail`, caps `final_preference_score` at `0`, and
+  cannot be outweighed by traveler preference.
+- Soft policy constraints are advisory rules. Each failed advisory subtracts 10
+  points from the base preference score of 100 while preserving `status=pass`
+  when no hard constraints fail.
+- Mixed results keep both explanations: hard blocks still cap the final score at
+  0, and advisory failures are listed as soft penalties for reviewer context.
+
+Each policy issue also includes a `policy_effect` context value:
+`hard_block`, `soft_penalty`, or `none`. Hard-block issues include
+`preference_score_cap=0` and `can_be_outweighed_by_preference=false`; soft
+penalties include `score_delta=-10`.

--- a/docs/policy-api.md
+++ b/docs/policy-api.md
@@ -65,13 +65,34 @@ Example JSON structure (matches `PolicyCheckResult` in
       "severity": "warning",
       "context": {
         "rule_id": "advance_booking",
-        "severity": "advisory"
+        "severity": "advisory",
+        "policy_effect": "soft_penalty",
+        "score_delta": -10,
+        "can_be_outweighed_by_preference": true
       }
     }
   ],
-  "policy_version": "d7a6d25a"
+  "policy_version": "d7a6d25a",
+  "business_policy_score": {
+    "base_preference_score": 100,
+    "final_preference_score": 90,
+    "hard_blocked": false,
+    "hard_block_codes": [],
+    "soft_penalty_points": 10,
+    "soft_penalty_codes": ["advance_booking"],
+    "explanation": "Soft business-policy constraints subtract 10 points each from the preference score."
+  }
 }
 ```
+
+Business-mode scoring is deterministic:
+
+- Failed hard policy constraints cap `final_preference_score` at `0` and set
+  `status` to `fail`.
+- Failed advisory constraints subtract 10 points each from the base preference
+  score of 100.
+- When hard and soft constraints both fail, the final score remains `0` and the
+  soft penalties remain listed for explanation.
 
 ### PlannerPolicySnapshotRequest (input)
 

--- a/src/travel_plan_permission/__init__.py
+++ b/src/travel_plan_permission/__init__.py
@@ -56,6 +56,8 @@ from .policy import (
     ThirdPartyPaidRule,
 )
 from .policy_api import (
+    BusinessPolicyEffect,
+    BusinessPolicyScore,
     PlannerApprovalTrigger,
     PlannerAuthContract,
     PlannerBlockingIssue,
@@ -182,6 +184,8 @@ __all__ = [
     "AuditLog",
     "Delegation",
     "BudgetLimitRule",
+    "BusinessPolicyEffect",
+    "BusinessPolicyScore",
     "CANONICAL_TRIP_FIELDS",
     "CabinClassRule",
     "DEFAULT_TEMPLATE_VERSION",

--- a/src/travel_plan_permission/policy_api.py
+++ b/src/travel_plan_permission/policy_api.py
@@ -42,6 +42,7 @@ from .security import (
 
 PolicyIssueSeverity = Literal["info", "warning", "error"]
 PolicyCheckStatus = Literal["pass", "fail"]
+BusinessPolicyEffect = Literal["none", "soft_penalty", "hard_block"]
 ReconciliationStatus = Literal["under_budget", "on_budget", "over_budget"]
 PolicySnapshotFreshness = Literal["current", "stale", "invalidated"]
 PlannerOperationType = Literal[
@@ -68,6 +69,8 @@ PlannerExecutionState = Literal[
 PolicyIssueContextValue = str | int | float | bool | None
 _PLANNER_POLICY_CONTRACT_VERSION = "2026-04-11"
 _PLANNER_POLICY_TTL = timedelta(hours=24)
+_BUSINESS_POLICY_BASE_SCORE = 100
+_BUSINESS_POLICY_SOFT_PENALTY = 10
 _DOCUMENTATION_RULE_IDS = frozenset(
     {"fare_evidence", "hotel_comparison", "third_party_paid"}
 )
@@ -75,6 +78,7 @@ _DOCUMENTATION_RULE_IDS = frozenset(
 __all__ = [
     "PolicyIssueSeverity",
     "PolicyCheckStatus",
+    "BusinessPolicyEffect",
     "PolicySnapshotFreshness",
     "PlannerOperationType",
     "PlannerProposalStatus",
@@ -84,6 +88,7 @@ __all__ = [
     "ReconciliationStatus",
     "PolicyIssue",
     "PolicyCheckResult",
+    "BusinessPolicyScore",
     "PlannerPolicySnapshotRequest",
     "PlannerPolicyRequirement",
     "PlannerApprovalTrigger",
@@ -130,6 +135,35 @@ class PolicyIssue(BaseModel):
     )
 
 
+class BusinessPolicyScore(BaseModel):
+    """Business-mode preference score effects from policy results."""
+
+    base_preference_score: int = Field(
+        default=_BUSINESS_POLICY_BASE_SCORE,
+        ge=0,
+        le=100,
+        description="Preference score before business policy effects",
+    )
+    final_preference_score: int = Field(
+        ..., ge=0, le=100, description="Preference score after policy effects"
+    )
+    hard_blocked: bool = Field(
+        ..., description="Whether a hard policy constraint capped the score at zero"
+    )
+    hard_block_codes: list[str] = Field(
+        default_factory=list, description="Hard policy rules that cannot be outweighed"
+    )
+    soft_penalty_points: int = Field(
+        default=0, ge=0, description="Total additive penalty from advisory rules"
+    )
+    soft_penalty_codes: list[str] = Field(
+        default_factory=list, description="Advisory rules that reduced the score"
+    )
+    explanation: str = Field(
+        ..., description="Human-readable scoring semantics for callers"
+    )
+
+
 class PolicyCheckResult(BaseModel):
     """Aggregated policy check results for a trip plan."""
 
@@ -139,6 +173,16 @@ class PolicyCheckResult(BaseModel):
     )
     policy_version: str = Field(
         ..., description="Deterministic policy version identifier"
+    )
+    business_policy_score: BusinessPolicyScore = Field(
+        default_factory=lambda: BusinessPolicyScore(
+            final_preference_score=_BUSINESS_POLICY_BASE_SCORE,
+            hard_blocked=False,
+            explanation="No business-policy constraint changed the preference score.",
+        ),
+        description=(
+            "Business-mode score explanation showing hard blocks and soft preference penalties"
+        ),
     )
 
 
@@ -806,12 +850,82 @@ def _issue_severity(result: PolicyResult) -> PolicyIssueSeverity:
     return "info"
 
 
+def _policy_effect(result: PolicyResult) -> BusinessPolicyEffect:
+    if result.passed:
+        return "none"
+    if result.severity == Severity.BLOCKING:
+        return "hard_block"
+    if result.severity == Severity.ADVISORY:
+        return "soft_penalty"
+    return "none"
+
+
 def _issue_from_result(result: PolicyResult) -> PolicyIssue:
+    effect = _policy_effect(result)
+    context: dict[str, PolicyIssueContextValue] = {
+        "rule_id": result.rule_id,
+        "severity": result.severity,
+        "policy_effect": effect,
+    }
+    if effect == "hard_block":
+        context.update(
+            {
+                "preference_score_cap": 0,
+                "can_be_outweighed_by_preference": False,
+            }
+        )
+    elif effect == "soft_penalty":
+        context.update(
+            {
+                "score_delta": -_BUSINESS_POLICY_SOFT_PENALTY,
+                "can_be_outweighed_by_preference": True,
+            }
+        )
     return PolicyIssue(
         code=result.rule_id,
         message=result.message,
         severity=_issue_severity(result),
-        context={"rule_id": result.rule_id, "severity": result.severity},
+        context=context,
+    )
+
+
+def _business_policy_score(results: Sequence[PolicyResult]) -> BusinessPolicyScore:
+    hard_block_codes = [
+        result.rule_id
+        for result in results
+        if not result.passed and result.severity == Severity.BLOCKING
+    ]
+    soft_penalty_codes = [
+        result.rule_id
+        for result in results
+        if not result.passed and result.severity == Severity.ADVISORY
+    ]
+    soft_penalty_points = len(soft_penalty_codes) * _BUSINESS_POLICY_SOFT_PENALTY
+    hard_blocked = bool(hard_block_codes)
+    final_score = (
+        0
+        if hard_blocked
+        else max(0, _BUSINESS_POLICY_BASE_SCORE - soft_penalty_points)
+    )
+    if hard_blocked:
+        explanation = (
+            "Hard business-policy constraints cap the preference score at 0; "
+            "traveler preference cannot outweigh them."
+        )
+    elif soft_penalty_codes:
+        explanation = (
+            "Soft business-policy constraints subtract "
+            f"{_BUSINESS_POLICY_SOFT_PENALTY} points each from the preference score."
+        )
+    else:
+        explanation = "No business-policy constraint changed the preference score."
+    return BusinessPolicyScore(
+        final_preference_score=final_score,
+        hard_blocked=hard_blocked,
+        hard_block_codes=hard_block_codes,
+        soft_penalty_points=soft_penalty_points,
+        soft_penalty_codes=soft_penalty_codes,
+        explanation=explanation,
     )
 
 
@@ -1505,7 +1619,10 @@ def check_trip_plan(plan: TripPlan) -> PolicyCheckResult:
     )
     status: PolicyCheckStatus = "fail" if has_blocking else "pass"
     return PolicyCheckResult(
-        status=status, issues=issues, policy_version=_policy_version(engine)
+        status=status,
+        issues=issues,
+        policy_version=_policy_version(engine),
+        business_policy_score=_business_policy_score(results),
     )
 
 

--- a/tests/python/test_canonical_flow.py
+++ b/tests/python/test_canonical_flow.py
@@ -28,10 +28,16 @@ def test_canonical_trip_plan_flow_renders_policy_and_spreadsheet() -> None:
 
     policy_result = check_trip_plan(trip_input.plan)
     policy_dump = policy_result.model_dump()
-    assert set(policy_dump) == {"status", "issues", "policy_version"}
+    assert set(policy_dump) == {
+        "status",
+        "issues",
+        "policy_version",
+        "business_policy_score",
+    }
     assert policy_dump["status"] in ("pass", "fail")
     assert isinstance(policy_dump["issues"], list)
     assert re.fullmatch(r"[0-9a-f]{64}", policy_dump["policy_version"])
+    assert 0 <= policy_dump["business_policy_score"]["final_preference_score"] <= 100
     if policy_result.issues:
         issue_dump = policy_result.issues[0].model_dump()
         assert set(issue_dump) == {"code", "message", "severity", "context"}

--- a/tests/python/test_policy_api.py
+++ b/tests/python/test_policy_api.py
@@ -90,6 +90,29 @@ def matching_receipts() -> list[Receipt]:
     ]
 
 
+class StaticPolicyRule(PolicyRule):
+    """Small test rule for deterministic scoring assertions."""
+
+    def __init__(
+        self, rule_id: str, severity: str, *, passed: bool, message: str
+    ) -> None:
+        super().__init__(severity)
+        self.rule_id = rule_id
+        self._passed = passed
+        self._message = message
+
+    def evaluate(self, _context: PolicyContext) -> PolicyResult:
+        return PolicyResult(
+            rule_id=self.rule_id,
+            severity=self.severity,
+            passed=self._passed,
+            message=self._message,
+        )
+
+    def message(self) -> str:
+        return self._message
+
+
 def test_check_trip_plan_reports_policy_issues(trip_plan: TripPlan) -> None:
     result = check_trip_plan(trip_plan)
 
@@ -99,6 +122,112 @@ def test_check_trip_plan_reports_policy_issues(trip_plan: TripPlan) -> None:
     assert any(issue.code == "fare_evidence" for issue in result.issues)
     for issue in result.issues:
         assert issue.context["rule_id"] == issue.code
+
+
+def test_business_policy_score_stays_full_when_compliant(
+    trip_plan: TripPlan, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    engine = PolicyEngine(
+        [
+            StaticPolicyRule(
+                "preferred_carrier", Severity.BLOCKING, passed=True, message="Allowed."
+            )
+        ]
+    )
+    monkeypatch.setattr(PolicyEngine, "from_file", lambda *_args, **_kwargs: engine)
+
+    result = check_trip_plan(trip_plan)
+
+    assert result.status == "pass"
+    assert result.issues == []
+    assert result.business_policy_score.final_preference_score == 100
+    assert result.business_policy_score.hard_blocked is False
+    assert result.business_policy_score.soft_penalty_points == 0
+
+
+def test_soft_policy_penalty_reduces_preference_score_predictably(
+    trip_plan: TripPlan, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    engine = PolicyEngine(
+        [
+            StaticPolicyRule(
+                "hotel_comparison",
+                Severity.ADVISORY,
+                passed=False,
+                message="Comparable hotel evidence missing.",
+            )
+        ]
+    )
+    monkeypatch.setattr(PolicyEngine, "from_file", lambda *_args, **_kwargs: engine)
+
+    result = check_trip_plan(trip_plan)
+
+    assert result.status == "pass"
+    assert result.business_policy_score.final_preference_score == 90
+    assert result.business_policy_score.soft_penalty_points == 10
+    assert result.business_policy_score.soft_penalty_codes == ["hotel_comparison"]
+    assert result.issues[0].context["policy_effect"] == "soft_penalty"
+    assert result.issues[0].context["score_delta"] == -10
+
+
+def test_hard_policy_block_cannot_be_outweighed_by_preference(
+    trip_plan: TripPlan, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    engine = PolicyEngine(
+        [
+            StaticPolicyRule(
+                "fare_comparison",
+                Severity.BLOCKING,
+                passed=False,
+                message="Selected fare exceeds allowed threshold.",
+            )
+        ]
+    )
+    monkeypatch.setattr(PolicyEngine, "from_file", lambda *_args, **_kwargs: engine)
+
+    result = check_trip_plan(trip_plan)
+
+    assert result.status == "fail"
+    assert result.business_policy_score.final_preference_score == 0
+    assert result.business_policy_score.hard_block_codes == ["fare_comparison"]
+    assert result.issues[0].context["policy_effect"] == "hard_block"
+    assert result.issues[0].context["preference_score_cap"] == 0
+    assert result.issues[0].context["can_be_outweighed_by_preference"] is False
+
+
+def test_mixed_policy_tradeoff_preserves_soft_penalty_explanation_under_hard_block(
+    trip_plan: TripPlan, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    engine = PolicyEngine(
+        [
+            StaticPolicyRule(
+                "fare_comparison",
+                Severity.BLOCKING,
+                passed=False,
+                message="Selected fare exceeds allowed threshold.",
+            ),
+            StaticPolicyRule(
+                "advance_booking",
+                Severity.ADVISORY,
+                passed=False,
+                message="Short booking window needs manager context.",
+            ),
+        ]
+    )
+    monkeypatch.setattr(PolicyEngine, "from_file", lambda *_args, **_kwargs: engine)
+
+    result = check_trip_plan(trip_plan)
+
+    assert result.status == "fail"
+    assert result.business_policy_score.final_preference_score == 0
+    assert result.business_policy_score.hard_blocked is True
+    assert result.business_policy_score.soft_penalty_points == 10
+    assert result.business_policy_score.soft_penalty_codes == ["advance_booking"]
+    effects = {issue.code: issue.context["policy_effect"] for issue in result.issues}
+    assert effects == {
+        "fare_comparison": "hard_block",
+        "advance_booking": "soft_penalty",
+    }
 
 
 def test_check_trip_plan_triggers_fare_comparison_when_inputs_present(

--- a/tests/python/test_public_api.py
+++ b/tests/python/test_public_api.py
@@ -10,6 +10,8 @@ def test_public_api_imports() -> None:
     travel_plan_permission = importlib.import_module("travel_plan_permission")
 
     from travel_plan_permission import (
+        BusinessPolicyEffect,
+        BusinessPolicyScore,
         PlannerBlockingIssue,
         PlannerEvaluationOutcome,
         PlannerExceptionRequirement,
@@ -39,6 +41,8 @@ def test_public_api_imports() -> None:
     )
 
     required_exports = {
+        "BusinessPolicyEffect",
+        "BusinessPolicyScore",
         "PlannerBlockingIssue",
         "PlannerEvaluationOutcome",
         "PlannerExceptionRequirement",
@@ -70,6 +74,8 @@ def test_public_api_imports() -> None:
     assert required_exports.issubset(set(travel_plan_permission.__all__))
     assert travel_plan_permission.__version__
     assert TripPlan is not None
+    assert BusinessPolicyEffect is not None
+    assert BusinessPolicyScore is not None
     assert check_trip_plan is not None
     assert list_allowed_vendors is not None
     assert reconcile is not None


### PR DESCRIPTION
Closes #950

Supersedes closed PR #971; reopens the same validated #950 branch content on a fresh PR because #971 is closed and must not be pushed to.

## Summary
- Adds `business_policy_score` to planner-facing `PolicyCheckResult`
- Marks policy issue effects as hard blocks, soft penalties, or neutral policy outcomes
- Documents deterministic hard-block and soft-penalty scoring semantics

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache-pd-tpp-950-remote uv run ruff check src/travel_plan_permission/policy_api.py src/travel_plan_permission/__init__.py tests/python/test_policy_api.py tests/python/test_public_api.py tests/python/test_canonical_flow.py`
- `UV_CACHE_DIR=/tmp/uv-cache-pd-tpp-950-remote uv run mypy src/travel_plan_permission/policy_api.py`
- `UV_CACHE_DIR=/tmp/uv-cache-pd-tpp-950-remote uv run pytest -q tests/python/test_policy_api.py tests/python/test_public_api.py tests/python/test_canonical_flow.py`
- `git diff --check origin/main...HEAD`

<!-- pr-preamble:start -->
<!-- meta:issue:950 -->
> **Source:** Issue #950

Closes #950

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Business travel ranking needs a clear rule for how hard policy constraints and soft preferences interact. Without a documented and tested scoring policy, the system can either overrule business requirements with leisure-style preferences or bury useful preferences behind opaque hard failures.

#### Tasks
- [ ] Audit existing approval rules, validation config, and preference/ranking contract docs.
- [ ] Document whether policy violations are hard blocks, capped scores, additive penalties, or explanatory flags.
- [ ] Implement the rule in the evaluation/scoring code path used for business proposals.
- [ ] Add tests covering compliant option, soft-policy penalty, hard-policy block, and mixed preference tradeoff.
- [ ] Expose score explanation fields so callers can tell whether business policy or preference drove the result.

#### Acceptance criteria
- [ ] Business-mode scoring has documented hard-block and soft-penalty semantics.
- [ ] Tests prove a hard policy constraint cannot be outweighed by traveler preference.
- [ ] Tests prove soft policy constraints modify the preference score predictably.
- [ ] Evaluation output includes explanation fields for policy constraint effects.

**Head SHA:** 35f60409a0d73382130822ad7d892550763e09b5
**Latest Runs:** ⏹️ cancelled — Gate
**Required:** gate: ⏹️ cancelled

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| .github/workflows/autofix.yml | ❌ failure | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24976108625) |
| Agents Auto-Pilot | ⏭️ skipped | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24976112659) |
| Agents Bot Comment Handler | ⏹️ cancelled | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24976112741) |
| Agents Gate Followups | ✅ success | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24976112730) |
| Agents Keepalive Loop | ❔ in progress | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24976112734) |
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24976112689) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24976112668) |
| Agents Verifier | ❔ in progress | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24976112758) |
| CI | ❔ in progress | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24976112698) |
| Claude Code Review (Opt-in) | ❔ in progress | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24976112657) |
| Create Issue from Verification (DEPRECATED) | ⏭️ skipped | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24976112591) |
| Create Issue from Verification (Enhanced) | ⏭️ skipped | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24976112624) |
| Create New PR from Verification | ⏭️ skipped | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24976112674) |
| Dependabot Auto-merge | ⏭️ skipped | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24976112518) |
| Gate | ⏹️ cancelled | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24976112722) |
| Health 45 Agents Guard | ⏳ pending | [View run](https://github.com/stranske/Travel-Plan-Permission/actions/runs/24976112661) |
<!-- auto-status-summary:end -->