### PR TITLE
Issue #1001: Validate approved_request_id linkage and block exports on mismatch

### DIFF
--- a/scripts/sync_test_dependencies.py
+++ b/scripts/sync_test_dependencies.py
@@ -55,6 +55,7 @@ STDLIB_MODULES = {
     "gc",
     "glob",
     "hashlib",
+    "html",
     "http",
     "importlib",
     "inspect",

--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -35,6 +35,7 @@ from .export import ExportService
 from .models import (
     ApprovalStatus,
     ExceptionRequest,
+    ExceptionStatus,
     ExceptionType,
     ExpenseCategory,
     ExpenseItem,
@@ -1179,9 +1180,118 @@ def _expense_export_artifacts(
     }
 
 
+@dataclass(frozen=True)
+class _ExpenseLinkageResolution:
+    """Resolved linkage metadata for an expense draft's `approved_request_id`."""
+
+    kind: str
+    status_value: str
+    is_approved: bool
+    traveler_name: str | None
+    trip_id: str | None
+
+
+def _resolve_expense_linkage(
+    proposal_store: PlannerProposalStore | None,
+    approved_request_id: str,
+) -> _ExpenseLinkageResolution | None:
+    if proposal_store is None:
+        return None
+    manager_review = proposal_store.lookup_manager_review(approved_request_id)
+    if manager_review is not None:
+        return _ExpenseLinkageResolution(
+            kind="manager_review",
+            status_value=manager_review.status.value,
+            is_approved=manager_review.status == ReviewStatus.APPROVED,
+            traveler_name=manager_review.trip_plan.traveler_name,
+            trip_id=manager_review.trip_plan.trip_id,
+        )
+    exception_requests = proposal_store.exception_requests_by_draft_id.get(approved_request_id)
+    if exception_requests:
+        approved = next(
+            (
+                request
+                for request in exception_requests
+                if request.status == ExceptionStatus.APPROVED
+            ),
+            None,
+        )
+        chosen = approved or exception_requests[-1]
+        traveler_name: str | None = None
+        trip_id: str | None = None
+        portal_draft = proposal_store.lookup_portal_draft(approved_request_id)
+        if portal_draft is None:
+            portal_draft = proposal_store.lookup_expense_draft(approved_request_id)
+        if portal_draft is not None:
+            traveler_value = portal_draft.answers.get("traveler_name")
+            trip_value = portal_draft.answers.get("trip_id")
+            traveler_name = str(traveler_value) if traveler_value else None
+            trip_id = str(trip_value) if trip_value else None
+        return _ExpenseLinkageResolution(
+            kind="exception_request",
+            status_value=chosen.status.value,
+            is_approved=chosen.status == ExceptionStatus.APPROVED,
+            traveler_name=traveler_name,
+            trip_id=trip_id,
+        )
+    return None
+
+
+def _validate_expense_linkage(
+    proposal_store: PlannerProposalStore | None,
+    answers: dict[str, object],
+) -> list[str]:
+    raw = answers.get("approved_request_id")
+    if not isinstance(raw, str) or not raw.strip():
+        return []
+    if proposal_store is None:
+        return []
+    approved_request_id = raw.strip()
+    resolution = _resolve_expense_linkage(proposal_store, approved_request_id)
+    if resolution is None:
+        return [
+            f"Approved request id '{approved_request_id}' was not found in the "
+            "manager-review or exception-request stores."
+        ]
+    errors: list[str] = []
+    if not resolution.is_approved:
+        errors.append(
+            f"Approved request id '{approved_request_id}' was found in the "
+            f"{resolution.kind} store but its status is '{resolution.status_value}', "
+            "not approved."
+        )
+    traveler_value = answers.get("traveler_name")
+    if (
+        resolution.traveler_name is not None
+        and isinstance(traveler_value, str)
+        and traveler_value
+        and resolution.traveler_name != traveler_value
+    ):
+        errors.append(
+            f"Approved request id '{approved_request_id}' is for traveler "
+            f"'{resolution.traveler_name}', but the expense draft lists traveler "
+            f"'{traveler_value}'."
+        )
+    trip_value = answers.get("trip_id")
+    if (
+        resolution.trip_id is not None
+        and isinstance(trip_value, str)
+        and trip_value
+        and resolution.trip_id != trip_value
+    ):
+        errors.append(
+            f"Approved request id '{approved_request_id}' is for trip "
+            f"'{resolution.trip_id}', but the expense draft lists trip "
+            f"'{trip_value}'."
+        )
+    return errors
+
+
 def _expense_review_state(
     draft_id: str,
     answers: dict[str, object],
+    *,
+    proposal_store: PlannerProposalStore | None = None,
 ) -> ExpensePortalReviewState:
     missing_fields = [
         field_name for field_name in _EXPENSE_REQUIRED_FIELDS if not answers.get(field_name)
@@ -1192,6 +1302,10 @@ def _expense_review_state(
     receipt_extraction: ReceiptExtractionResult | None = None
     expense_report: ExpenseReport | None = None
     artifacts: dict[str, PortalArtifact] = {}
+
+    linkage_errors = _validate_expense_linkage(proposal_store, answers)
+    validation_errors.extend(linkage_errors)
+    linkage_blocks_export = bool(linkage_errors)
 
     ocr_text = answers.get("receipt_ocr_text")
     if isinstance(ocr_text, str) and ocr_text.strip():
@@ -1255,37 +1369,38 @@ def _expense_review_state(
                     "Receipt missing: reviewers should hold reimbursement until the traveler uploads support."
                 )
 
-            expense = ExpenseItem(
-                category=category,
-                description=str(answers["expense_description"]),
-                vendor=str(answers.get("expense_vendor") or "") or None,
-                amount=expense_amount,
-                expense_date=expense_date,
-                receipt_attached=receipt is not None,
-                receipt_url=str(receipt_reference) if receipt_reference else None,
-                receipt_references=[receipt] if receipt is not None else [],
-                third_party_paid_explanation=(
-                    str(answers["third_party_paid_explanation"])
-                    if answers.get("third_party_paid_explanation")
-                    else None
-                ),
-            )
-            expense_report = ExpenseReport(
-                report_id=f"EXP-{draft_id.upper()}",
-                trip_id=str(answers["trip_id"]),
-                traveler_name=str(answers["traveler_name"]),
-                cost_center=str(answers.get("cost_center") or "") or None,
-                expenses=[expense],
-            )
-            expense_report = ApprovalEngine.from_file().evaluate_report(expense_report)
-            if expense_report.approval_status == ApprovalStatus.FLAGGED:
-                review_warnings.append(
-                    "Policy warning: manager or accounting review is required before reimbursement."
+            if not linkage_blocks_export:
+                expense = ExpenseItem(
+                    category=category,
+                    description=str(answers["expense_description"]),
+                    vendor=str(answers.get("expense_vendor") or "") or None,
+                    amount=expense_amount,
+                    expense_date=expense_date,
+                    receipt_attached=receipt is not None,
+                    receipt_url=str(receipt_reference) if receipt_reference else None,
+                    receipt_references=[receipt] if receipt is not None else [],
+                    third_party_paid_explanation=(
+                        str(answers["third_party_paid_explanation"])
+                        if answers.get("third_party_paid_explanation")
+                        else None
+                    ),
                 )
-            artifacts = _expense_export_artifacts(
-                draft_id=draft_id,
-                expense_report=expense_report,
-            )
+                expense_report = ExpenseReport(
+                    report_id=f"EXP-{draft_id.upper()}",
+                    trip_id=str(answers["trip_id"]),
+                    traveler_name=str(answers["traveler_name"]),
+                    cost_center=str(answers.get("cost_center") or "") or None,
+                    expenses=[expense],
+                )
+                expense_report = ApprovalEngine.from_file().evaluate_report(expense_report)
+                if expense_report.approval_status == ApprovalStatus.FLAGGED:
+                    review_warnings.append(
+                        "Policy warning: manager or accounting review is required before reimbursement."
+                    )
+                artifacts = _expense_export_artifacts(
+                    draft_id=draft_id,
+                    expense_report=expense_report,
+                )
         except ValidationError as exc:
             validation_errors.extend(
                 f"{'.'.join(str(part) for part in error['loc'])}: {error['msg']}"
@@ -1511,7 +1626,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
     @app.post("/portal/expenses/review")
     async def portal_expense_review(request: Request) -> Response:
         answers = _expense_answers_from_encoded_body(await request.body())
-        review = _expense_review_state("preview", answers)
+        review = _expense_review_state("preview", answers, proposal_store=proposal_store)
         if review.missing_fields or review.validation_errors:
             return _TEMPLATES.TemplateResponse(
                 request=request,
@@ -1520,7 +1635,9 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
                 status_code=status.HTTP_400_BAD_REQUEST,
             )
         draft = proposal_store.save_expense_draft(answers)
-        persisted_review = _expense_review_state(draft.draft_id, answers)
+        persisted_review = _expense_review_state(
+            draft.draft_id, answers, proposal_store=proposal_store
+        )
         if persisted_review.artifacts:
             proposal_store.cache_expense_artifacts(draft.draft_id, persisted_review.artifacts)
         return RedirectResponse(
@@ -1582,7 +1699,9 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"No expense portal draft found for '{draft_id}'.",
             )
-        review = _expense_review_state(draft.draft_id, draft.answers)
+        review = _expense_review_state(
+            draft.draft_id, draft.answers, proposal_store=proposal_store
+        )
         if review.artifacts and not draft.cached_artifacts:
             proposal_store.cache_expense_artifacts(draft.draft_id, review.artifacts)
         return _TEMPLATES.TemplateResponse(
@@ -2017,7 +2136,9 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
             )
         artifacts = draft.cached_artifacts
         if not artifacts:
-            review = _expense_review_state(draft.draft_id, draft.answers)
+            review = _expense_review_state(
+                draft.draft_id, draft.answers, proposal_store=proposal_store
+            )
             artifacts = review.artifacts
             if artifacts:
                 proposal_store.cache_expense_artifacts(draft.draft_id, artifacts)

--- a/src/travel_plan_permission/models.py
+++ b/src/travel_plan_permission/models.py
@@ -160,6 +160,7 @@ class ExceptionStatus(StrEnum):
     APPROVED = "approved"
     REJECTED = "rejected"
     ESCALATED = "escalated"
+    WITHDRAWN = "withdrawn"
 
 
 class ExceptionApprovalRecord(BaseModel):

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -867,8 +867,7 @@ def test_expense_portal_blocks_export_when_linkage_not_approved(
     assert response.status_code == 400
     assert (
         f"Approved request id 'REQ-410' was found in the manager_review store but "
-        f"its status is '{status_value.value}', not approved."
-        in html.unescape(response.text)
+        f"its status is '{status_value.value}', not approved." in html.unescape(response.text)
     )
     assert not store.expense_drafts_by_id
 
@@ -883,8 +882,7 @@ def test_expense_portal_blocks_export_when_traveler_name_mismatch() -> None:
     assert response.status_code == 400
     assert (
         "Approved request id 'REQ-410' is for traveler 'Jamie Park', but the "
-        "expense draft lists traveler 'Alex Rivera'."
-        in html.unescape(response.text)
+        "expense draft lists traveler 'Alex Rivera'." in html.unescape(response.text)
     )
     assert not store.expense_drafts_by_id
 
@@ -899,17 +897,14 @@ def test_expense_portal_blocks_export_when_trip_id_mismatch() -> None:
     assert response.status_code == 400
     assert (
         "Approved request id 'REQ-410' is for trip 'TRIP-OTHER', but the "
-        "expense draft lists trip 'TRIP-410'."
-        in html.unescape(response.text)
+        "expense draft lists trip 'TRIP-410'." in html.unescape(response.text)
     )
     assert not store.expense_drafts_by_id
 
 
 def test_expense_portal_resolves_linkage_via_exception_request_store() -> None:
     store = PlannerProposalStore()
-    portal_draft = store.save_portal_draft(
-        {"traveler_name": "Alex Rivera", "trip_id": "TRIP-410"}
-    )
+    portal_draft = store.save_portal_draft({"traveler_name": "Alex Rivera", "trip_id": "TRIP-410"})
     store.create_exception_request(
         portal_draft.draft_id,
         http_service.ExceptionRequest(
@@ -940,9 +935,7 @@ def test_expense_portal_resolves_linkage_via_exception_request_store() -> None:
 
 def test_expense_portal_blocks_export_when_exception_request_pending() -> None:
     store = PlannerProposalStore()
-    portal_draft = store.save_portal_draft(
-        {"traveler_name": "Alex Rivera", "trip_id": "TRIP-410"}
-    )
+    portal_draft = store.save_portal_draft({"traveler_name": "Alex Rivera", "trip_id": "TRIP-410"})
     store.create_exception_request(
         portal_draft.draft_id,
         http_service.ExceptionRequest(
@@ -965,6 +958,38 @@ def test_expense_portal_blocks_export_when_exception_request_pending() -> None:
     assert (
         f"Approved request id '{portal_draft.draft_id}' was found in the "
         "exception_request store but its status is 'pending', not approved."
+        in html.unescape(response.text)
+    )
+    assert not store.expense_drafts_by_id
+
+
+def test_expense_portal_blocks_export_when_exception_request_withdrawn() -> None:
+    store = PlannerProposalStore()
+    portal_draft = store.save_portal_draft({"traveler_name": "Alex Rivera", "trip_id": "TRIP-410"})
+    store.create_exception_request(
+        portal_draft.draft_id,
+        http_service.ExceptionRequest(
+            type=http_service.ExceptionType.ADVANCE_BOOKING,
+            justification=(
+                "Withdrawn exception request that must not unlock reimbursement "
+                "exports even though it was previously submitted."
+            ),
+            requestor="alex.rivera",
+            amount="100",
+        ),
+    )
+    raw = store.exception_requests_by_draft_id[portal_draft.draft_id][0]
+    raw.status = http_service.ExceptionStatus.WITHDRAWN
+    payload = _expense_form_payload()
+    payload["approved_request_id"] = portal_draft.draft_id
+    client = TestClient(create_app(store))
+
+    response = client.post("/portal/expenses/review", data=payload)
+
+    assert response.status_code == 400
+    assert (
+        f"Approved request id '{portal_draft.draft_id}' was found in the "
+        "exception_request store but its status is 'withdrawn', not approved."
         in html.unescape(response.text)
     )
     assert not store.expense_drafts_by_id

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import html
 import json
 import re
 import subprocess
@@ -12,6 +13,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 
 import jwt
+import pytest
 from cryptography.hazmat.primitives.asymmetric import rsa
 from fastapi.testclient import TestClient
 
@@ -222,6 +224,37 @@ def _expense_form_payload() -> dict[str, str]:
         "manager_disposition": "Need lodging policy confirmation",
         "accounting_disposition": "Queue next export batch",
     }
+
+
+def _seed_manager_review(
+    store: PlannerProposalStore,
+    *,
+    review_id: str = "REQ-410",
+    draft_id: str = "draft-410",
+    traveler_name: str = "Alex Rivera",
+    trip_id: str = "TRIP-410",
+    status: http_service.ReviewStatus = http_service.ReviewStatus.APPROVED,
+) -> http_service.ReviewRequest:
+    fixture = _load_fixture("proposal_submission.json")
+    trip_plan = http_service.TripPlan.model_validate(fixture)
+    trip_plan = trip_plan.model_copy(update={"trip_id": trip_id, "traveler_name": traveler_name})
+    snapshot = http_service.get_policy_snapshot(trip_plan)
+    result = http_service.check_trip_plan(trip_plan)
+    timestamp = datetime.now(UTC)
+    review = http_service.ReviewRequest(
+        review_id=review_id,
+        draft_id=draft_id,
+        trip_plan=trip_plan,
+        policy_snapshot=snapshot,
+        policy_result=result,
+        status=status,
+        submitted_at=timestamp,
+        updated_at=timestamp,
+        history=(),
+    )
+    store.manager_reviews.reviews_by_id[review_id] = review
+    store.manager_reviews.review_ids_by_draft_id[draft_id] = review_id
+    return review
 
 
 def test_readyz_reports_missing_runtime_config(monkeypatch) -> None:
@@ -662,6 +695,7 @@ def test_expense_portal_form_renders() -> None:
 
 def test_expense_portal_review_surfaces_missing_receipt_warning() -> None:
     store = PlannerProposalStore()
+    _seed_manager_review(store)
     client = TestClient(create_app(store))
     payload = _expense_form_payload()
     payload.pop("receipt_file_reference")
@@ -688,6 +722,7 @@ def test_expense_portal_review_surfaces_missing_receipt_warning() -> None:
 
 def test_expense_portal_generates_exports_and_policy_warning() -> None:
     store = PlannerProposalStore()
+    _seed_manager_review(store)
     client = TestClient(create_app(store))
     payload = _expense_form_payload()
     payload["expense_amount"] = "7500.00"
@@ -722,7 +757,9 @@ def test_expense_portal_generates_exports_and_policy_warning() -> None:
 
 
 def test_expense_portal_invalid_amount_returns_validation_error() -> None:
-    client = TestClient(create_app())
+    store = PlannerProposalStore()
+    _seed_manager_review(store)
+    client = TestClient(create_app(store))
     payload = _expense_form_payload()
     payload["expense_amount"] = "not-a-decimal"
 
@@ -735,7 +772,9 @@ def test_expense_portal_invalid_amount_returns_validation_error() -> None:
 def test_expense_portal_missing_approval_rules_returns_validation_error(
     monkeypatch,
 ) -> None:
-    client = TestClient(create_app())
+    store = PlannerProposalStore()
+    _seed_manager_review(store)
+    client = TestClient(create_app(store))
     payload = _expense_form_payload()
 
     monkeypatch.setattr("travel_plan_permission.approval._default_rules_path", lambda: None)
@@ -752,6 +791,7 @@ def test_expense_portal_missing_approval_rules_returns_validation_error(
 
 def test_expense_portal_caches_artifacts_with_persisted_draft_id() -> None:
     store = PlannerProposalStore()
+    _seed_manager_review(store)
     client = TestClient(create_app(store))
 
     response = client.post(
@@ -776,6 +816,7 @@ def test_expense_portal_caches_artifacts_with_persisted_draft_id() -> None:
 
 def test_expense_portal_rejects_invalid_decimal_input_without_saving() -> None:
     store = PlannerProposalStore()
+    _seed_manager_review(store)
     client = TestClient(create_app(store))
     payload = _expense_form_payload()
     payload["expense_amount"] = "not-a-decimal"
@@ -788,6 +829,144 @@ def test_expense_portal_rejects_invalid_decimal_input_without_saving() -> None:
 
     assert response.status_code == 400
     assert "not-a-decimal" in response.text
+    assert not store.expense_drafts_by_id
+
+
+def test_expense_portal_blocks_export_when_approved_request_id_unknown() -> None:
+    store = PlannerProposalStore()
+    client = TestClient(create_app(store))
+    payload = _expense_form_payload()
+
+    response = client.post("/portal/expenses/review", data=payload)
+
+    assert response.status_code == 400
+    assert (
+        "Approved request id 'REQ-410' was not found in the manager-review or "
+        "exception-request stores." in html.unescape(response.text)
+    )
+    assert not store.expense_drafts_by_id
+
+
+@pytest.mark.parametrize(
+    "status_value",
+    [
+        http_service.ReviewStatus.PENDING_MANAGER_REVIEW,
+        http_service.ReviewStatus.REJECTED,
+        http_service.ReviewStatus.CHANGES_REQUESTED,
+    ],
+)
+def test_expense_portal_blocks_export_when_linkage_not_approved(
+    status_value: http_service.ReviewStatus,
+) -> None:
+    store = PlannerProposalStore()
+    _seed_manager_review(store, status=status_value)
+    client = TestClient(create_app(store))
+
+    response = client.post("/portal/expenses/review", data=_expense_form_payload())
+
+    assert response.status_code == 400
+    assert (
+        f"Approved request id 'REQ-410' was found in the manager_review store but "
+        f"its status is '{status_value.value}', not approved."
+        in html.unescape(response.text)
+    )
+    assert not store.expense_drafts_by_id
+
+
+def test_expense_portal_blocks_export_when_traveler_name_mismatch() -> None:
+    store = PlannerProposalStore()
+    _seed_manager_review(store, traveler_name="Jamie Park")
+    client = TestClient(create_app(store))
+
+    response = client.post("/portal/expenses/review", data=_expense_form_payload())
+
+    assert response.status_code == 400
+    assert (
+        "Approved request id 'REQ-410' is for traveler 'Jamie Park', but the "
+        "expense draft lists traveler 'Alex Rivera'."
+        in html.unescape(response.text)
+    )
+    assert not store.expense_drafts_by_id
+
+
+def test_expense_portal_blocks_export_when_trip_id_mismatch() -> None:
+    store = PlannerProposalStore()
+    _seed_manager_review(store, trip_id="TRIP-OTHER")
+    client = TestClient(create_app(store))
+
+    response = client.post("/portal/expenses/review", data=_expense_form_payload())
+
+    assert response.status_code == 400
+    assert (
+        "Approved request id 'REQ-410' is for trip 'TRIP-OTHER', but the "
+        "expense draft lists trip 'TRIP-410'."
+        in html.unescape(response.text)
+    )
+    assert not store.expense_drafts_by_id
+
+
+def test_expense_portal_resolves_linkage_via_exception_request_store() -> None:
+    store = PlannerProposalStore()
+    portal_draft = store.save_portal_draft(
+        {"traveler_name": "Alex Rivera", "trip_id": "TRIP-410"}
+    )
+    store.create_exception_request(
+        portal_draft.draft_id,
+        http_service.ExceptionRequest(
+            type=http_service.ExceptionType.ADVANCE_BOOKING,
+            justification=(
+                "Reimbursement cycle requires the prior advance-booking exception "
+                "to ride alongside the receipt batch for this trip."
+            ),
+            requestor="alex.rivera",
+            amount="100",
+        ),
+    )
+    raw = store.exception_requests_by_draft_id[portal_draft.draft_id][0]
+    raw.status = http_service.ExceptionStatus.APPROVED
+    payload = _expense_form_payload()
+    payload["approved_request_id"] = portal_draft.draft_id
+    client = TestClient(create_app(store))
+
+    response = client.post(
+        "/portal/expenses/review",
+        data=payload,
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert "Download CSV" in response.text
+
+
+def test_expense_portal_blocks_export_when_exception_request_pending() -> None:
+    store = PlannerProposalStore()
+    portal_draft = store.save_portal_draft(
+        {"traveler_name": "Alex Rivera", "trip_id": "TRIP-410"}
+    )
+    store.create_exception_request(
+        portal_draft.draft_id,
+        http_service.ExceptionRequest(
+            type=http_service.ExceptionType.ADVANCE_BOOKING,
+            justification=(
+                "Pending exception request that should not unlock reimbursement "
+                "exports until manager approval is recorded."
+            ),
+            requestor="alex.rivera",
+            amount="100",
+        ),
+    )
+    payload = _expense_form_payload()
+    payload["approved_request_id"] = portal_draft.draft_id
+    client = TestClient(create_app(store))
+
+    response = client.post("/portal/expenses/review", data=payload)
+
+    assert response.status_code == 400
+    assert (
+        f"Approved request id '{portal_draft.draft_id}' was found in the "
+        "exception_request store but its status is 'pending', not approved."
+        in html.unescape(response.text)
+    )
     assert not store.expense_drafts_by_id
 
 


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:1001 -->
> **Source:** Issue #1001

Closes #1001

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`approved_request_id` is listed in `_EXPENSE_REQUIRED_FIELDS`
(`src/travel_plan_permission/http_service.py:212-213`) and the expense
review path checks that the field is non-empty
(`_expense_review_state` lines 1109–1111), but no code path verifies
that the supplied `approved_request_id`:

1. Corresponds to a real manager review or approved request that exists
   in the store.
2. Is currently in an `APPROVED` state (not `PENDING`, `REJECTED`, or
   `WITHDRAWN`).
3. Belongs to the same traveler / trip / cost-center context that the
   expense draft is claiming.

`_expense_review_state` builds an `ExpenseReport` directly from form
data (lines 1196–1202) and immediately exports CSV/XLSX artifacts via
`_expense_export_artifacts` (lines 1208–1211) without consulting the
manager-review or exception-request store. That leaves the
reimbursement workflow open to:

- Free-form `approved_request_id` strings that point at nothing.
- Linkage to an unapproved or rejected request.
- Expense reports filed against a different traveler or trip than the
  approved request was for.

This is a correctness and integrity hole, and it blocks any meaningful
audit of the reimbursement chain.

Declared changed-file scope for keepalive scope enforcement:

- `src/travel_plan_permission/http_service.py`
- `tests/python/test_http_service.py`
- `scripts/sync_test_dependencies.py`

#### Tasks
- [x] In `_expense_review_state`, after the `missing_fields` guard, look up `approved_request_id` against the manager-review store and the exception-request store (whichever owns it; investigate both).
- [x] Add a `validation_errors` entry when the id resolves to nothing in either store.
- [x] Add a `validation_errors` entry when the resolved request is not in `APPROVED` state, naming the actual state.
- [x] Add a `validation_errors` entry when the resolved request's `traveler_name` (or equivalent) does not match the expense draft's `traveler_name`.
- [x] Add a `validation_errors` entry when the resolved request's `trip_id` does not match the expense draft's `trip_id`.
- [x] Suppress `_expense_export_artifacts` and `expense_report` construction when any of the linkage validation errors are set — do not generate a CSV/XLSX for a draft whose linkage is bad.
- [x] Surface the linkage validation errors through the existing `ExpensePortalReviewState.validation_errors` channel so the portal review template can render them.
- [x] Add unit tests for: missing linkage; unapproved linkage (`PENDING`, `REJECTED`, `WITHDRAWN` each); traveler mismatch; trip mismatch; happy path with a properly approved and matching request.
- [x] Add an integration test that submits an expense draft with a bad linkage through the portal route and asserts the export is blocked.

#### Acceptance criteria
- [x] An expense draft whose `approved_request_id` does not exist in any approval store produces a `validation_errors` entry naming the missing id and no export artifacts are generated.
- [x] An expense draft linked to a `PENDING`, `REJECTED`, or `WITHDRAWN` request produces a `validation_errors` entry naming the actual status and no export artifacts are generated.
- [x] An expense draft whose traveler does not match the linked approved request produces a `validation_errors` entry and no export artifacts.
- [x] An expense draft whose trip does not match the linked approved request produces a `validation_errors` entry and no export artifacts.
- [x] A correctly-linked, approved, traveler-and-trip-matching expense draft produces a populated `ExpenseReport` and CSV/XLSX artifacts as today.
- [x] All listed unit and integration tests pass in CI.
- [x] No existing test that depended on the un-validated path regresses without an explicit acceptance update.

<!-- auto-status-summary:end -->