### PR TITLE
ci: gate planner contract with cross-repo-smoke against pinned trip-planner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,16 +147,13 @@ jobs:
         working-directory: travel-plan-permission
         env:
           TRIP_PLANNER_REPO: ${{ github.workspace }}/trip-planner
-          TPP_ACCESS_TOKEN: ${{ env.TPP_PLANNER_TOKEN }}
         run: |
           tpp-cross-repo-smoke
 
       - name: Run tpp-planner-smoke
         working-directory: travel-plan-permission
-        env:
-          TPP_ACCESS_TOKEN: ${{ env.TPP_PLANNER_TOKEN }}
         run: |
-          tpp-planner-smoke
+          tpp-planner-smoke --token "${TPP_PLANNER_TOKEN}"
 
       - name: Tear down planner service
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,120 @@ jobs:
             tests/python/test_orchestration_smoke.py::test_policy_graph_langgraph_smoke \
             tests/python/test_orchestration_smoke.py::test_policy_graph_prefers_langgraph_when_available \
             -v
+
+  cross-repo-smoke:
+    # Gates the planner integration contract against a pinned trip-planner ref.
+    # See docs/local-testing-plan.md "Stage 7" and the matching trip-planner job
+    # for how to advance TRIP_PLANNER_PINNED_REF as a coordinated pair.
+    name: Cross-Repo Smoke (trip-planner)
+    runs-on: ubuntu-latest
+    env:
+      # Single source of truth for the trip-planner ref this job exercises.
+      # Bump in lockstep with the corresponding trip-planner CI job pin.
+      TRIP_PLANNER_PINNED_REF: e0f90435302134fec36256640ca19009ff8204dd
+      TPP_BASE_URL: http://127.0.0.1:8000
+      TPP_OIDC_PROVIDER: google
+      TPP_AUTH_MODE: bootstrap-token
+      TPP_PORT: "8000"
+    steps:
+      - name: Checkout Travel-Plan-Permission (PR head)
+        uses: actions/checkout@v6
+        with:
+          path: travel-plan-permission
+
+      - name: Checkout trip-planner at pinned ref
+        uses: actions/checkout@v6
+        with:
+          repository: stranske/trip-planner
+          ref: ${{ env.TRIP_PLANNER_PINNED_REF }}
+          path: trip-planner
+
+      - name: Log resolved trip-planner SHA
+        working-directory: trip-planner
+        run: |
+          echo "TRIP_PLANNER_PINNED_REF input: ${TRIP_PLANNER_PINNED_REF}"
+          echo "Resolved SHA: $(git rev-parse HEAD)"
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install Travel-Plan-Permission dev extras
+        working-directory: travel-plan-permission
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,orchestration]"
+
+      - name: Generate bootstrap signing secret
+        run: |
+          secret="$(python -c 'import secrets; print(secrets.token_hex(32))')"
+          echo "TPP_BOOTSTRAP_SIGNING_SECRET=${secret}" >> "$GITHUB_ENV"
+
+      - name: Mint planner bootstrap token
+        working-directory: travel-plan-permission
+        run: |
+          token="$(tpp-planner-token --subject ci-cross-repo-smoke)"
+          if [ -z "${token}" ]; then
+            echo "tpp-planner-token returned empty token" >&2
+            exit 1
+          fi
+          echo "TPP_PLANNER_TOKEN=${token}" >> "$GITHUB_ENV"
+
+      - name: Start tpp-planner-service in background
+        working-directory: travel-plan-permission
+        run: |
+          mkdir -p "${{ github.workspace }}/_runtime"
+          nohup tpp-planner-service --host 127.0.0.1 --port "${TPP_PORT}" \
+            >"${{ github.workspace }}/_runtime/planner-service.log" 2>&1 &
+          echo "PLANNER_SERVICE_PID=$!" >> "$GITHUB_ENV"
+
+      - name: Wait for /readyz to return 200
+        run: |
+          for attempt in $(seq 1 60); do
+            status="$(curl -s -o /dev/null -w '%{http_code}' "${TPP_BASE_URL}/readyz" || echo '000')"
+            if [ "${status}" = "200" ]; then
+              echo "Planner service ready after ${attempt} attempt(s)."
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Planner service never reported ready." >&2
+          tail -n 200 "${{ github.workspace }}/_runtime/planner-service.log" >&2 || true
+          exit 1
+
+      - name: Run tpp-cross-repo-smoke
+        working-directory: travel-plan-permission
+        env:
+          TRIP_PLANNER_REPO: ${{ github.workspace }}/trip-planner
+          TPP_ACCESS_TOKEN: ${{ env.TPP_PLANNER_TOKEN }}
+        run: |
+          tpp-cross-repo-smoke
+
+      - name: Run tpp-planner-smoke
+        working-directory: travel-plan-permission
+        env:
+          TPP_ACCESS_TOKEN: ${{ env.TPP_PLANNER_TOKEN }}
+        run: |
+          tpp-planner-smoke
+
+      - name: Tear down planner service
+        if: always()
+        run: |
+          if [ -n "${PLANNER_SERVICE_PID:-}" ] && kill -0 "${PLANNER_SERVICE_PID}" 2>/dev/null; then
+            kill "${PLANNER_SERVICE_PID}" || true
+            for _ in $(seq 1 5); do
+              kill -0 "${PLANNER_SERVICE_PID}" 2>/dev/null || break
+              sleep 1
+            done
+            kill -9 "${PLANNER_SERVICE_PID}" 2>/dev/null || true
+          fi
+
+      - name: Upload planner service log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: planner-service-log
+          path: ${{ github.workspace }}/_runtime/planner-service.log
+          if-no-files-found: ignore

