### PR TITLE
test: surface restart audit events in admin

### DIFF
--- a/src/travel_plan_permission/templates/portal_admin.html
+++ b/src/travel_plan_permission/templates/portal_admin.html
@@ -211,7 +211,12 @@
             <h2>Audit history</h2>
             <ul>
               {% for event in audit_events %}
-                <li>{{ event.timestamp.isoformat() }}: {{ event.event_type.value }} · {{ event.outcome }} by {{ event.actor }}{% if event.subject %} on {{ event.subject }}{% endif %}</li>
+                <li>
+                  {{ event.timestamp.isoformat() }}: {{ event.event_type.value }} · {{ event.outcome }} by {{ event.actor }}{% if event.subject %} on {{ event.subject }}{% endif %}
+                  {% if event.metadata %}
+                    <code>{{ event.metadata | tojson }}</code>
+                  {% endif %}
+                </li>
               {% else %}
                 <li>No audit events recorded yet.</li>
               {% endfor %}

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -2208,6 +2208,50 @@ def test_audit_events_queryable_after_restart_for_auth_and_status_change(tmp_pat
     )
 
 
+def test_audit_events_queryable_from_admin_after_restart(monkeypatch, tmp_path) -> None:
+    _set_bootstrap_runtime_env(monkeypatch)
+    state_path = tmp_path / "portal-runtime-state.sqlite3"
+
+    first_store = PlannerProposalStore(state_path=state_path)
+    first_store.security.audit_log.record(
+        event_type=AuditEventType.AUTHENTICATION,
+        actor="static-token",
+        subject="planner-admin",
+        outcome="success",
+        metadata={"provider": "static-token"},
+    )
+    first_store.security.audit_log.record(
+        event_type=AuditEventType.REVIEW,
+        actor="workflow-portal",
+        subject="review-123",
+        outcome="proposal_status_change",
+        metadata={
+            "proposal_id": "prop-123",
+            "from_status": "submitted",
+            "to_status": "approved",
+        },
+    )
+    first_store.store.save_snapshot(first_store._serialize_state())
+
+    restarted = PlannerProposalStore(state_path=state_path)
+    client = TestClient(create_app(restarted))
+    response = client.get(
+        "/portal/admin",
+        headers=_bootstrap_auth_header(
+            subject="planner-admin",
+            permissions=(Permission.VIEW,),
+        ),
+    )
+
+    assert response.status_code == 200
+    assert "static-token" in response.text
+    assert "planner-admin" in response.text
+    assert "workflow-portal" in response.text
+    assert "review-123" in response.text
+    assert "proposal_status_change" in response.text
+    assert "prop-123" in response.text
+
+
 def test_audit_events_round_trip_serialize_and_load(tmp_path) -> None:
     state_path = tmp_path / "portal-runtime-state.sqlite3"
     first_store = PlannerProposalStore(state_path=state_path)


### PR DESCRIPTION
## Summary
- adds a restart regression proving in-process auth-success and proposal-status-change audit events remain visible through `/portal/admin` after reload
- renders audit-event metadata in the admin audit history so proposal identifiers are inspectable from the durable UI surface

## Verifier follow-up
Addresses the Anthropic CONCERNS on #1008: missing admin-surface restart evidence for auth-success and proposal-status-change audit events.

Source PR: #1008
Source issue: #1000 (already closed)

## Validation
- `PYTHONPYCACHEPREFIX=/private/tmp/tpp-pycache python3 -m compileall -q src/travel_plan_permission tests/python/test_http_service.py`
- `UV_CACHE_DIR=/private/tmp/uv-cache UV_PYTHON_INSTALL_DIR=/private/tmp/uv-python uv run --python 3.13 pytest tests/python/test_http_service.py::test_audit_events_queryable_from_admin_after_restart tests/python/test_http_service.py::test_audit_events_queryable_after_restart_for_auth_and_status_change tests/python/test_http_service.py::test_expense_drafts_round_trip_serialize_and_load -q` did not return output in this sandbox before handoff
