### PR TITLE
Issue #1001 follow-up: cover ExceptionStatus.REJECTED and add direct _expense_review_state unit tests

### DIFF
--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -1699,9 +1699,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"No expense portal draft found for '{draft_id}'.",
             )
-        review = _expense_review_state(
-            draft.draft_id, draft.answers, proposal_store=proposal_store
-        )
+        review = _expense_review_state(draft.draft_id, draft.answers, proposal_store=proposal_store)
         if review.artifacts and not draft.cached_artifacts:
             proposal_store.cache_expense_artifacts(draft.draft_id, review.artifacts)
         return _TEMPLATES.TemplateResponse(

--- a/src/travel_plan_permission/planner_auth.py
+++ b/src/travel_plan_permission/planner_auth.py
@@ -478,9 +478,7 @@ def authenticate_request(
             metadata.update(
                 {
                     "provider": known_context.provider,
-                    "permissions": [
-                        permission.value for permission in known_context.permissions
-                    ],
+                    "permissions": [permission.value for permission in known_context.permissions],
                 }
             )
         audit.write_audit_event(

--- a/tests/python/test_audit.py
+++ b/tests/python/test_audit.py
@@ -334,9 +334,7 @@ class TestExportCLI:
         )
         assert rc == 3
 
-    def test_export_main_returns_3_when_audit_events_columns_mismatch(
-        self, tmp_path: Path
-    ) -> None:
+    def test_export_main_returns_3_when_audit_events_columns_mismatch(self, tmp_path: Path) -> None:
         store_path = tmp_path / "bad-schema.sqlite3"
         conn = sqlite3.connect(store_path)
         try:

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -933,7 +933,17 @@ def test_expense_portal_resolves_linkage_via_exception_request_store() -> None:
     assert "Download CSV" in response.text
 
 
-def test_expense_portal_blocks_export_when_exception_request_pending() -> None:
+@pytest.mark.parametrize(
+    "exception_status",
+    [
+        http_service.ExceptionStatus.PENDING,
+        http_service.ExceptionStatus.REJECTED,
+        http_service.ExceptionStatus.WITHDRAWN,
+    ],
+)
+def test_expense_portal_blocks_export_when_exception_request_unapproved(
+    exception_status: http_service.ExceptionStatus,
+) -> None:
     store = PlannerProposalStore()
     portal_draft = store.save_portal_draft({"traveler_name": "Alex Rivera", "trip_id": "TRIP-410"})
     store.create_exception_request(
@@ -941,45 +951,15 @@ def test_expense_portal_blocks_export_when_exception_request_pending() -> None:
         http_service.ExceptionRequest(
             type=http_service.ExceptionType.ADVANCE_BOOKING,
             justification=(
-                "Pending exception request that should not unlock reimbursement "
-                "exports until manager approval is recorded."
-            ),
-            requestor="alex.rivera",
-            amount="100",
-        ),
-    )
-    payload = _expense_form_payload()
-    payload["approved_request_id"] = portal_draft.draft_id
-    client = TestClient(create_app(store))
-
-    response = client.post("/portal/expenses/review", data=payload)
-
-    assert response.status_code == 400
-    assert (
-        f"Approved request id '{portal_draft.draft_id}' was found in the "
-        "exception_request store but its status is 'pending', not approved."
-        in html.unescape(response.text)
-    )
-    assert not store.expense_drafts_by_id
-
-
-def test_expense_portal_blocks_export_when_exception_request_withdrawn() -> None:
-    store = PlannerProposalStore()
-    portal_draft = store.save_portal_draft({"traveler_name": "Alex Rivera", "trip_id": "TRIP-410"})
-    store.create_exception_request(
-        portal_draft.draft_id,
-        http_service.ExceptionRequest(
-            type=http_service.ExceptionType.ADVANCE_BOOKING,
-            justification=(
-                "Withdrawn exception request that must not unlock reimbursement "
-                "exports even though it was previously submitted."
+                f"Exception request in '{exception_status.value}' state must not "
+                "unlock reimbursement exports until manager approval is recorded."
             ),
             requestor="alex.rivera",
             amount="100",
         ),
     )
     raw = store.exception_requests_by_draft_id[portal_draft.draft_id][0]
-    raw.status = http_service.ExceptionStatus.WITHDRAWN
+    raw.status = exception_status
     payload = _expense_form_payload()
     payload["approved_request_id"] = portal_draft.draft_id
     client = TestClient(create_app(store))
@@ -989,10 +969,143 @@ def test_expense_portal_blocks_export_when_exception_request_withdrawn() -> None
     assert response.status_code == 400
     assert (
         f"Approved request id '{portal_draft.draft_id}' was found in the "
-        "exception_request store but its status is 'withdrawn', not approved."
-        in html.unescape(response.text)
+        f"exception_request store but its status is '{exception_status.value}', "
+        "not approved." in html.unescape(response.text)
     )
     assert not store.expense_drafts_by_id
+
+
+def _seed_exception_request(
+    store: PlannerProposalStore,
+    *,
+    traveler_name: str = "Alex Rivera",
+    trip_id: str = "TRIP-410",
+    status: http_service.ExceptionStatus = http_service.ExceptionStatus.APPROVED,
+    justification: str = "Reimbursement cycle requires the prior advance-booking exception.",
+) -> str:
+    portal_draft = store.save_portal_draft({"traveler_name": traveler_name, "trip_id": trip_id})
+    store.create_exception_request(
+        portal_draft.draft_id,
+        http_service.ExceptionRequest(
+            type=http_service.ExceptionType.ADVANCE_BOOKING,
+            justification=justification,
+            requestor="alex.rivera",
+            amount="100",
+        ),
+    )
+    raw = store.exception_requests_by_draft_id[portal_draft.draft_id][0]
+    raw.status = status
+    return portal_draft.draft_id
+
+
+def test_expense_review_state_blocks_artifacts_when_linkage_missing() -> None:
+    store = PlannerProposalStore()
+    answers = _expense_form_payload()
+
+    state = http_service._expense_review_state(
+        "draft-410",
+        answers,
+        proposal_store=store,
+    )
+
+    assert any(
+        "was not found in the manager-review or exception-request stores" in error
+        for error in state.validation_errors
+    )
+    assert state.expense_report is None
+    assert state.artifacts == {}
+
+
+def test_expense_review_state_blocks_artifacts_when_manager_review_unapproved() -> None:
+    store = PlannerProposalStore()
+    _seed_manager_review(store, status=http_service.ReviewStatus.PENDING_MANAGER_REVIEW)
+    answers = _expense_form_payload()
+
+    state = http_service._expense_review_state(
+        "draft-410",
+        answers,
+        proposal_store=store,
+    )
+
+    assert any(
+        "manager_review store but its status is 'pending_manager_review'" in error
+        for error in state.validation_errors
+    )
+    assert state.expense_report is None
+    assert state.artifacts == {}
+
+
+def test_expense_review_state_blocks_artifacts_when_exception_request_rejected() -> None:
+    store = PlannerProposalStore()
+    draft_id = _seed_exception_request(store, status=http_service.ExceptionStatus.REJECTED)
+    answers = _expense_form_payload()
+    answers["approved_request_id"] = draft_id
+
+    state = http_service._expense_review_state(
+        "draft-410",
+        answers,
+        proposal_store=store,
+    )
+
+    assert any(
+        "exception_request store but its status is 'rejected'" in error
+        for error in state.validation_errors
+    )
+    assert state.expense_report is None
+    assert state.artifacts == {}
+
+
+def test_expense_review_state_blocks_artifacts_on_traveler_mismatch() -> None:
+    store = PlannerProposalStore()
+    _seed_manager_review(store, traveler_name="Jamie Park")
+    answers = _expense_form_payload()
+
+    state = http_service._expense_review_state(
+        "draft-410",
+        answers,
+        proposal_store=store,
+    )
+
+    assert any("is for traveler 'Jamie Park'" in error for error in state.validation_errors)
+    assert state.expense_report is None
+    assert state.artifacts == {}
+
+
+def test_expense_review_state_blocks_artifacts_on_trip_mismatch() -> None:
+    store = PlannerProposalStore()
+    _seed_manager_review(store, trip_id="TRIP-OTHER")
+    answers = _expense_form_payload()
+
+    state = http_service._expense_review_state(
+        "draft-410",
+        answers,
+        proposal_store=store,
+    )
+
+    assert any("is for trip 'TRIP-OTHER'" in error for error in state.validation_errors)
+    assert state.expense_report is None
+    assert state.artifacts == {}
+
+
+def test_expense_review_state_emits_artifacts_when_linkage_valid() -> None:
+    store = PlannerProposalStore()
+    _seed_manager_review(store)
+    answers = _expense_form_payload()
+
+    state = http_service._expense_review_state(
+        "draft-410",
+        answers,
+        proposal_store=store,
+    )
+
+    linkage_errors = [
+        error
+        for error in state.validation_errors
+        if "approved_request_id" in error.lower() or "approved request id" in error
+    ]
+    assert linkage_errors == []
+    assert state.expense_report is not None
+    assert state.artifacts != {}
 
 
 def test_portal_draft_validation_returns_bad_request_without_saving() -> None:

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -1138,6 +1138,32 @@ def test_expense_review_state_emits_artifacts_when_linkage_valid() -> None:
     assert state.artifacts != {}
 
 
+def test_expense_portal_detail_surfaces_validation_errors_when_approval_rescinded() -> None:
+    """GET detail page re-validates linkage and renders errors even for saved drafts."""
+    store = PlannerProposalStore()
+    _seed_manager_review(store)
+    client = TestClient(create_app(store))
+
+    # Save a valid expense draft while approval is still active.
+    save_response = client.post(
+        "/portal/expenses/review",
+        data=_expense_form_payload(),
+        follow_redirects=False,
+    )
+    assert save_response.status_code == 303
+    location = save_response.headers["location"]
+    draft_id = location.rstrip("/").split("/")[-1]
+
+    # Rescind the approval by overwriting the stored review with REJECTED status.
+    _seed_manager_review(store, status=http_service.ReviewStatus.REJECTED)
+
+    # GET the detail page — must re-validate and surface the new linkage error.
+    detail_response = client.get(f"/portal/expenses/{draft_id}")
+    assert detail_response.status_code == 200
+    assert "Validation notes" in detail_response.text
+    assert "status is 'rejected', not approved" in html.unescape(detail_response.text)
+
+
 def test_portal_draft_validation_returns_bad_request_without_saving() -> None:
     store = PlannerProposalStore()
     client = TestClient(create_app(store))

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -1055,6 +1055,36 @@ def test_expense_review_state_blocks_artifacts_when_exception_request_rejected()
     assert state.artifacts == {}
 
 
+@pytest.mark.parametrize(
+    "exception_status",
+    [
+        http_service.ExceptionStatus.PENDING,
+        http_service.ExceptionStatus.REJECTED,
+        http_service.ExceptionStatus.WITHDRAWN,
+    ],
+)
+def test_expense_review_state_blocks_artifacts_when_exception_request_unapproved(
+    exception_status: http_service.ExceptionStatus,
+) -> None:
+    store = PlannerProposalStore()
+    draft_id = _seed_exception_request(store, status=exception_status)
+    answers = _expense_form_payload()
+    answers["approved_request_id"] = draft_id
+
+    state = http_service._expense_review_state(
+        "draft-410",
+        answers,
+        proposal_store=store,
+    )
+
+    assert any(
+        f"exception_request store but its status is '{exception_status.value}'" in error
+        for error in state.validation_errors
+    )
+    assert state.expense_report is None
+    assert state.artifacts == {}
+
+
 def test_expense_review_state_blocks_artifacts_on_traveler_mismatch() -> None:
     store = PlannerProposalStore()
     _seed_manager_review(store, traveler_name="Jamie Park")


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:1001 -->
> **Source:** Issue #1001

Closes #1001

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`approved_request_id` is listed in `_EXPENSE_REQUIRED_FIELDS`
(`src/travel_plan_permission/http_service.py:212-213`) and the expense
review path checks that the field is non-empty
(`_expense_review_state` lines 1109–1111), but no code path verifies
that the supplied `approved_request_id`:

1. Corresponds to a real manager review or approved request that exists
   in the store.
2. Is currently in an `APPROVED` state (not `PENDING`, `REJECTED`, or
   `WITHDRAWN`).
3. Belongs to the same traveler / trip / cost-center context that the
   expense draft is claiming.

`_expense_review_state` builds an `ExpenseReport` directly from form
data (lines 1196–1202) and immediately exports CSV/XLSX artifacts via
`_expense_export_artifacts` (lines 1208–1211) without consulting the
manager-review or exception-request store. That leaves the
reimbursement workflow open to:

- Free-form `approved_request_id` strings that point at nothing.
- Linkage to an unapproved or rejected request.
- Expense reports filed against a different traveler or trip than the
  approved request was for.

This is a correctness and integrity hole, and it blocks any meaningful
audit of the reimbursement chain.

Declared changed-file scope for keepalive scope enforcement:

- `src/travel_plan_permission/http_service.py`
- `tests/python/test_http_service.py`
- `scripts/sync_test_dependencies.py`

#### Tasks
- [x] In `_expense_review_state`, after the `missing_fields` guard, look up `approved_request_id` against the manager-review store and the exception-request store (whichever owns it; investigate both).
- [x] Add a `validation_errors` entry when the id resolves to nothing in either store.
- [x] Add a `validation_errors` entry when the resolved request is not in `APPROVED` state, naming the actual state.
- [x] Add a `validation_errors` entry when the resolved request's `traveler_name` (or equivalent) does not match the expense draft's `traveler_name`.
- [x] Add a `validation_errors` entry when the resolved request's `trip_id` does not match the expense draft's `trip_id`.
- [x] Suppress `_expense_export_artifacts` and `expense_report` construction when any of the linkage validation errors are set — do not generate a CSV/XLSX for a draft whose linkage is bad.
- [x] Surface the linkage validation errors through the existing `ExpensePortalReviewState.validation_errors` channel so the portal review template can render them.
- [x] Add unit tests for: missing linkage; unapproved linkage (`PENDING`, `REJECTED`, `WITHDRAWN` each); traveler mismatch; trip mismatch; happy path with a properly approved and matching request.
- [x] Add an integration test that submits an expense draft with a bad linkage through the portal route and asserts the export is blocked.

#### Acceptance criteria
- [x] An expense draft whose `approved_request_id` does not exist in any approval store produces a `validation_errors` entry naming the missing id and no export artifacts are generated.
- [x] An expense draft linked to a `PENDING`, `REJECTED`, or `WITHDRAWN` request produces a `validation_errors` entry naming the actual status and no export artifacts are generated.
- [x] An expense draft whose traveler does not match the linked approved request produces a `validation_errors` entry and no export artifacts.
- [x] An expense draft whose trip does not match the linked approved request produces a `validation_errors` entry and no export artifacts.
- [x] A correctly-linked, approved, traveler-and-trip-matching expense draft produces a populated `ExpenseReport` and CSV/XLSX artifacts as today.
- [x] All listed unit and integration tests pass in CI.
- [x] No existing test that depended on the un-validated path regresses without an explicit acceptance update.

<!-- auto-status-summary:end -->