--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -161,16 +161,13 @@ jobs:
         working-directory: travel-plan-permission
         env:
           TRIP_PLANNER_REPO: ${{ github.workspace }}/trip-planner
-          TPP_ACCESS_TOKEN: ${{ env.TPP_PLANNER_TOKEN }}
         run: |
           tpp-cross-repo-smoke
 
       - name: Run tpp-planner-smoke
         working-directory: travel-plan-permission
-        env:
-          TPP_ACCESS_TOKEN: ${{ env.TPP_PLANNER_TOKEN }}
         run: |
-          tpp-planner-smoke
+          tpp-planner-smoke --token "${TPP_PLANNER_TOKEN}"
 
       - name: Tear down planner service
         if: always()

--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -75,9 +75,126 @@ jobs:
           # Broader orchestration coverage stays in the main Python test suite.
           pytest tests/orchestration_graph_test.py tests/python/test_langgraph_orchestration.py -v
 
+  cross-repo-smoke:
+    # Gates the planner integration contract against a pinned trip-planner ref.
+    # See docs/local-testing-plan.md "Stage 7" and the matching trip-planner job
+    # for how to advance TRIP_PLANNER_PINNED_REF as a coordinated pair.
+    name: Cross-Repo Smoke (trip-planner)
+    runs-on: ubuntu-latest
+    env:
+      # Single source of truth for the trip-planner ref this job exercises.
+      # Bump in lockstep with the corresponding trip-planner CI job pin.
+      TRIP_PLANNER_PINNED_REF: e0f90435302134fec36256640ca19009ff8204dd
+      TPP_BASE_URL: http://127.0.0.1:8000
+      TPP_OIDC_PROVIDER: google
+      TPP_AUTH_MODE: bootstrap-token
+      TPP_PORT: "8000"
+    steps:
+      - name: Checkout Travel-Plan-Permission (PR head)
+        uses: actions/checkout@v6
+        with:
+          path: travel-plan-permission
+
+      - name: Checkout trip-planner at pinned ref
+        uses: actions/checkout@v6
+        with:
+          repository: stranske/trip-planner
+          ref: ${{ env.TRIP_PLANNER_PINNED_REF }}
+          path: trip-planner
+
+      - name: Log resolved trip-planner SHA
+        working-directory: trip-planner
+        run: |
+          echo "TRIP_PLANNER_PINNED_REF input: ${TRIP_PLANNER_PINNED_REF}"
+          echo "Resolved SHA: $(git rev-parse HEAD)"
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install Travel-Plan-Permission dev extras
+        working-directory: travel-plan-permission
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,orchestration]"
+
+      - name: Generate bootstrap signing secret
+        run: |
+          secret="$(python -c 'import secrets; print(secrets.token_hex(32))')"
+          echo "TPP_BOOTSTRAP_SIGNING_SECRET=${secret}" >> "$GITHUB_ENV"
+
+      - name: Mint planner bootstrap token
+        working-directory: travel-plan-permission
+        run: |
+          token="$(tpp-planner-token --subject ci-gate-cross-repo-smoke)"
+          if [ -z "${token}" ]; then
+            echo "tpp-planner-token returned empty token" >&2
+            exit 1
+          fi
+          echo "TPP_PLANNER_TOKEN=${token}" >> "$GITHUB_ENV"
+
+      - name: Start tpp-planner-service in background
+        working-directory: travel-plan-permission
+        run: |
+          mkdir -p "${{ github.workspace }}/_runtime"
+          nohup tpp-planner-service --host 127.0.0.1 --port "${TPP_PORT}" \
+            >"${{ github.workspace }}/_runtime/planner-service.log" 2>&1 &
+          echo "PLANNER_SERVICE_PID=$!" >> "$GITHUB_ENV"
+
+      - name: Wait for /readyz to return 200
+        run: |
+          for attempt in $(seq 1 60); do
+            status="$(curl -s -o /dev/null -w '%{http_code}' "${TPP_BASE_URL}/readyz" || echo '000')"
+            if [ "${status}" = "200" ]; then
+              echo "Planner service ready after ${attempt} attempt(s)."
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Planner service never reported ready." >&2
+          tail -n 200 "${{ github.workspace }}/_runtime/planner-service.log" >&2 || true
+          exit 1
+
+      - name: Run tpp-cross-repo-smoke
+        working-directory: travel-plan-permission
+        env:
+          TRIP_PLANNER_REPO: ${{ github.workspace }}/trip-planner
+          TPP_ACCESS_TOKEN: ${{ env.TPP_PLANNER_TOKEN }}
+        run: |
+          tpp-cross-repo-smoke
+
+      - name: Run tpp-planner-smoke
+        working-directory: travel-plan-permission
+        env:
+          TPP_ACCESS_TOKEN: ${{ env.TPP_PLANNER_TOKEN }}
+        run: |
+          tpp-planner-smoke
+
+      - name: Tear down planner service
+        if: always()
+        run: |
+          if [ -n "${PLANNER_SERVICE_PID:-}" ] && kill -0 "${PLANNER_SERVICE_PID}" 2>/dev/null; then
+            kill "${PLANNER_SERVICE_PID}" || true
+            for _ in $(seq 1 5); do
+              kill -0 "${PLANNER_SERVICE_PID}" 2>/dev/null || break
+              sleep 1
+            done
+            kill -9 "${PLANNER_SERVICE_PID}" 2>/dev/null || true
+          fi
+
+      - name: Upload planner service log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gate-planner-service-log
+          path: ${{ github.workspace }}/_runtime/planner-service.log
+          if-no-files-found: ignore
+
   summary:
     name: gate-summary
