### PR TITLE
Follow-up: close PR 1025 OIDC verifier contract gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,9 @@ export TPP_OIDC_ROLE_MAP='{"sub:user@example.com":"traveler"}'
 OIDC mode validates the bearer JWT against the provider JWKS, issuer, audience,
 expiry, not-before, and subject claims before resolving the subject to a TPP
 role. Invalid OIDC bearer tokens are rejected at the HTTP boundary with a
-structured `{"error_code": "invalid_token", "message": "..."}` response body
-and a `WWW-Authenticate: Bearer error="invalid_token"` challenge header. The
+structured `{"detail": {"error_code": "invalid_token", "message": "..."}}`
+response body (FastAPI wraps the error fields under `detail`) and a
+`WWW-Authenticate: Bearer error="invalid_token"` challenge header. The
 role map can also be loaded from `TPP_OIDC_ROLE_MAP_FILE` when the JSON mapping
 should live in a mounted config file instead of an environment variable. Set
 exactly one of `TPP_OIDC_ROLE_MAP` or `TPP_OIDC_ROLE_MAP_FILE`; `/readyz`

--- a/README.md
+++ b/README.md
@@ -97,11 +97,16 @@ export TPP_OIDC_ROLE_MAP='{"sub:user@example.com":"traveler"}'
 
 OIDC mode validates the bearer JWT against the provider JWKS, issuer, audience,
 expiry, not-before, and subject claims before resolving the subject to a TPP
-role. The role map can also be loaded from `TPP_OIDC_ROLE_MAP_FILE` when the
-JSON mapping should live in a mounted config file instead of an environment
-variable. Set `TPP_OIDC_SUBJECT_CLAIM` to use a verified claim other than `sub`
-as the role-map lookup key. Azure AD and Okta deployments can override
-discovery defaults with `TPP_OIDC_ISSUER` and `TPP_OIDC_JWKS_URL`.
+role. Invalid OIDC bearer tokens are rejected at the HTTP boundary with a
+structured `{"error_code": "invalid_token", "message": "..."}` response body
+and a `WWW-Authenticate: Bearer error="invalid_token"` challenge header. The
+role map can also be loaded from `TPP_OIDC_ROLE_MAP_FILE` when the JSON mapping
+should live in a mounted config file instead of an environment variable. Set
+exactly one of `TPP_OIDC_ROLE_MAP` or `TPP_OIDC_ROLE_MAP_FILE`; `/readyz`
+reports `misconfigured` when both are present. Set `TPP_OIDC_SUBJECT_CLAIM` to
+use a verified claim other than `sub` as the role-map lookup key. Azure AD and
+Okta deployments can override discovery defaults with `TPP_OIDC_ISSUER` and
+`TPP_OIDC_JWKS_URL`.
 
 For a browser-facing draft flow on top of the same runtime, open:
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -88,9 +88,9 @@ Accepted role values are the existing security model roles: `traveler`,
 `approver`, `finance_admin`, `policy_admin`, and `system_admin`.
 Use `TPP_OIDC_ROLE_MAP_FILE` instead of `TPP_OIDC_ROLE_MAP` to load the same
 JSON object from disk. Do not set both sources at once; the service reports
-`/readyz` as `misconfigured` with
-`TPP_OIDC_ROLE_MAP/TPP_OIDC_ROLE_MAP_FILE` in `invalid_config` when both are
-present, and planner routes return 503 until the conflict is fixed.
+`/readyz` as `misconfigured` with both `TPP_OIDC_ROLE_MAP` and
+`TPP_OIDC_ROLE_MAP_FILE` listed in `invalid_config` when both are present, and
+planner routes return 503 until the conflict is fixed.
 `TPP_OIDC_SUBJECT_CLAIM` changes the subject claim used for lookup, so role maps
 may key entries as `<claim>:<value>` when matching on something other than
 `sub`.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -87,9 +87,18 @@ export TPP_OIDC_ROLE_MAP='{"sub:user@example.com":"approver"}'
 Accepted role values are the existing security model roles: `traveler`,
 `approver`, `finance_admin`, `policy_admin`, and `system_admin`.
 Use `TPP_OIDC_ROLE_MAP_FILE` instead of `TPP_OIDC_ROLE_MAP` to load the same
-JSON object from disk. Do not set both sources at once. `TPP_OIDC_SUBJECT_CLAIM`
-changes the subject claim used for lookup, so role maps may key entries as
-`<claim>:<value>` when matching on something other than `sub`.
+JSON object from disk. Do not set both sources at once; the service reports
+`/readyz` as `misconfigured` with
+`TPP_OIDC_ROLE_MAP/TPP_OIDC_ROLE_MAP_FILE` in `invalid_config` when both are
+present, and planner routes return 503 until the conflict is fixed.
+`TPP_OIDC_SUBJECT_CLAIM` changes the subject claim used for lookup, so role maps
+may key entries as `<claim>:<value>` when matching on something other than
+`sub`.
+
+OIDC authentication failures are exposed as HTTP 401 responses with a
+structured detail body containing `error_code` and `message`, plus a
+`WWW-Authenticate: Bearer error="invalid_token"` challenge header. Permission
+failures after a valid token continue to return role-aware authorization errors.
 
 For local and preview live tests, `TPP_ACCESS_TOKEN` is a bounded bootstrap
 credential, not an auth bypass. Startup fails unless the token is paired with a

