### PR TITLE
Follow-up: close PR 1002 OIDC verifier gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,11 @@ export TPP_OIDC_ROLE_MAP='{"sub:user@example.com":"traveler"}'
 
 OIDC mode validates the bearer JWT against the provider JWKS, issuer, audience,
 expiry, not-before, and subject claims before resolving the subject to a TPP
-role. Azure AD and Okta deployments can override discovery defaults with
-`TPP_OIDC_ISSUER` and `TPP_OIDC_JWKS_URL`.
+role. The role map can also be loaded from `TPP_OIDC_ROLE_MAP_FILE` when the
+JSON mapping should live in a mounted config file instead of an environment
+variable. Set `TPP_OIDC_SUBJECT_CLAIM` to use a verified claim other than `sub`
+as the role-map lookup key. Azure AD and Okta deployments can override
+discovery defaults with `TPP_OIDC_ISSUER` and `TPP_OIDC_JWKS_URL`.
 
 For a browser-facing draft flow on top of the same runtime, open:
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -49,6 +49,10 @@ The expected deployment config shape is:
 - `TPP_BOOTSTRAP_TOKEN_TTL_SECONDS` optionally bounds local or preview bootstrap tokens
 - `TPP_OIDC_AUDIENCE` when `TPP_AUTH_MODE=oidc`
 - `TPP_OIDC_ROLE_MAP` optionally maps verified subjects to existing roles
+- `TPP_OIDC_ROLE_MAP_FILE` optionally points at the same JSON role-map shape
+  when the mapping is provided as a mounted config file
+- `TPP_OIDC_SUBJECT_CLAIM` optionally selects the verified token claim used as
+  the authenticated subject and role-map lookup key; it defaults to `sub`
 - `TPP_OIDC_ISSUER` and `TPP_OIDC_JWKS_URL` optionally override provider defaults
 
 ### Supported auth modes
@@ -82,6 +86,10 @@ export TPP_OIDC_ROLE_MAP='{"sub:user@example.com":"approver"}'
 
 Accepted role values are the existing security model roles: `traveler`,
 `approver`, `finance_admin`, `policy_admin`, and `system_admin`.
+Use `TPP_OIDC_ROLE_MAP_FILE` instead of `TPP_OIDC_ROLE_MAP` to load the same
+JSON object from disk. Do not set both sources at once. `TPP_OIDC_SUBJECT_CLAIM`
+changes the subject claim used for lookup, so role maps may key entries as
+`<claim>:<value>` when matching on something other than `sub`.
 
 For local and preview live tests, `TPP_ACCESS_TOKEN` is a bounded bootstrap
 credential, not an auth bypass. Startup fails unless the token is paired with a