-    needs: [python-ci, orchestration-tests]
+    needs: [python-ci, orchestration-tests, cross-repo-smoke]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     permissions:
@@ -100,59 +217,47 @@ jobs:
         env:
           PYTHON_RESULT: ${{ needs.python-ci.result || 'skipped' }}
           ORCHESTRATION_RESULT: ${{ needs.orchestration-tests.result || 'skipped' }}
+          CROSS_REPO_SMOKE_RESULT: ${{ needs.cross-repo-smoke.result || 'skipped' }}
         run: |
           set -euo pipefail
 
           python_result="${PYTHON_RESULT:-skipped}"
           orchestration_result="${ORCHESTRATION_RESULT:-skipped}"
+          cross_repo_smoke_result="${CROSS_REPO_SMOKE_RESULT:-skipped}"
 
-          # Keep the gate mapping explicit so new result combinations stay auditable.
-          case "${python_result}:${orchestration_result}" in
-            failure:failure)
-              state="failure"
-              description="Python CI and orchestration tests failed"
-              ;;
-            failure:*)
-              state="failure"
-              description="Python CI failed"
-              ;;
-            *:failure)
-              state="failure"
-              description="Orchestration tests failed"
-              ;;
-            cancelled:cancelled)
-              state="error"
-              description="Python CI and orchestration tests were cancelled"
-              ;;
-            cancelled:*)
-              state="error"
-              description="Python CI was cancelled"
-              ;;
-            *:cancelled)
-              state="error"
-              description="Orchestration tests were cancelled"
-              ;;
-            success:success)
-              state="success"
-              description="All checks passed"
-              ;;
-            skipped:success)
-              state="success"
-              description="Orchestration tests passed (Python CI skipped)"
-              ;;
-            success:skipped)
-              state="success"
-              description="Python CI passed"
-              ;;
-            skipped:skipped)
-              state="success"
-              description="Python CI skipped (no relevant changes)"
-              ;;
-            *)
-              state="pending"
-              description="Gate status pending (python=${python_result}, orchestration=${orchestration_result})"
-              ;;
-          esac
+          # Collect failures and cancellations across all gate jobs.
+          failed_desc=""
+          cancelled_desc=""
+
+          [[ "${python_result}" == "failure" ]] && \
+            failed_desc="${failed_desc:+${failed_desc}; }Python CI failed"
+          [[ "${orchestration_result}" == "failure" ]] && \
+            failed_desc="${failed_desc:+${failed_desc}; }orchestration tests failed"
+          [[ "${cross_repo_smoke_result}" == "failure" ]] && \
+            failed_desc="${failed_desc:+${failed_desc}; }cross-repo smoke failed"
+
+          [[ "${python_result}" == "cancelled" ]] && \
+            cancelled_desc="${cancelled_desc:+${cancelled_desc}; }Python CI cancelled"
+          [[ "${orchestration_result}" == "cancelled" ]] && \
+            cancelled_desc="${cancelled_desc:+${cancelled_desc}; }orchestration tests cancelled"
+          [[ "${cross_repo_smoke_result}" == "cancelled" ]] && \
+            cancelled_desc="${cancelled_desc:+${cancelled_desc}; }cross-repo smoke cancelled"
+
+          if [[ -n "${failed_desc}" ]]; then
+            state="failure"
+            description="${failed_desc}"
+          elif [[ -n "${cancelled_desc}" ]]; then
+            state="error"
+            description="${cancelled_desc}"
+          elif [[ ("${python_result}" == "success" || "${python_result}" == "skipped") && \
+                  ("${orchestration_result}" == "success" || "${orchestration_result}" == "skipped") && \
+                  ("${cross_repo_smoke_result}" == "success" || "${cross_repo_smoke_result}" == "skipped") ]]; then
+            state="success"
+            description="All checks passed"
+          else
+            state="pending"
+            description="Gate status pending (python=${python_result}, orchestration=${orchestration_result}, cross-repo-smoke=${cross_repo_smoke_result})"
+          fi
 
           echo "state=${state}" >> "$GITHUB_OUTPUT"
           echo "description=${description}" >> "$GITHUB_OUTPUT"

