### PR TITLE
Issue #1001 follow-up: make expense linkage export block explicit

### DIFF
--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -2143,6 +2143,12 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"No expense portal draft found for '{draft_id}'.",
             )
+        linkage_validation = _validate_expense_linkage(proposal_store, draft.answers)
+        if linkage_validation.blocks_export:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Expense export is blocked: " + "; ".join(linkage_validation.errors),
+            )
         artifacts = draft.cached_artifacts
         if not artifacts:
             review = _expense_review_state(

--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -1191,6 +1191,14 @@ class _ExpenseLinkageResolution:
     trip_id: str | None
 
 
+@dataclass(frozen=True)
+class _ExpenseLinkageValidation:
+    """Validation result that also declares whether exports must be suppressed."""
+
+    errors: tuple[str, ...] = ()
+    blocks_export: bool = False
+
+
 def _resolve_expense_linkage(
     proposal_store: PlannerProposalStore | None,
     approved_request_id: str,
@@ -1240,19 +1248,20 @@ def _resolve_expense_linkage(
 def _validate_expense_linkage(
     proposal_store: PlannerProposalStore | None,
     answers: dict[str, object],
-) -> list[str]:
+) -> _ExpenseLinkageValidation:
     raw = answers.get("approved_request_id")
     if not isinstance(raw, str) or not raw.strip():
-        return []
+        return _ExpenseLinkageValidation()
     if proposal_store is None:
-        return []
+        return _ExpenseLinkageValidation()
     approved_request_id = raw.strip()
     resolution = _resolve_expense_linkage(proposal_store, approved_request_id)
     if resolution is None:
-        return [
+        errors = (
             f"Approved request id '{approved_request_id}' was not found in the "
-            "manager-review or exception-request stores."
-        ]
+            "manager-review or exception-request stores.",
+        )
+        return _ExpenseLinkageValidation(errors=errors, blocks_export=True)
     errors: list[str] = []
     if not resolution.is_approved:
         errors.append(
@@ -1284,7 +1293,10 @@ def _validate_expense_linkage(
             f"'{resolution.trip_id}', but the expense draft lists trip "
             f"'{trip_value}'."
         )
-    return errors
+    return _ExpenseLinkageValidation(
+        errors=tuple(errors),
+        blocks_export=bool(errors),
+    )
 
 
 def _expense_review_state(
@@ -1303,9 +1315,8 @@ def _expense_review_state(
     expense_report: ExpenseReport | None = None
     artifacts: dict[str, PortalArtifact] = {}
 
-    linkage_errors = _validate_expense_linkage(proposal_store, answers)
-    validation_errors.extend(linkage_errors)
-    linkage_blocks_export = bool(linkage_errors)
+    linkage_validation = _validate_expense_linkage(proposal_store, answers)
+    validation_errors.extend(linkage_validation.errors)
 
     ocr_text = answers.get("receipt_ocr_text")
     if isinstance(ocr_text, str) and ocr_text.strip():
@@ -1369,7 +1380,7 @@ def _expense_review_state(
                     "Receipt missing: reviewers should hold reimbursement until the traveler uploads support."
                 )
 
-            if not linkage_blocks_export:
+            if not linkage_validation.blocks_export:
                 expense = ExpenseItem(
                     category=category,
                     description=str(answers["expense_description"]),

--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -1315,14 +1315,15 @@ def _expense_review_state(
     expense_report: ExpenseReport | None = None
     artifacts: dict[str, PortalArtifact] = {}
 
-    linkage_validation = _validate_expense_linkage(proposal_store, answers)
-    validation_errors.extend(linkage_validation.errors)
+    linkage_validation = _ExpenseLinkageValidation()
 
     ocr_text = answers.get("receipt_ocr_text")
     if isinstance(ocr_text, str) and ocr_text.strip():
         receipt_extraction = ReceiptProcessor.extract_from_text(ocr_text)
 
     if not missing_fields:
+        linkage_validation = _validate_expense_linkage(proposal_store, answers)
+        validation_errors.extend(linkage_validation.errors)
         try:
             category = ExpenseCategory(str(answers["expense_category"]))
             expense_amount = Decimal(str(answers["expense_amount"]))

--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -1257,11 +1257,11 @@ def _validate_expense_linkage(
     approved_request_id = raw.strip()
     resolution = _resolve_expense_linkage(proposal_store, approved_request_id)
     if resolution is None:
-        errors = (
+        missing_linkage_errors = (
             f"Approved request id '{approved_request_id}' was not found in the "
             "manager-review or exception-request stores.",
         )
-        return _ExpenseLinkageValidation(errors=errors, blocks_export=True)
+        return _ExpenseLinkageValidation(errors=missing_linkage_errors, blocks_export=True)
     errors: list[str] = []
     if not resolution.is_approved:
         errors.append(

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -902,6 +902,22 @@ def test_expense_portal_blocks_export_when_trip_id_mismatch() -> None:
     assert not store.expense_drafts_by_id
 
 
+def test_expense_portal_bad_linkage_response_hides_export_actions() -> None:
+    """Portal review route should not render export actions when linkage validation fails."""
+    store = PlannerProposalStore()
+    _seed_manager_review(store, traveler_name="Jamie Park")
+    client = TestClient(create_app(store))
+
+    response = client.post("/portal/expenses/review", data=_expense_form_payload())
+
+    assert response.status_code == 400
+    body = html.unescape(response.text)
+    assert "Validation notes" in body
+    assert "Download CSV" not in body
+    assert "Download Excel" not in body
+    assert not store.expense_drafts_by_id
+
+
 def test_expense_portal_resolves_linkage_via_exception_request_store() -> None:
     store = PlannerProposalStore()
     portal_draft = store.save_portal_draft({"traveler_name": "Alex Rivera", "trip_id": "TRIP-410"})

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -8,6 +8,7 @@ import sys
 import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
+from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
@@ -812,6 +813,42 @@ def test_expense_portal_caches_artifacts_with_persisted_draft_id() -> None:
     assert "preview" not in draft.cached_artifacts["expense-csv"].filename.lower()
     assert "preview" not in draft.cached_artifacts["expense-xlsx"].filename.lower()
     assert b"EXP-PREVIEW" not in draft.cached_artifacts["expense-csv"].content
+
+
+def test_expense_artifact_download_revalidates_cached_linkage() -> None:
+    store = PlannerProposalStore()
+    review = _seed_manager_review(store)
+    client = TestClient(create_app(store))
+
+    response = client.post(
+        "/portal/expenses/review",
+        data=_expense_form_payload(),
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    match = re.search(r"/portal/expenses/([^/]+)/artifacts/expense-csv", response.text)
+    assert match is not None
+    draft_id = match.group(1)
+    draft = store.lookup_expense_draft(draft_id)
+    assert draft is not None
+    assert set(draft.cached_artifacts) == {"expense-csv", "expense-xlsx"}
+
+    store.manager_reviews.reviews_by_id[review.review_id] = replace(
+        review,
+        status=http_service.ReviewStatus.REJECTED,
+        updated_at=datetime.now(UTC),
+    )
+    csv_export = client.get(f"/portal/expenses/{draft_id}/artifacts/expense-csv")
+    excel_export = client.get(f"/portal/expenses/{draft_id}/artifacts/expense-xlsx")
+
+    assert csv_export.status_code == 403
+    assert excel_export.status_code == 403
+    assert csv_export.json()["detail"] == (
+        "Expense export is blocked: Approved request id 'REQ-410' was found "
+        "in the manager_review store but its status is 'rejected', not approved."
+    )
+    assert excel_export.json() == csv_export.json()
 
 
 def test_expense_portal_rejects_invalid_decimal_input_without_saving() -> None:

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -1115,6 +1115,36 @@ def test_expense_linkage_validation_allows_approved_manager_review_exports() -> 
     assert validation.errors == ()
 
 
+def test_expense_linkage_validation_marks_exception_traveler_mismatch_as_export_blocking() -> None:
+    store = PlannerProposalStore()
+    draft_id = _seed_exception_request(store, traveler_name="Jamie Park")
+    answers = _expense_form_payload()
+    answers["approved_request_id"] = draft_id
+
+    validation = http_service._validate_expense_linkage(store, answers)
+
+    assert validation.blocks_export is True
+    assert validation.errors == (
+        f"Approved request id '{draft_id}' is for traveler 'Jamie Park', but the "
+        "expense draft lists traveler 'Alex Rivera'.",
+    )
+
+
+def test_expense_linkage_validation_marks_exception_trip_mismatch_as_export_blocking() -> None:
+    store = PlannerProposalStore()
+    draft_id = _seed_exception_request(store, trip_id="TRIP-OTHER")
+    answers = _expense_form_payload()
+    answers["approved_request_id"] = draft_id
+
+    validation = http_service._validate_expense_linkage(store, answers)
+
+    assert validation.blocks_export is True
+    assert validation.errors == (
+        f"Approved request id '{draft_id}' is for trip 'TRIP-OTHER', but the "
+        "expense draft lists trip 'TRIP-410'.",
+    )
+
+
 def test_expense_review_state_blocks_artifacts_when_linkage_missing() -> None:
     store = PlannerProposalStore()
     answers = _expense_form_payload()

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -998,6 +998,31 @@ def _seed_exception_request(
     return portal_draft.draft_id
 
 
+def test_expense_linkage_validation_marks_unapproved_exception_as_export_blocking() -> None:
+    store = PlannerProposalStore()
+    draft_id = _seed_exception_request(store, status=http_service.ExceptionStatus.REJECTED)
+    answers = _expense_form_payload()
+    answers["approved_request_id"] = draft_id
+
+    validation = http_service._validate_expense_linkage(store, answers)
+
+    assert validation.blocks_export is True
+    assert validation.errors == (
+        f"Approved request id '{draft_id}' was found in the exception_request "
+        "store but its status is 'rejected', not approved.",
+    )
+
+
+def test_expense_linkage_validation_allows_approved_manager_review_exports() -> None:
+    store = PlannerProposalStore()
+    _seed_manager_review(store)
+
+    validation = http_service._validate_expense_linkage(store, _expense_form_payload())
+
+    assert validation.blocks_export is False
+    assert validation.errors == ()
+
+
 def test_expense_review_state_blocks_artifacts_when_linkage_missing() -> None:
     store = PlannerProposalStore()
     answers = _expense_form_payload()

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -1029,6 +1029,45 @@ def test_expense_linkage_validation_marks_unapproved_exception_as_export_blockin
     )
 
 
+def test_expense_linkage_validation_marks_missing_linkage_as_export_blocking() -> None:
+    store = PlannerProposalStore()
+    answers = _expense_form_payload()
+    answers["approved_request_id"] = "REQ-404"
+
+    validation = http_service._validate_expense_linkage(store, answers)
+
+    assert validation.blocks_export is True
+    assert validation.errors == (
+        "Approved request id 'REQ-404' was not found in the manager-review or "
+        "exception-request stores.",
+    )
+
+
+@pytest.mark.parametrize(
+    "exception_status",
+    [
+        http_service.ExceptionStatus.PENDING,
+        http_service.ExceptionStatus.REJECTED,
+        http_service.ExceptionStatus.WITHDRAWN,
+    ],
+)
+def test_expense_linkage_validation_marks_unapproved_exception_statuses_as_export_blocking(
+    exception_status: http_service.ExceptionStatus,
+) -> None:
+    store = PlannerProposalStore()
+    draft_id = _seed_exception_request(store, status=exception_status)
+    answers = _expense_form_payload()
+    answers["approved_request_id"] = draft_id
+
+    validation = http_service._validate_expense_linkage(store, answers)
+
+    assert validation.blocks_export is True
+    assert validation.errors == (
+        f"Approved request id '{draft_id}' was found in the exception_request "
+        f"store but its status is '{exception_status.value}', not approved.",
+    )
+
+
 def test_expense_linkage_validation_allows_approved_manager_review_exports() -> None:
     store = PlannerProposalStore()
     _seed_manager_review(store)


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:1001 -->
> **Source:** Issue #1001

Closes #1001

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`approved_request_id` is listed in `_EXPENSE_REQUIRED_FIELDS`
(`src/travel_plan_permission/http_service.py:212-213`) and the expense
review path checks that the field is non-empty
(`_expense_review_state` lines 1109–1111), but no code path verifies
that the supplied `approved_request_id`:

1. Corresponds to a real manager review or approved request that exists
   in the store.
2. Is currently in an `APPROVED` state (not `PENDING`, `REJECTED`, or
   `WITHDRAWN`).
3. Belongs to the same traveler / trip / cost-center context that the
   expense draft is claiming.

`_expense_review_state` builds an `ExpenseReport` directly from form
data (lines 1196–1202) and immediately exports CSV/XLSX artifacts via
`_expense_export_artifacts` (lines 1208–1211) without consulting the
manager-review or exception-request store. That leaves the
reimbursement workflow open to:

- Free-form `approved_request_id` strings that point at nothing.
- Linkage to an unapproved or rejected request.
- Expense reports filed against a different traveler or trip than the
  approved request was for.

This is a correctness and integrity hole, and it blocks any meaningful
audit of the reimbursement chain.

Declared changed-file scope for keepalive scope enforcement:

- `src/travel_plan_permission/http_service.py`
- `tests/python/test_http_service.py`
- `scripts/sync_test_dependencies.py`

#### Tasks
- [x] In `_expense_review_state`, after the `missing_fields` guard, look up `approved_request_id` against the manager-review store and the exception-request store (whichever owns it; investigate both).
- [x] Add a `validation_errors` entry when the id resolves to nothing in either store.
- [ ] Add a `validation_errors` entry when the resolved request is not in `APPROVED` state, naming the actual state.
- [x] Add a `validation_errors` entry when the resolved request's `traveler_name` (or equivalent) does not match the expense draft's `traveler_name`.
- [x] Add a `validation_errors` entry when the resolved request's `trip_id` does not match the expense draft's `trip_id`.
- [x] Suppress `_expense_export_artifacts` and `expense_report` construction when any of the linkage validation errors are set — do not generate a CSV/XLSX for a draft whose linkage is bad.
- [x] Surface the linkage validation errors through the existing `ExpensePortalReviewState.validation_errors` channel so the portal review template can render them.
- [ ] Add unit tests for: missing linkage; unapproved linkage (`PENDING`, `REJECTED`, `WITHDRAWN` each); traveler mismatch; trip mismatch; happy path with a properly approved and matching request.
- [x] Add an integration test that submits an expense draft with a bad linkage through the portal route and asserts the export is blocked.

#### Acceptance criteria
- [x] An expense draft whose `approved_request_id` does not exist in any approval store produces a `validation_errors` entry naming the missing id and no export artifacts are generated.
- [x] An expense draft linked to a `PENDING`, `REJECTED`, or `WITHDRAWN` request produces a `validation_errors` entry naming the actual status and no export artifacts are generated.
- [x] An expense draft whose traveler does not match the linked approved request produces a `validation_errors` entry and no export artifacts.
- [x] An expense draft whose trip does not match the linked approved request produces a `validation_errors` entry and no export artifacts.
- [x] A correctly-linked, approved, traveler-and-trip-matching expense draft produces a populated `ExpenseReport` and CSV/XLSX artifacts as today.
- [ ] All listed unit and integration tests pass in CI.
- [ ] No existing test that depended on the un-validated path regresses without an explicit acceptance update.

<!-- auto-status-summary:end -->