--- a/src/travel_plan_permission/__init__.py
+++ b/src/travel_plan_permission/__init__.py
@@ -33,6 +33,7 @@ from .models import (
     determine_exception_approval_level,
 )
 from .planner_auth import (
+    AuthMode,
     PlannerAuthConfig,
     PlannerAuthContext,
     PlannerAuthMode,
@@ -228,6 +229,7 @@ __all__ = [
     "PlannerExecutionState",
     "PlannerOperationType",
     "PlannerApprovalTrigger",
+    "AuthMode",
     "PlannerAuthConfig",
     "PlannerAuthContext",
     "PlannerAuthMode",

--- a/src/travel_plan_permission/planner_auth.py
+++ b/src/travel_plan_permission/planner_auth.py
@@ -119,6 +119,7 @@ class PlannerAuthConfig:
     bootstrap_ttl_seconds: int | None
     oidc_audience: str | None
     oidc_role_map_configured: bool
+    oidc_role_map: dict[str, RoleName]
     oidc_subject_claim: str
     missing_config: tuple[str, ...]
     invalid_config: tuple[str, ...]
@@ -138,6 +139,7 @@ class PlannerAuthConfig:
 
         missing: list[str] = []
         invalid: list[str] = []
+        parsed_oidc_role_map: dict[str, RoleName] = {}
 
         if not base_url:
             missing.append("TPP_BASE_URL")
@@ -188,7 +190,7 @@ class PlannerAuthConfig:
                 invalid.append("TPP_OIDC_ROLE_MAP_FILE")
             if (oidc_role_map or oidc_role_map_file) and not role_map_sources_conflict:
                 try:
-                    parsed_role_map = _load_oidc_role_map(
+                    loaded_role_map = _load_oidc_role_map(
                         raw_role_map=oidc_role_map,
                         role_map_file=oidc_role_map_file,
                     )
@@ -197,9 +199,9 @@ class PlannerAuthConfig:
                         "TPP_OIDC_ROLE_MAP_FILE" if oidc_role_map_file else "TPP_OIDC_ROLE_MAP"
                     )
                 else:
-                    for role_name in parsed_role_map.values():
+                    for subject_claim, role_name in loaded_role_map.items():
                         try:
-                            RoleName(str(role_name))
+                            parsed_oidc_role_map[str(subject_claim)] = RoleName(str(role_name))
                         except ValueError:
                             invalid.append(
                                 "TPP_OIDC_ROLE_MAP_FILE"
@@ -217,6 +219,7 @@ class PlannerAuthConfig:
             bootstrap_ttl_seconds=bootstrap_ttl_seconds or _DEFAULT_BOOTSTRAP_TTL_SECONDS,
             oidc_audience=oidc_audience,
             oidc_role_map_configured=bool(oidc_role_map or oidc_role_map_file),
+            oidc_role_map=parsed_oidc_role_map,
             oidc_subject_claim=oidc_subject_claim,
             missing_config=tuple(missing),
             invalid_config=tuple(invalid),
@@ -412,16 +415,13 @@ def _role_permissions_for_claims(
     subject = str(subject_value)
     if not subject:
         raise OIDCAuthenticationError("OIDC bearer token subject is invalid.")
-    raw_role_map = os.getenv("TPP_OIDC_ROLE_MAP")
-    role_map_file = os.getenv("TPP_OIDC_ROLE_MAP_FILE")
     role_name = RoleName.TRAVELER
-    if raw_role_map or role_map_file:
-        role_map = _load_oidc_role_map(raw_role_map=raw_role_map, role_map_file=role_map_file)
-        mapped = role_map.get(f"sub:{subject}", role_map.get(subject))
+    if config.oidc_role_map:
+        mapped = config.oidc_role_map.get(f"sub:{subject}", config.oidc_role_map.get(subject))
         if mapped is None:
-            mapped = role_map.get(f"{config.oidc_subject_claim}:{subject}")
+            mapped = config.oidc_role_map.get(f"{config.oidc_subject_claim}:{subject}")
         if mapped is not None:
-            role_name = RoleName(str(mapped))
+            role_name = mapped
     return tuple(sorted(DEFAULT_ROLES[role_name].permissions, key=lambda item: item.value))
 
 

--- a/src/travel_plan_permission/planner_auth.py
+++ b/src/travel_plan_permission/planner_auth.py
@@ -364,7 +364,11 @@ def _get_cached_jwks(jwks_url: str, *, force_refresh: bool = False) -> dict[str,
 
     document = _fetch_jwks_document(jwks_url)
     with _JWKS_CACHE_LOCK:
-        _JWKS_CACHE[jwks_url] = (now + _DEFAULT_JWKS_CACHE_TTL_SECONDS, document)
+        # Start the TTL when we write the fetched document into cache.
+        _JWKS_CACHE[jwks_url] = (
+            time.monotonic() + _DEFAULT_JWKS_CACHE_TTL_SECONDS,
+            document,
+        )
     return document
 
 

--- a/src/travel_plan_permission/planner_auth.py
+++ b/src/travel_plan_permission/planner_auth.py
@@ -406,7 +406,12 @@ def _load_oidc_role_map(
 def _role_permissions_for_claims(
     claims: dict[str, object], config: PlannerAuthConfig
 ) -> tuple[Permission, ...]:
-    subject = str(claims.get(config.oidc_subject_claim) or claims["sub"])
+    subject_value = claims.get(config.oidc_subject_claim)
+    if subject_value is None:
+        subject_value = claims["sub"]
+    subject = str(subject_value)
+    if not subject:
+        raise OIDCAuthenticationError("OIDC bearer token subject is invalid.")
     raw_role_map = os.getenv("TPP_OIDC_ROLE_MAP")
     role_map_file = os.getenv("TPP_OIDC_ROLE_MAP_FILE")
     role_name = RoleName.TRAVELER
@@ -463,7 +468,11 @@ def _verify_oidc_token(
             algorithms=[alg],
             audience=config.oidc_audience,
             issuer=settings["issuer"],
-            options={"require": ["iss", "aud", "exp", "nbf", "sub"]},
+            options={
+                "require": ["iss", "aud", "exp", "nbf", "sub"],
+                "verify_exp": True,
+                "verify_nbf": True,
+            },
         )
     except jwt.ExpiredSignatureError as exc:
         raise OIDCAuthenticationError("OIDC bearer token has expired.") from exc
@@ -476,7 +485,12 @@ def _verify_oidc_token(
     except (jwt.PyJWTError, TypeError, ValueError) as exc:
         raise OIDCAuthenticationError("OIDC bearer token is invalid.") from exc
 
-    subject = str(claims.get(config.oidc_subject_claim) or claims["sub"])
+    subject_value = claims.get(config.oidc_subject_claim)
+    if subject_value is None:
+        subject_value = claims["sub"]
+    subject = str(subject_value)
+    if not subject:
+        raise OIDCAuthenticationError("OIDC bearer token subject is invalid.")
     permissions = _role_permissions_for_claims(claims, config)
     expires_at = datetime.fromtimestamp(int(claims["exp"]), tz=UTC)
     return PlannerAuthContext(

--- a/src/travel_plan_permission/planner_auth.py
+++ b/src/travel_plan_permission/planner_auth.py
@@ -30,19 +30,22 @@ _PLANNER_TOKEN_AUDIENCE = "planner-service"
 _PLANNER_STATIC_TOKEN_SUBJECT = "planner-static-client"
 _OIDC_ALLOWED_ALGORITHMS = frozenset({"RS256"})
 
+_AZURE_AD_OIDC_SETTINGS = {
+    "issuer": "https://login.microsoftonline.com/{tenant_id}/v2.0",
+    "jwks_url": "https://login.microsoftonline.com/common/discovery/v2.0/keys",
+}
+_OKTA_OIDC_SETTINGS = {
+    "issuer": "https://{yourOktaDomain}/oauth2/default",
+    "jwks_url": "https://{yourOktaDomain}/oauth2/default/v1/keys",
+}
+_GOOGLE_OIDC_SETTINGS = {
+    "issuer": "https://accounts.google.com",
+    "jwks_url": "https://www.googleapis.com/oauth2/v3/certs",
+}
 _OIDC_PROVIDER_REGISTRY: dict[str, dict[str, str]] = {
-    "azure_ad": {
-        "issuer": "https://login.microsoftonline.com/{tenant_id}/v2.0",
-        "jwks_url": "https://login.microsoftonline.com/common/discovery/v2.0/keys",
-    },
-    "okta": {
-        "issuer": "https://{yourOktaDomain}/oauth2/default",
-        "jwks_url": "https://{yourOktaDomain}/oauth2/default/v1/keys",
-    },
-    "google": {
-        "issuer": "https://accounts.google.com",
-        "jwks_url": "https://www.googleapis.com/oauth2/v3/certs",
-    },
+    "azure_ad": _AZURE_AD_OIDC_SETTINGS,
+    "okta": _OKTA_OIDC_SETTINGS,
+    "google": _GOOGLE_OIDC_SETTINGS,
 }
 _JWKS_CACHE: dict[str, tuple[float, dict[str, object]]] = {}
 _JWKS_CACHE_LOCK = threading.Lock()

--- a/src/travel_plan_permission/planner_auth.py
+++ b/src/travel_plan_permission/planner_auth.py
@@ -126,6 +126,7 @@ class PlannerAuthConfig:
         ttl_raw = os.getenv("TPP_BOOTSTRAP_TOKEN_TTL_SECONDS")
         oidc_audience = os.getenv("TPP_OIDC_AUDIENCE")
         oidc_role_map = os.getenv("TPP_OIDC_ROLE_MAP")
+        oidc_role_map_file = os.getenv("TPP_OIDC_ROLE_MAP_FILE")
         oidc_subject_claim = os.getenv("TPP_OIDC_SUBJECT_CLAIM", "sub")
 
         missing: list[str] = []
@@ -175,21 +176,30 @@ class PlannerAuthConfig:
                     missing.append("TPP_OIDC_ISSUER")
                 if "{" in jwks_url:
                     missing.append("TPP_OIDC_JWKS_URL")
-            if oidc_role_map:
+            role_map_sources_conflict = bool(oidc_role_map and oidc_role_map_file)
+            if role_map_sources_conflict:
+                invalid.append("TPP_OIDC_ROLE_MAP_FILE")
+            if (oidc_role_map or oidc_role_map_file) and not role_map_sources_conflict:
                 try:
-                    parsed_role_map = json.loads(oidc_role_map)
-                except json.JSONDecodeError:
-                    invalid.append("TPP_OIDC_ROLE_MAP")
+                    parsed_role_map = _load_oidc_role_map(
+                        raw_role_map=oidc_role_map,
+                        role_map_file=oidc_role_map_file,
+                    )
+                except (OSError, ValueError):
+                    invalid.append(
+                        "TPP_OIDC_ROLE_MAP_FILE" if oidc_role_map_file else "TPP_OIDC_ROLE_MAP"
+                    )
                 else:
-                    if not isinstance(parsed_role_map, dict):
-                        invalid.append("TPP_OIDC_ROLE_MAP")
-                    else:
-                        for role_name in parsed_role_map.values():
-                            try:
-                                RoleName(str(role_name))
-                            except ValueError:
-                                invalid.append("TPP_OIDC_ROLE_MAP")
-                                break
+                    for role_name in parsed_role_map.values():
+                        try:
+                            RoleName(str(role_name))
+                        except ValueError:
+                            invalid.append(
+                                "TPP_OIDC_ROLE_MAP_FILE"
+                                if oidc_role_map_file
+                                else "TPP_OIDC_ROLE_MAP"
+                            )
+                            break
 
         return cls(
             base_url=base_url,
@@ -199,7 +209,7 @@ class PlannerAuthConfig:
             bootstrap_secret_configured=bool(bootstrap_secret),
             bootstrap_ttl_seconds=bootstrap_ttl_seconds or _DEFAULT_BOOTSTRAP_TTL_SECONDS,
             oidc_audience=oidc_audience,
-            oidc_role_map_configured=bool(oidc_role_map),
+            oidc_role_map_configured=bool(oidc_role_map or oidc_role_map_file),
             oidc_subject_claim=oidc_subject_claim,
             missing_config=tuple(missing),
             invalid_config=tuple(invalid),
@@ -363,14 +373,34 @@ def _select_jwk(jwks: dict[str, object], kid: str | None) -> dict[str, object] |
     return None
 
 
+def _load_oidc_role_map(
+    *,
+    raw_role_map: str | None = None,
+    role_map_file: str | None = None,
+) -> dict[str, object]:
+    if raw_role_map and role_map_file:
+        raise ValueError("Set either TPP_OIDC_ROLE_MAP or TPP_OIDC_ROLE_MAP_FILE, not both.")
+    if role_map_file:
+        with open(role_map_file, encoding="utf-8") as handle:
+            parsed = json.load(handle)
+    elif raw_role_map:
+        parsed = json.loads(raw_role_map)
+    else:
+        return {}
+    if not isinstance(parsed, dict):
+        raise ValueError("OIDC role map must be a JSON object.")
+    return parsed
+
+
 def _role_permissions_for_claims(
     claims: dict[str, object], config: PlannerAuthConfig
 ) -> tuple[Permission, ...]:
     subject = str(claims.get(config.oidc_subject_claim) or claims["sub"])
     raw_role_map = os.getenv("TPP_OIDC_ROLE_MAP")
+    role_map_file = os.getenv("TPP_OIDC_ROLE_MAP_FILE")
     role_name = RoleName.TRAVELER
-    if raw_role_map:
-        role_map = json.loads(raw_role_map)
+    if raw_role_map or role_map_file:
+        role_map = _load_oidc_role_map(raw_role_map=raw_role_map, role_map_file=role_map_file)
         mapped = role_map.get(f"sub:{subject}", role_map.get(subject))
         if mapped is None:
             mapped = role_map.get(f"{config.oidc_subject_claim}:{subject}")
@@ -422,7 +452,7 @@ def _verify_oidc_token(
             algorithms=[alg],
             audience=config.oidc_audience,
             issuer=settings["issuer"],
-            options={"require": ["exp", "nbf", "sub"]},
+            options={"require": ["iss", "aud", "exp", "nbf", "sub"]},
         )
     except jwt.ExpiredSignatureError as exc:
         raise OIDCAuthenticationError("OIDC bearer token has expired.") from exc

--- a/src/travel_plan_permission/planner_auth.py
+++ b/src/travel_plan_permission/planner_auth.py
@@ -48,12 +48,16 @@ _JWKS_CACHE: dict[str, tuple[float, dict[str, object]]] = {}
 _JWKS_CACHE_LOCK = threading.Lock()
 
 
-class PlannerAuthMode(StrEnum):
+class AuthMode(StrEnum):
     """Configured planner-facing authentication mode."""
 
     STATIC_TOKEN = "static-token"
     BOOTSTRAP_TOKEN = "bootstrap-token"
     OIDC = "oidc"
+
+
+# Backward-compatible alias for existing imports.
+PlannerAuthMode = AuthMode
 
 
 class OIDCAuthenticationError(PermissionError):

--- a/tests/python/test_audit.py
+++ b/tests/python/test_audit.py
@@ -550,6 +550,7 @@ class TestEmitPoints:
             bootstrap_ttl_seconds=900,
             oidc_audience=None,
             oidc_role_map_configured=False,
+            oidc_role_map={},
             oidc_subject_claim="sub",
             missing_config=("TPP_AUTH_MODE",),
             invalid_config=(),

--- a/tests/python/test_planner_auth.py
+++ b/tests/python/test_planner_auth.py
@@ -46,19 +46,21 @@ def _oidc_token(
     *,
     kid: str = "planner-key",
     subject: str = "user@example.com",
-    audience: str = "trip-planner",
-    issuer: str = "https://accounts.google.com",
+    audience: str | None = "trip-planner",
+    issuer: str | None = "https://accounts.google.com",
     expires_delta: timedelta = timedelta(minutes=10),
     include_nbf: bool = True,
     nbf_offset: timedelta = timedelta(seconds=-5),
 ) -> str:
     now = datetime.now(UTC)
     claims = {
-        "iss": issuer,
-        "aud": audience,
         "sub": subject,
         "exp": now + expires_delta,
     }
+    if issuer is not None:
+        claims["iss"] = issuer
+    if audience is not None:
+        claims["aud"] = audience
     if include_nbf:
         claims["nbf"] = now + nbf_offset
     return jwt.encode(
@@ -169,12 +171,43 @@ def test_oidc_token_uses_role_mapping(monkeypatch, oidc_keys) -> None:
     assert context.can(Permission.EXPORT)
 
 
+def test_oidc_token_uses_role_mapping_file(monkeypatch, tmp_path, oidc_keys) -> None:
+    _set_oidc_env(monkeypatch)
+    role_map_file = tmp_path / "oidc-role-map.json"
+    role_map_file.write_text('{"sub:user@example.com": "finance_admin"}', encoding="utf-8")
+    monkeypatch.setenv("TPP_OIDC_ROLE_MAP_FILE", str(role_map_file))
+    token = _oidc_token(oidc_keys)
+
+    context = authenticate_request(
+        f"Bearer {token}",
+        config=PlannerAuthConfig.from_env(),
+        required_permission=Permission.EXPORT,
+    )
+
+    assert PlannerAuthConfig.from_env().oidc_role_map_configured is True
+    assert context.can(Permission.EXPORT)
+
+
+def test_oidc_auth_config_rejects_conflicting_role_map_sources(monkeypatch, tmp_path) -> None:
+    _set_oidc_env(monkeypatch)
+    role_map_file = tmp_path / "oidc-role-map.json"
+    role_map_file.write_text('{"sub:user@example.com": "finance_admin"}', encoding="utf-8")
+    monkeypatch.setenv("TPP_OIDC_ROLE_MAP", '{"sub:user@example.com": "traveler"}')
+    monkeypatch.setenv("TPP_OIDC_ROLE_MAP_FILE", str(role_map_file))
+
+    config = PlannerAuthConfig.from_env()
+
+    assert config.invalid_config == ("TPP_OIDC_ROLE_MAP_FILE",)
+
+
 @pytest.mark.parametrize(
     ("token_kwargs", "message"),
     [
         ({"expires_delta": timedelta(seconds=-30)}, "has expired"),
         ({"audience": "wrong-audience"}, "audience is invalid"),
         ({"issuer": "https://issuer.example"}, "issuer is invalid"),
+        ({"audience": None}, "is invalid"),
+        ({"issuer": None}, "is invalid"),
     ],
 )
 def test_oidc_token_rejects_invalid_standard_claims(

--- a/tests/python/test_planner_auth.py
+++ b/tests/python/test_planner_auth.py
@@ -9,6 +9,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 
 import travel_plan_permission.planner_auth as planner_auth
 from travel_plan_permission.planner_auth import (
+    AuthMode,
     PlannerAuthConfig,
     PlannerAuthMode,
     authenticate_request,
@@ -87,6 +88,11 @@ def test_bootstrap_auth_config_requires_explicit_mode(monkeypatch) -> None:
 
     assert config.auth_mode is None
     assert config.missing_config == ("TPP_AUTH_MODE",)
+
+
+def test_auth_mode_alias_includes_oidc() -> None:
+    assert AuthMode.OIDC.value == "oidc"
+    assert PlannerAuthMode is AuthMode
 
 
 def test_oidc_auth_config_requires_audience(monkeypatch) -> None:

--- a/tests/python/test_planner_auth.py
+++ b/tests/python/test_planner_auth.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from datetime import UTC, datetime, timedelta
 
+import httpx
 import jwt
 import pytest
 from cryptography.hazmat.primitives.asymmetric import rsa
@@ -442,6 +443,33 @@ def test_oidc_kid_miss_forces_jwks_refresh(monkeypatch) -> None:
 
     assert context.subject == "user@example.com"
     assert fetch_counter["value"] == 2
+
+
+@pytest.mark.integration
+def test_oidc_token_authenticates_against_stubbed_jwks_transport(monkeypatch) -> None:
+    _set_oidc_env(monkeypatch)
+    planner_auth._JWKS_CACHE.clear()
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    token = _oidc_token(private_key)
+    jwks = {"keys": [_rsa_jwk(private_key, kid="planner-key")]}
+
+    def _fake_get(url: str, *, timeout: float) -> httpx.Response:
+        assert timeout == 5.0
+        request = httpx.Request("GET", url)
+        return httpx.Response(200, json=jwks, request=request)
+
+    monkeypatch.setenv("TPP_OIDC_JWKS_URL", "https://issuer.example/jwks.json")
+    monkeypatch.setattr(planner_auth.httpx, "get", _fake_get)
+    context = authenticate_request(
+        f"Bearer {token}",
+        config=PlannerAuthConfig.from_env(),
+        required_permission=Permission.VIEW,
+    )
+
+    assert context.subject == "user@example.com"
+    assert context.auth_mode == PlannerAuthMode.OIDC
+    cached = planner_auth._get_cached_jwks("https://issuer.example/jwks.json")
+    assert cached == jwks
 
 
 def test_bootstrap_token_authenticates_required_permission(monkeypatch) -> None:

--- a/tests/python/test_planner_auth.py
+++ b/tests/python/test_planner_auth.py
@@ -177,6 +177,35 @@ def test_oidc_token_uses_role_mapping(monkeypatch, oidc_keys) -> None:
     assert context.can(Permission.EXPORT)
 
 
+def test_oidc_token_uses_custom_subject_claim_for_role_mapping(monkeypatch, oidc_keys) -> None:
+    _set_oidc_env(monkeypatch)
+    monkeypatch.setenv("TPP_OIDC_SUBJECT_CLAIM", "email")
+    monkeypatch.setenv("TPP_OIDC_ROLE_MAP", '{"email:user@example.com": "finance_admin"}')
+    now = datetime.now(UTC)
+    token = jwt.encode(
+        {
+            "sub": "opaque-subject",
+            "email": "user@example.com",
+            "iss": "https://accounts.google.com",
+            "aud": "trip-planner",
+            "nbf": now - timedelta(seconds=5),
+            "exp": now + timedelta(minutes=10),
+        },
+        oidc_keys,
+        algorithm="RS256",
+        headers={"kid": "planner-key"},
+    )
+
+    context = authenticate_request(
+        f"Bearer {token}",
+        config=PlannerAuthConfig.from_env(),
+        required_permission=Permission.EXPORT,
+    )
+
+    assert context.subject == "user@example.com"
+    assert context.can(Permission.EXPORT)
+
+
 def test_oidc_token_uses_role_mapping_file(monkeypatch, tmp_path, oidc_keys) -> None:
     _set_oidc_env(monkeypatch)
     role_map_file = tmp_path / "oidc-role-map.json"

--- a/tests/python/test_planner_auth.py
+++ b/tests/python/test_planner_auth.py
@@ -306,7 +306,7 @@ def test_jwks_cache_reuses_document_within_ttl(monkeypatch) -> None:
 
 def test_jwks_cache_refreshes_after_ttl_expiry(monkeypatch) -> None:
     planner_auth._JWKS_CACHE.clear()
-    ticks = iter([100.0, 750.0])
+    ticks = iter([100.0, 100.0, 750.0, 750.0])
     fetch_counter = {"value": 0}
 
     monkeypatch.setattr(planner_auth.time, "monotonic", lambda: next(ticks))
@@ -319,6 +319,29 @@ def test_jwks_cache_refreshes_after_ttl_expiry(monkeypatch) -> None:
 
     first = planner_auth._get_cached_jwks("https://issuer.example/jwks.json")
     second = planner_auth._get_cached_jwks("https://issuer.example/jwks.json")
+
+    assert first["keys"][0]["kid"] == "k1"
+    assert second["keys"][0]["kid"] == "k2"
+    assert fetch_counter["value"] == 2
+
+
+def test_jwks_cache_force_refresh_bypasses_ttl(monkeypatch) -> None:
+    planner_auth._JWKS_CACHE.clear()
+    fetch_counter = {"value": 0}
+
+    monkeypatch.setattr(planner_auth.time, "monotonic", lambda: 100.0)
+
+    def _fetch(_url: str) -> dict[str, object]:
+        fetch_counter["value"] += 1
+        return {"keys": [{"kid": f"k{fetch_counter['value']}"}]}
+
+    monkeypatch.setattr(planner_auth, "_fetch_jwks_document", _fetch)
+
+    first = planner_auth._get_cached_jwks("https://issuer.example/jwks.json")
+    second = planner_auth._get_cached_jwks(
+        "https://issuer.example/jwks.json",
+        force_refresh=True,
+    )
 
     assert first["keys"][0]["kid"] == "k1"
     assert second["keys"][0]["kid"] == "k2"

--- a/tests/python/test_planner_auth.py
+++ b/tests/python/test_planner_auth.py
@@ -11,6 +11,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 import travel_plan_permission.planner_auth as planner_auth
 from travel_plan_permission.planner_auth import (
     AuthMode,
+    OIDCAuthenticationError,
     PlannerAuthConfig,
     PlannerAuthMode,
     authenticate_request,
@@ -324,6 +325,63 @@ def test_oidc_token_rejects_signature_mismatch(monkeypatch, oidc_keys) -> None:
             config=PlannerAuthConfig.from_env(),
             required_permission=Permission.VIEW,
         )
+
+
+@pytest.mark.parametrize(
+    ("token_kwargs", "expected_message"),
+    [
+        ({"expires_delta": timedelta(seconds=-30)}, "has expired"),
+        ({"audience": "wrong-audience"}, "audience is invalid"),
+        ({"issuer": "https://issuer.example"}, "issuer is invalid"),
+    ],
+)
+def test_oidc_standard_claim_failures_raise_structured_invalid_token(
+    monkeypatch,
+    oidc_keys,
+    token_kwargs,
+    expected_message,
+) -> None:
+    _set_oidc_env(monkeypatch)
+    token = _oidc_token(oidc_keys, **token_kwargs)
+
+    with pytest.raises(OIDCAuthenticationError, match=expected_message) as excinfo:
+        authenticate_request(
+            f"Bearer {token}",
+            config=PlannerAuthConfig.from_env(),
+            required_permission=Permission.VIEW,
+        )
+
+    assert excinfo.value.error_code == "invalid_token"
+
+
+def test_oidc_kid_miss_raises_structured_invalid_token(monkeypatch, oidc_keys) -> None:
+    _set_oidc_env(monkeypatch)
+    token = _oidc_token(oidc_keys, kid="missing-key")
+
+    with pytest.raises(OIDCAuthenticationError, match="key id was not found") as excinfo:
+        authenticate_request(
+            f"Bearer {token}",
+            config=PlannerAuthConfig.from_env(),
+            required_permission=Permission.VIEW,
+        )
+
+    assert excinfo.value.error_code == "invalid_token"
+
+
+def test_oidc_signature_mismatch_raises_structured_invalid_token(monkeypatch, oidc_keys) -> None:
+    _set_oidc_env(monkeypatch)
+    assert oidc_keys is not None
+    other_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    token = _oidc_token(other_key)
+
+    with pytest.raises(OIDCAuthenticationError, match="is invalid") as excinfo:
+        authenticate_request(
+            f"Bearer {token}",
+            config=PlannerAuthConfig.from_env(),
+            required_permission=Permission.VIEW,
+        )
+
+    assert excinfo.value.error_code == "invalid_token"
 
 
 def test_oidc_token_rejects_missing_nbf(monkeypatch, oidc_keys) -> None:

--- a/tests/python/test_planner_auth.py
+++ b/tests/python/test_planner_auth.py
@@ -119,6 +119,7 @@ def test_oidc_provider_registry_defaults(provider, requires_override) -> None:
         bootstrap_ttl_seconds=900,
         oidc_audience="trip-planner",
         oidc_role_map_configured=False,
+        oidc_role_map={},
         oidc_subject_claim="sub",
         missing_config=(),
         invalid_config=(),
@@ -211,16 +212,52 @@ def test_oidc_token_uses_role_mapping_file(monkeypatch, tmp_path, oidc_keys) -> 
     role_map_file = tmp_path / "oidc-role-map.json"
     role_map_file.write_text('{"sub:user@example.com": "finance_admin"}', encoding="utf-8")
     monkeypatch.setenv("TPP_OIDC_ROLE_MAP_FILE", str(role_map_file))
+    config = PlannerAuthConfig.from_env()
+    role_map_file.write_text('{"sub:user@example.com": "traveler"}', encoding="utf-8")
     token = _oidc_token(oidc_keys)
 
     context = authenticate_request(
         f"Bearer {token}",
-        config=PlannerAuthConfig.from_env(),
+        config=config,
         required_permission=Permission.EXPORT,
     )
 
-    assert PlannerAuthConfig.from_env().oidc_role_map_configured is True
+    assert config.oidc_role_map_configured is True
     assert context.can(Permission.EXPORT)
+
+
+def test_oidc_auth_config_rejects_missing_role_map_file(monkeypatch, tmp_path) -> None:
+    _set_oidc_env(monkeypatch)
+    monkeypatch.setenv("TPP_OIDC_ROLE_MAP_FILE", str(tmp_path / "missing-role-map.json"))
+
+    config = PlannerAuthConfig.from_env()
+
+    assert config.invalid_config == ("TPP_OIDC_ROLE_MAP_FILE",)
+    assert config.oidc_role_map == {}
+
+
+def test_oidc_auth_config_rejects_invalid_role_map_file_json(monkeypatch, tmp_path) -> None:
+    _set_oidc_env(monkeypatch)
+    role_map_file = tmp_path / "oidc-role-map.json"
+    role_map_file.write_text("{not-json", encoding="utf-8")
+    monkeypatch.setenv("TPP_OIDC_ROLE_MAP_FILE", str(role_map_file))
+
+    config = PlannerAuthConfig.from_env()
+
+    assert config.invalid_config == ("TPP_OIDC_ROLE_MAP_FILE",)
+    assert config.oidc_role_map == {}
+
+
+def test_oidc_auth_config_rejects_non_object_role_map_file(monkeypatch, tmp_path) -> None:
+    _set_oidc_env(monkeypatch)
+    role_map_file = tmp_path / "oidc-role-map.json"
+    role_map_file.write_text('["finance_admin"]', encoding="utf-8")
+    monkeypatch.setenv("TPP_OIDC_ROLE_MAP_FILE", str(role_map_file))
+
+    config = PlannerAuthConfig.from_env()
+
+    assert config.invalid_config == ("TPP_OIDC_ROLE_MAP_FILE",)
+    assert config.oidc_role_map == {}
 
 
 def test_oidc_auth_config_rejects_conflicting_role_map_sources(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:996 -->
> **Source:** Issue #996

Closes #996

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The planner-facing HTTP service advertises support for `azure_ad`, `okta`, and
`google` OIDC providers (`docs/security-model.md` lines 88–95), but the auth
implementation in `src/travel_plan_permission/planner_auth.py` only honors the
`static-token` and `bootstrap-token` modes. `TPP_OIDC_PROVIDER` is presently
metadata used to gate token *minting*; it does not validate any third-party
JWT. As a result, a real Google ID token, Azure AD bearer, or Okta access
token cannot authenticate against `/planner/snapshot`, `/planner/proposals`,
or any other planner route. This blocks live testing of the cross-repo
trip-planner ↔ TPP handshake against any real identity provider.

#### Tasks
- [x] Add `OIDC = "oidc"` to `AuthMode` in `src/travel_plan_permission/planner_auth.py`.
- [x] Add a per-provider issuer/JWKS URL registry (constants) for `azure_ad`, `okta`, `google`.
- [x] Implement a JWKS fetcher with TTL caching and a single in-process cache.
- [x] Implement `_verify_oidc_token(token, *, config) -> AuthenticatedRequest` that validates signature, `iss`, `aud`, `exp`, `nbf`, and resolves `sub` to a role binding.
- [x] Branch `authenticate_request` in `src/travel_plan_permission/planner_auth.py` so the OIDC mode dispatches to `_verify_oidc_token`.
- [ ] Add a `TPP_OIDC_AUDIENCE` env var (required when `TPP_AUTH_MODE=oidc`) and validate it in the startup config check used by `/readyz`.
- [ ] Add a role-mapping table loaded from env (`TPP_OIDC_ROLE_MAP`) or a config file, defaulting to traveler-only.
- [ ] Add unit tests covering: valid token → authenticated; expired token → 401; wrong audience → 401; wrong issuer → 401; missing JWKS key id → 401; signature mismatch → 401.
- [x] Add an integration test against a stubbed JWKS server using `pytest-httpserver` or equivalent.
- [x] Update `docs/security-model.md` and `README.md` with the new env vars and OIDC mode usage.

#### Acceptance criteria
- [ ] `TPP_AUTH_MODE=oidc` with valid `TPP_OIDC_PROVIDER`, `TPP_OIDC_AUDIENCE`, and a real signed JWT authenticates a `GET /planner/snapshot` request.
- [ ] Invalid signature, expired exp, mismatched aud, and mismatched iss each return HTTP 401 with a structured `error_code` body field and a `WWW-Authenticate: Bearer error="invalid_token"` header.
- [ ] `/readyz` fails fast when `TPP_AUTH_MODE=oidc` is set without `TPP_OIDC_AUDIENCE`.
- [ ] Existing `static-token` and `bootstrap-token` paths remain green in CI.
- [ ] JWKS responses are cached for at least 10 minutes by default and refreshed on `kid` miss.
- [ ] Unit and integration tests covering the cases above pass in CI.
- [ ] `docs/security-model.md` documents the new env vars and the role-mapping mechanism.

<!-- auto-status-summary:end -->