### PR TITLE
feat(pr-00-gate): wire path-classifier for path-aware skips

### DIFF
--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -38,8 +38,33 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  detect:
+    name: classify changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      is_docs_only: ${{ steps.classify.outputs.is-docs-only || 'false' }}
+      is_python_code: ${{ steps.classify.outputs.is-python-code || 'true' }}
+      is_workflow_change: ${{ steps.classify.outputs.is-workflow-change || 'false' }}
+      is_security_relevant: ${{ steps.classify.outputs.is-security-relevant || 'true' }}
+      classification_rationale: ${{ steps.classify.outputs.classification-rationale || 'path classifier unavailable' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Classify changed paths
+        id: classify
+        uses: ./.github/actions/path-classifier
+        with:
+          force-full: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'verify:full') || github.event_name == 'schedule' }}
+
   python-ci:
     name: Python CI
+    needs: detect
+    if: >-
+      ${{
+        needs.detect.outputs.is_docs_only != 'true' &&
+        needs.detect.outputs.is_python_code == 'true'
+      }}
     uses: stranske/Workflows/.github/workflows/reusable-10-ci-python.yml@main
     with:
       python-versions: '["3.12", "3.13"]'
@@ -53,6 +78,12 @@ jobs:
 
   orchestration-tests:
     name: Orchestration Tests (LangGraph)
+    needs: detect
+    if: >-
+      ${{
+        needs.detect.outputs.is_docs_only != 'true' &&
+        needs.detect.outputs.is_python_code == 'true'
+      }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -80,6 +111,8 @@ jobs:
     # See docs/local-testing-plan.md "Stage 7" and the matching trip-planner job
     # for how to advance TRIP_PLANNER_PINNED_REF as a coordinated pair.
     name: Cross-Repo Smoke (trip-planner)
+    needs: detect
+    if: ${{ needs.detect.outputs.is_docs_only != 'true' }}
     runs-on: ubuntu-latest
     env:
       TPP_BASE_URL: http://127.0.0.1:8000
@@ -219,7 +252,7 @@ jobs:
 
   summary:
     name: gate-summary
-    needs: [python-ci, orchestration-tests, cross-repo-smoke]
+    needs: [detect, python-ci, orchestration-tests, cross-repo-smoke]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     permissions:
@@ -240,6 +273,7 @@ jobs:
       - name: Summarize results
         id: summarize
         env:
+          DETECT_RESULT: ${{ needs.detect.result || 'skipped' }}
           PYTHON_RESULT: ${{ needs.python-ci.result || 'skipped' }}
           ORCHESTRATION_RESULT: ${{ needs.orchestration-tests.result || 'skipped' }}
           CROSS_REPO_SMOKE_RESULT: ${{ needs.cross-repo-smoke.result || 'skipped' }}
@@ -282,6 +316,20 @@ jobs:
           else
             state="pending"
             description="Gate status pending (python=${python_result}, orchestration=${orchestration_result}, cross-repo-smoke=${cross_repo_smoke_result})"
+          fi
+
+          detect_result="${DETECT_RESULT:-skipped}"
+          if [[ "${detect_result}" != "success" ]]; then
+            if [[ "${detect_result}" == "failure" ]]; then
+              state="failure"
+              description="Path classification failed"
+            elif [[ "${detect_result}" == "cancelled" ]]; then
+              state="error"
+              description="Path classification was cancelled"
+            else
+              state="pending"
+              description="Path classification status unknown"
+            fi
           fi
 
           echo "state=${state}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Wire this consumer's customized `pr-00-gate.yml` to the synced `.github/actions/path-classifier` action.
- Gate expensive jobs using classifier outputs from the Wave 1 Fix #3 pattern shipped in Workflows PR #2001.
- Preserve consumer-specific gate customizations, including existing coverage thresholds, Python versions, paths, markers, and repo-specific jobs.

## Context
Source pattern: Phase 5 synthesis, "Systemic fix 3 — `path-classifier` composite action", and Wave 1 Fix #3 / Workflows PR #2001.

## Test plan
Manual: confirm gate runs and classifier-gated jobs appropriately skip on a docs-only test PR; the next non-docs PR exercises the full job set.