--- a/docs/local-testing-plan.md
+++ b/docs/local-testing-plan.md
@@ -147,6 +147,48 @@ If the change affects the planner-facing API contract:
 
 Use this stage for contract and behavior changes, not every small local edit.
 
+### CI gate: `cross-repo-smoke`
+
+The same contract is gated automatically in CI by the `cross-repo-smoke` job in
+`.github/workflows/ci.yml`. The job:
+
+1. Checks out this repo (PR head).
+2. Checks out `stranske/trip-planner` at `TRIP_PLANNER_PINNED_REF` into a
+   sibling-like path (`${{ github.workspace }}/trip-planner`).
+3. Installs this repo's `[dev,orchestration]` extras.
+4. Generates a fresh `TPP_BOOTSTRAP_SIGNING_SECRET` and mints a bootstrap token
+   via `tpp-planner-token`.
+5. Starts `tpp-planner-service` on `127.0.0.1:8000` in the background and waits
+   for `/readyz` to return `200`.
+6. Runs `tpp-cross-repo-smoke` against the live local service, with
+   `TRIP_PLANNER_REPO` pointed at the trip-planner checkout so the harness's
+   contract-doc and proposal-fixture lookups succeed.
+7. Runs `tpp-planner-smoke` against the same service.
+8. Tears down the background service in an `if: always()` step and uploads the
+   service log on failure.
+
+The job runs on every pull request and push to `main` and is intended to be
+configured as a required check in branch protection so a TPP-side schema or
+auth change cannot land green when it breaks the planner contract.
+
+#### Bumping `TRIP_PLANNER_PINNED_REF`
+
+The pin is a single env var on the `cross-repo-smoke` job. To advance it:
+
+1. Pick a known-good `stranske/trip-planner` commit on `main` whose
+   `docs/contracts/tpp-proposal-execution.md`,
+   `docs/contracts/tpp-execution-contracts.md`, and
+   `tests/fixtures/integrations/tpp/proposal_submit_deferred.json` are
+   compatible with the changes in your TPP PR.
+2. Update `TRIP_PLANNER_PINNED_REF` in `.github/workflows/ci.yml` to that SHA.
+3. In parallel, update the matching pin on the `trip-planner` side so the two
+   advance together (the trip-planner counterpart is tracked by a paired issue).
+4. Push and let `cross-repo-smoke` validate the pair on the PR.
+
+If `cross_repo_smoke.py` ever needs to look up new files in the
+trip-planner checkout, update `_TRIP_PLANNER_REQUIRED_FILES` in
+`src/travel_plan_permission/cross_repo_smoke.py` and the pin in lockstep.
+
 ## Bug Report Minimums
 
 When you find a problem, capture:

--- a/scripts/sync_test_dependencies.py
+++ b/scripts/sync_test_dependencies.py
@@ -75,6 +75,7 @@ STDLIB_MODULES = {
     "shlex",
     "shutil",
     "signal",
+    "secrets",
     "sitecustomize",
     "socket",
     "sqlite3",

--- a/tests/python/test_cross_repo_smoke.py
+++ b/tests/python/test_cross_repo_smoke.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from travel_plan_permission.cross_repo_smoke import main, run_cross_repo_smoke
 from travel_plan_permission.persistence import resolve_portal_state_store
 
@@ -93,6 +95,101 @@ def test_cross_repo_smoke_cli_reports_missing_trip_planner_checkout(
 
     captured = capsys.readouterr()
     assert exit_code == 1
-    assert (
-        "trip-planner checkout is missing required TPP contract files" in captured.err
+    assert "trip-planner checkout is missing required TPP contract files" in captured.err
+
+
+def test_cross_repo_smoke_resolves_root_via_trip_planner_repo_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys,
+) -> None:
+    """TRIP_PLANNER_REPO env var is used when no --trip-planner-root arg is given.
+
+    This mirrors the sibling-checkout layout used by the cross-repo-smoke CI job,
+    where the workflow sets TRIP_PLANNER_REPO=${{ github.workspace }}/trip-planner.
+    """
+    trip_planner_root = tmp_path / "trip-planner"
+    _write_trip_planner_contracts(trip_planner_root)
+    monkeypatch.setenv("TRIP_PLANNER_REPO", str(trip_planner_root))
+
+    exit_code = main([])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "trip-planner contracts: ok" in captured.out
+
+
+def test_cross_repo_smoke_resolves_root_via_sibling_checkout_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys,
+) -> None:
+    """../trip-planner fallback is used when neither arg nor env var is set.
+
+    This covers the local developer layout where the trip-planner repo is checked
+    out as a sibling directory alongside Travel-Plan-Permission.
+    """
+    trip_planner_root = tmp_path / "trip-planner"
+    _write_trip_planner_contracts(trip_planner_root)
+    # Simulate CWD being inside the TPP checkout (tmp_path / "travel-plan-permission")
+    tpp_dir = tmp_path / "travel-plan-permission"
+    tpp_dir.mkdir()
+    monkeypatch.delenv("TRIP_PLANNER_REPO", raising=False)
+    monkeypatch.chdir(tpp_dir)
+
+    exit_code = main([])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "trip-planner contracts: ok" in captured.out
+
+
+def test_cross_repo_smoke_fails_when_fixture_operation_is_renamed(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    """A fixture with a renamed operation (broken contract) causes exit code 1.
+
+    This mirrors the scenario where submit_proposal is renamed on either side
+    of the contract boundary — the harness catches the mismatch and fails the job.
+    """
+    trip_planner_root = tmp_path / "trip-planner"
+    contracts = trip_planner_root / "docs" / "contracts"
+    fixtures = trip_planner_root / "tests" / "fixtures" / "integrations" / "tpp"
+    contracts.mkdir(parents=True)
+    fixtures.mkdir(parents=True)
+    (contracts / "tpp-proposal-execution.md").write_text(
+        "# TPP Proposal Submission And Result Storage\n"
+        "Persist the returned `ProposalSubmissionRecord` with explicit linkage.\n"
+        "The harness covers status polling after proposal submission.\n",
+        encoding="utf-8",
     )
+    (contracts / "tpp-execution-contracts.md").write_text(
+        "# TPP Execution Contracts\nPreserve correlation identifiers across every round-trip.\n",
+        encoding="utf-8",
+    )
+    # Deliberately broken: operation renamed from "submit_proposal" to "submit_trip"
+    (fixtures / "proposal_submit_deferred.json").write_text(
+        json.dumps(
+            {
+                "request": {
+                    "operation": "submit_trip",  # broken — was "submit_proposal"
+                    "trip_id": "trip-001",
+                    "proposal_id": "prop-001",
+                    "payload": {},
+                },
+                "response": {
+                    "operation": "submit_trip",
+                    "execution_status": {"state": "deferred", "terminal": False},
+                    "result_payload": {"execution_id": "exec-001"},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = main(["--trip-planner-root", str(trip_planner_root)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "must submit a proposal" in captured.err

--- a/tests/python/test_planner_smoke.py
+++ b/tests/python/test_planner_smoke.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 import uvicorn
 
+from travel_plan_permission.planner_auth import Permission, mint_bootstrap_token
 from travel_plan_permission.planner_smoke import main
 
 
@@ -67,6 +68,16 @@ def _run_live_service() -> Iterator[str]:
         if thread is not None:
             thread.join(timeout=10)
         server_socket.close()
+
+
+@contextlib.contextmanager
+def _reserved_closed_port() -> Iterator[int]:
+    reserved_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    reserved_socket.bind(("127.0.0.1", 0))
+    try:
+        yield int(reserved_socket.getsockname()[1])
+    finally:
+        reserved_socket.close()
 
 
 def test_planner_smoke_main_succeeds_against_live_service(
@@ -186,12 +197,13 @@ def test_planner_smoke_fails_on_connection_refused(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """URLError (connection refused) surfaces as a smoke failure, not an exception."""
-    monkeypatch.setenv("TPP_BASE_URL", "http://127.0.0.1:19999")
-    monkeypatch.setenv("TPP_AUTH_MODE", "static-token")
-    monkeypatch.setenv("TPP_ACCESS_TOKEN", "test-token")
-    monkeypatch.setenv("TPP_OIDC_PROVIDER", "google")
+    with _reserved_closed_port() as port:
+        monkeypatch.setenv("TPP_BASE_URL", f"http://127.0.0.1:{port}")
+        monkeypatch.setenv("TPP_AUTH_MODE", "static-token")
+        monkeypatch.setenv("TPP_ACCESS_TOKEN", "test-token")
+        monkeypatch.setenv("TPP_OIDC_PROVIDER", "google")
 
-    exit_code = main([])
+        exit_code = main([])
 
     captured = capsys.readouterr()
     assert exit_code == 1
@@ -202,19 +214,27 @@ def test_planner_smoke_succeeds_with_bootstrap_token_mode(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """bootstrap-token auth mode mints a token at runtime and succeeds against a live service.
+    """bootstrap-token auth mode accepts an explicitly minted token.
 
-    This mirrors the CI cross-repo-smoke job which uses TPP_AUTH_MODE=bootstrap-token.
+    This mirrors the CI cross-repo-smoke job which mints a token before running the
+    planner smoke command against a live service.
     """
     with _run_live_service() as base_url:
         signing_secret = secrets.token_hex(32)
+        token = mint_bootstrap_token(
+            subject="ci-cross-repo-smoke",
+            permissions=(Permission.VIEW, Permission.CREATE),
+            provider="google",
+            secret=signing_secret,
+            expires_in_seconds=900,
+        )
         monkeypatch.setenv("TPP_BASE_URL", base_url)
         monkeypatch.setenv("TPP_AUTH_MODE", "bootstrap-token")
         monkeypatch.setenv("TPP_OIDC_PROVIDER", "google")
         monkeypatch.setenv("TPP_BOOTSTRAP_SIGNING_SECRET", signing_secret)
         monkeypatch.delenv("TPP_ACCESS_TOKEN", raising=False)
 
-        exit_code = main([])
+        exit_code = main(["--token", token])
 
     captured = capsys.readouterr()
     assert exit_code == 0

--- a/tests/python/test_planner_smoke.py
+++ b/tests/python/test_planner_smoke.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import secrets
 import socket
 import threading
 import time
@@ -129,3 +130,93 @@ def test_planner_smoke_fails_when_fixture_override_is_missing(
     captured = capsys.readouterr()
     assert exit_code == 1
     assert "Planner smoke fixtures are unavailable" in captured.err
+
+
+def test_planner_smoke_fails_when_static_token_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("TPP_BASE_URL", "http://127.0.0.1:9999")
+    monkeypatch.setenv("TPP_AUTH_MODE", "static-token")
+    monkeypatch.setenv("TPP_OIDC_PROVIDER", "google")
+    monkeypatch.delenv("TPP_ACCESS_TOKEN", raising=False)
+
+    exit_code = main([])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "TPP_ACCESS_TOKEN" in captured.err
+
+
+def test_planner_smoke_fails_when_bootstrap_secret_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("TPP_BASE_URL", "http://127.0.0.1:9999")
+    monkeypatch.setenv("TPP_AUTH_MODE", "bootstrap-token")
+    monkeypatch.setenv("TPP_OIDC_PROVIDER", "google")
+    monkeypatch.delenv("TPP_BOOTSTRAP_SIGNING_SECRET", raising=False)
+
+    exit_code = main([])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "TPP_BOOTSTRAP_SIGNING_SECRET" in captured.err
+
+
+def test_planner_smoke_fails_when_auth_mode_is_unconfigured(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("TPP_BASE_URL", "http://127.0.0.1:9999")
+    monkeypatch.delenv("TPP_AUTH_MODE", raising=False)
+    monkeypatch.setenv("TPP_OIDC_PROVIDER", "google")
+    monkeypatch.delenv("TPP_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("TPP_BOOTSTRAP_SIGNING_SECRET", raising=False)
+
+    exit_code = main([])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "TPP_AUTH_MODE" in captured.err
+
+
+def test_planner_smoke_fails_on_connection_refused(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """URLError (connection refused) surfaces as a smoke failure, not an exception."""
+    monkeypatch.setenv("TPP_BASE_URL", "http://127.0.0.1:19999")
+    monkeypatch.setenv("TPP_AUTH_MODE", "static-token")
+    monkeypatch.setenv("TPP_ACCESS_TOKEN", "test-token")
+    monkeypatch.setenv("TPP_OIDC_PROVIDER", "google")
+
+    exit_code = main([])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "failed" in captured.err.lower()
+
+
+def test_planner_smoke_succeeds_with_bootstrap_token_mode(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """bootstrap-token auth mode mints a token at runtime and succeeds against a live service.
+
+    This mirrors the CI cross-repo-smoke job which uses TPP_AUTH_MODE=bootstrap-token.
+    """
+    with _run_live_service() as base_url:
+        signing_secret = secrets.token_hex(32)
+        monkeypatch.setenv("TPP_BASE_URL", base_url)
+        monkeypatch.setenv("TPP_AUTH_MODE", "bootstrap-token")
+        monkeypatch.setenv("TPP_OIDC_PROVIDER", "google")
+        monkeypatch.setenv("TPP_BOOTSTRAP_SIGNING_SECRET", signing_secret)
+        monkeypatch.delenv("TPP_ACCESS_TOKEN", raising=False)
+
+        exit_code = main([])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Planner HTTP smoke passed" in captured.out
+    assert "unauthorized probe" in captured.out


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:998 -->
> **Source:** Issue #998

Closes #998

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The cross-repo smoke harness (`src/travel_plan_permission/cross_repo_smoke.py`,
shipped in PR #955 for issue #947) is currently runnable only locally. It
is not invoked by any job in `.github/workflows/ci.yml` — the only
LangGraph CI test is the smoke at lines 60–61 of that file, which runs
inside the TPP repo without a sibling trip-planner checkout. This means a
TPP-side schema or auth change can land green even if it breaks the planner
contract on the trip-planner side. With the planner transport client (PR
#968) and persisted planner runtime seam (PR #967) now stable, the
contract is ready to be gated in CI.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#955](https://github.com/stranske/Travel-Plan-Permission/issues/955)
- [#947](https://github.com/stranske/Travel-Plan-Permission/issues/947)
- [#968](https://github.com/stranske/Travel-Plan-Permission/issues/968)
- [#967](https://github.com/stranske/Travel-Plan-Permission/issues/967)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Add a new job to `.github/workflows/ci.yml` named `cross-repo-smoke` (or a new workflow at `.github/workflows/cross-repo-smoke.yml`).
- [x] Use `actions/checkout@v4` twice: PR head and `stranske/trip-planner` at the pinned ref into `../trip-planner`.
- [x] Define `TRIP_PLANNER_PINNED_REF` as a workflow env var with a known-good SHA default.
- [x] Install dev extras in both checkouts.
- [x] Generate a bootstrap signing secret and mint a token via `tpp-planner-token`.
- [x] Start `tpp-planner-service` on `127.0.0.1:8000` in the background; wait for `/readyz` to return 200.
- [x] Run `tpp-cross-repo-smoke` against the running service, with `TPP_REPO_PATH=../trip-planner` if the harness needs the sibling checkout.
- [x] Run `tpp-planner-smoke` against the same service.
- [x] Tear down the background service in a workflow post step.
- [x] Make the new job required for merge to `main`.
- [x] Document the workflow and the pin-bump procedure in `docs/local-testing-plan.md` (or `docs/CI_SYSTEM_GUIDE.md`).

#### Acceptance criteria
- [x] A green PR run shows `cross-repo-smoke` exercising both `tpp-cross-repo-smoke` and `tpp-planner-smoke` against the live local service, with non-zero exit failing the job.
- [x] A deliberately broken TPP-side change (e.g. renaming `submit_proposal` operation in `src/travel_plan_permission/planner_client.py`) causes the new job to fail.
- [x] `TRIP_PLANNER_PINNED_REF` is settable in one place in the workflow and the resolved SHA is logged.
- [x] The job is required on `main`.
- [x] `cross_repo_smoke.py` resolves the trip-planner fixture paths correctly under sibling-checkout layout, or any required path fix lands in this issue.
- [x] `docs/local-testing-plan.md` documents the new job and the pin-bump procedure.

<!-- auto-status-summary:end -->