--- a/src/travel_plan_permission/planner_auth.py
+++ b/src/travel_plan_permission/planner_auth.py
@@ -187,7 +187,8 @@ class PlannerAuthConfig:
                     missing.append("TPP_OIDC_JWKS_URL")
             role_map_sources_conflict = bool(oidc_role_map and oidc_role_map_file)
             if role_map_sources_conflict:
-                invalid.append("TPP_OIDC_ROLE_MAP/TPP_OIDC_ROLE_MAP_FILE")
+                invalid.append("TPP_OIDC_ROLE_MAP")
+                invalid.append("TPP_OIDC_ROLE_MAP_FILE")
             if (oidc_role_map or oidc_role_map_file) and not role_map_sources_conflict:
                 try:
                     loaded_role_map = _load_oidc_role_map(

--- a/src/travel_plan_permission/planner_auth.py
+++ b/src/travel_plan_permission/planner_auth.py
@@ -187,7 +187,7 @@ class PlannerAuthConfig:
                     missing.append("TPP_OIDC_JWKS_URL")
             role_map_sources_conflict = bool(oidc_role_map and oidc_role_map_file)
             if role_map_sources_conflict:
-                invalid.append("TPP_OIDC_ROLE_MAP_FILE")
+                invalid.append("TPP_OIDC_ROLE_MAP/TPP_OIDC_ROLE_MAP_FILE")
             if (oidc_role_map or oidc_role_map_file) and not role_map_sources_conflict:
                 try:
                     loaded_role_map = _load_oidc_role_map(

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -616,7 +616,7 @@ def test_readyz_reports_conflicting_oidc_role_map_sources(monkeypatch, tmp_path:
     payload = response.json()
     assert payload["status"] == "misconfigured"
     assert payload["config"]["missing_config"] == []
-    assert payload["config"]["invalid_config"] == ["TPP_OIDC_ROLE_MAP/TPP_OIDC_ROLE_MAP_FILE"]
+    assert payload["config"]["invalid_config"] == ["TPP_OIDC_ROLE_MAP", "TPP_OIDC_ROLE_MAP_FILE"]
     assert payload["config"]["oidc_role_map_configured"] is True
 
 

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -602,6 +602,46 @@ def test_readyz_reports_missing_oidc_audience(monkeypatch) -> None:
     assert response.json()["config"]["missing_config"] == ["TPP_OIDC_AUDIENCE"]
 
 
+def test_readyz_reports_conflicting_oidc_role_map_sources(monkeypatch, tmp_path: Path) -> None:
+    _set_oidc_runtime_env(monkeypatch)
+    role_map_file = tmp_path / "oidc-role-map.json"
+    role_map_file.write_text('{"sub:planner@example.com":"approver"}', encoding="utf-8")
+    monkeypatch.setenv("TPP_OIDC_ROLE_MAP", '{"sub:planner@example.com":"traveler"}')
+    monkeypatch.setenv("TPP_OIDC_ROLE_MAP_FILE", str(role_map_file))
+
+    client = TestClient(create_app())
+    response = client.get("/readyz")
+
+    assert response.status_code == 503
+    payload = response.json()
+    assert payload["status"] == "misconfigured"
+    assert payload["config"]["missing_config"] == []
+    assert payload["config"]["invalid_config"] == ["TPP_OIDC_ROLE_MAP/TPP_OIDC_ROLE_MAP_FILE"]
+
+
+def test_oidc_http_401_contract_includes_message_and_bearer_challenge(
+    monkeypatch,
+) -> None:
+    _set_oidc_runtime_env(monkeypatch)
+    client = TestClient(create_app())
+    trip_plan = _load_fixture("proposal_submission.json")
+    snapshot_request = _load_fixture("policy_snapshot_request.json")
+
+    response = client.request(
+        "GET",
+        "/api/planner/policy-snapshot",
+        headers=_oidc_auth_header(monkeypatch, audience="wrong-audience"),
+        json={"trip_plan": trip_plan, "request": snapshot_request},
+    )
+
+    assert response.status_code == 401
+    assert response.headers["www-authenticate"] == 'Bearer error="invalid_token"'
+    assert response.json()["detail"] == {
+        "error_code": "invalid_token",
+        "message": "OIDC bearer token audience is invalid.",
+    }
+
+
 def test_bootstrap_token_rejects_missing_create_permission(monkeypatch) -> None:
     _set_bootstrap_runtime_env(monkeypatch)
     client = TestClient(create_app())

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -620,6 +620,30 @@ def test_readyz_reports_conflicting_oidc_role_map_sources(monkeypatch, tmp_path:
     assert payload["config"]["oidc_role_map_configured"] is True
 
 
+def test_planner_route_returns_503_when_oidc_role_map_sources_conflict(
+    monkeypatch, tmp_path: Path
+) -> None:
+    _set_oidc_runtime_env(monkeypatch)
+    role_map_file = tmp_path / "oidc-role-map.json"
+    role_map_file.write_text('{"sub:planner@example.com":"approver"}', encoding="utf-8")
+    monkeypatch.setenv("TPP_OIDC_ROLE_MAP", '{"sub:planner@example.com":"traveler"}')
+    monkeypatch.setenv("TPP_OIDC_ROLE_MAP_FILE", str(role_map_file))
+
+    client = TestClient(create_app())
+    trip_plan = _load_fixture("proposal_submission.json")
+    snapshot_request = _load_fixture("policy_snapshot_request.json")
+
+    response = client.request(
+        "GET",
+        "/api/planner/policy-snapshot",
+        headers={"Authorization": "Bearer dev-token"},
+        json={"trip_plan": trip_plan, "request": snapshot_request},
+    )
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Planner auth config is not ready."
+
+
 def test_oidc_http_401_contract_includes_message_and_bearer_challenge(
     monkeypatch,
 ) -> None:

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -617,6 +617,7 @@ def test_readyz_reports_conflicting_oidc_role_map_sources(monkeypatch, tmp_path:
     assert payload["status"] == "misconfigured"
     assert payload["config"]["missing_config"] == []
     assert payload["config"]["invalid_config"] == ["TPP_OIDC_ROLE_MAP/TPP_OIDC_ROLE_MAP_FILE"]
+    assert payload["config"]["oidc_role_map_configured"] is True
 
 
 def test_oidc_http_401_contract_includes_message_and_bearer_challenge(
@@ -639,6 +640,29 @@ def test_oidc_http_401_contract_includes_message_and_bearer_challenge(
     assert response.json()["detail"] == {
         "error_code": "invalid_token",
         "message": "OIDC bearer token audience is invalid.",
+    }
+
+
+def test_oidc_http_401_contract_for_malformed_token_includes_bearer_challenge(
+    monkeypatch,
+) -> None:
+    _set_oidc_runtime_env(monkeypatch)
+    client = TestClient(create_app())
+    trip_plan = _load_fixture("proposal_submission.json")
+    snapshot_request = _load_fixture("policy_snapshot_request.json")
+
+    response = client.request(
+        "GET",
+        "/api/planner/policy-snapshot",
+        headers={"Authorization": "Bearer not-a-jwt"},
+        json={"trip_plan": trip_plan, "request": snapshot_request},
+    )
+
+    assert response.status_code == 401
+    assert response.headers["www-authenticate"] == 'Bearer error="invalid_token"'
+    assert response.json()["detail"] == {
+        "error_code": "invalid_token",
+        "message": "OIDC bearer token is malformed.",
     }
 
 

--- a/tests/python/test_planner_auth.py
+++ b/tests/python/test_planner_auth.py
@@ -271,7 +271,7 @@ def test_oidc_auth_config_rejects_conflicting_role_map_sources(monkeypatch, tmp_
 
     config = PlannerAuthConfig.from_env()
 
-    assert config.invalid_config == ("TPP_OIDC_ROLE_MAP/TPP_OIDC_ROLE_MAP_FILE",)
+    assert config.invalid_config == ("TPP_OIDC_ROLE_MAP", "TPP_OIDC_ROLE_MAP_FILE")
 
 
 @pytest.mark.parametrize(

--- a/tests/python/test_planner_auth.py
+++ b/tests/python/test_planner_auth.py
@@ -271,7 +271,7 @@ def test_oidc_auth_config_rejects_conflicting_role_map_sources(monkeypatch, tmp_
 
     config = PlannerAuthConfig.from_env()
 
-    assert config.invalid_config == ("TPP_OIDC_ROLE_MAP_FILE",)
+    assert config.invalid_config == ("TPP_OIDC_ROLE_MAP/TPP_OIDC_ROLE_MAP_FILE",)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Follow-up for merged PR #1025 verifier CONCERNS.
- Adds explicit /readyz coverage for conflicting OIDC role-map sources.
- Adds HTTP-level 401 contract coverage for invalid OIDC bearer tokens.
- Documents the OIDC WWW-Authenticate/error-code contract and role-map source conflict handling.

## Validation
- python -m pytest tests/python/test_http_service.py tests/python/test_planner_auth.py -q
- python -m ruff check src/travel_plan_permission/planner_auth.py tests/python/test_http_service.py tests/python/test_planner_auth.py README.md docs/security-model.md
- python -m ruff format --check src/travel_plan_permission/planner_auth.py tests/python/test_http_service.py tests/python/test_planner_auth.py

Source verifier evidence: #1025 provider comparison reported OpenAI CONCERNS / Anthropic PASS.