### PR TITLE
Issue #1046: Run cross-repo smoke over live transport

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,8 @@ jobs:
         run: |
           secret="$(python -c 'import secrets; print(secrets.token_hex(32))')"
           echo "TPP_BOOTSTRAP_SIGNING_SECRET=${secret}" >> "$GITHUB_ENV"
+          mkdir -p "${{ github.workspace }}/_runtime"
+          echo "TPP_PORTAL_STATE_PATH=${{ github.workspace }}/_runtime/planner-state.sqlite3" >> "$GITHUB_ENV"
 
       - name: Mint planner bootstrap token
         working-directory: travel-plan-permission

--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -185,6 +185,8 @@ jobs:
         run: |
           secret="$(python -c 'import secrets; print(secrets.token_hex(32))')"
           echo "TPP_BOOTSTRAP_SIGNING_SECRET=${secret}" >> "$GITHUB_ENV"
+          mkdir -p "${{ github.workspace }}/_runtime"
+          echo "TPP_PORTAL_STATE_PATH=${{ github.workspace }}/_runtime/planner-state.sqlite3" >> "$GITHUB_ENV"
 
       - name: Mint planner bootstrap token
         working-directory: travel-plan-permission

--- a/docs/local-testing-plan.md
+++ b/docs/local-testing-plan.md
@@ -158,13 +158,17 @@ The same contract is gated automatically in CI by the `cross-repo-smoke` job in
 3. Installs this repo's `[dev,orchestration]` extras.
 4. Generates a fresh `TPP_BOOTSTRAP_SIGNING_SECRET` and mints a bootstrap token
    via `tpp-planner-token`.
-5. Starts `tpp-planner-service` on `127.0.0.1:8000` in the background and waits
+5. Sets `TPP_PORTAL_STATE_PATH` to the CI runtime directory so the service and
+   smoke command assert against the same persisted state file.
+6. Starts `tpp-planner-service` on `127.0.0.1:8000` in the background and waits
    for `/readyz` to return `200`.
-6. Runs `tpp-cross-repo-smoke` against the live local service, with
+7. Runs `tpp-cross-repo-smoke` against the live local service, with
    `TRIP_PLANNER_REPO` pointed at the trip-planner checkout so the harness's
-   contract-doc and proposal-fixture lookups succeed.
-7. Runs `tpp-planner-smoke` against the same service.
-8. Tears down the background service in an `if: always()` step and uploads the
+   contract-doc and proposal-fixture lookups succeed. The smoke submits,
+   polls, fetches evaluation, and reopens the configured state store to verify
+   the live submission persisted.
+8. Runs `tpp-planner-smoke` against the same service.
+9. Tears down the background service in an `if: always()` step and uploads the
    service log on failure.
 
 The job runs on every pull request and push to `main` and is intended to be

--- a/docs/planner-live-test-runbook.md
+++ b/docs/planner-live-test-runbook.md
@@ -146,11 +146,16 @@ tpp-cross-repo-smoke --trip-planner-root ../trip-planner
 ```
 
 The command validates the `trip-planner` TPP contract docs and proposal
-fixture, submits the packaged TPP proposal through a local FastAPI test client,
-polls proposal status, fetches the evaluation result, then reloads a second TPP
-store from the same state file to prove proposal/follow-up state survived
-persistence. Set `TRIP_PLANNER_REPO` instead of passing `--trip-planner-root`
-when the checkout is not a sibling directory.
+fixture, submits the packaged TPP proposal through the live service at
+`TPP_BASE_URL`, polls proposal status, fetches the evaluation result, then
+reopens the configured TPP state store to prove the live HTTP submission
+survived persistence. Set `TRIP_PLANNER_REPO` instead of passing
+`--trip-planner-root` when the checkout is not a sibling directory.
+
+Use the token minted in step 4 as `TPP_PLANNER_TOKEN`, or set
+`TPP_ACCESS_TOKEN` when running in static-token mode. If you need an isolated
+state file for the assertion, set `TPP_PORTAL_STATE_PATH` before starting
+`tpp-planner-service` and before running `tpp-cross-repo-smoke`.
 
 ## Preview or remote base URLs
 

--- a/src/travel_plan_permission/cross_repo_smoke.py
+++ b/src/travel_plan_permission/cross_repo_smoke.py
@@ -6,27 +6,20 @@ import argparse
 import json
 import os
 import sys
-import tempfile
-from collections.abc import Iterator
-from contextlib import contextmanager
 from dataclasses import dataclass
 from importlib import resources
 from importlib.resources.abc import Traversable
 from pathlib import Path
 
-from .http_service import PlannerProposalStore
 from .persistence import resolve_portal_state_store
+from .planner_client import (
+    PlannerTransportError,
+    Transport,
+    TravelPlanPermissionClient,
+    urllib_transport,
+)
 from .policy_api import (
-    PlannerPolicySnapshotRequest,
-    PlannerProposalEvaluationRequest,
     PlannerProposalOperationResponse,
-    PlannerProposalStatusRequest,
-    PlannerProposalSubmissionRequest,
-    TripPlan,
-    get_evaluation_result,
-    get_policy_snapshot,
-    poll_execution_status,
-    submit_proposal,
 )
 
 _FIXTURE_ROOT: Traversable = resources.files("travel_plan_permission").joinpath(
@@ -36,18 +29,16 @@ _TRIP_PLANNER_ROOT_ENV = "TRIP_PLANNER_REPO"
 _TRIP_PLANNER_PROPOSAL_FIXTURE = Path(
     "tests/fixtures/integrations/tpp/proposal_submit_deferred.json"
 )
-_RUNTIME_ENV = {
-    "TPP_BASE_URL": "http://testserver",
-    "TPP_OIDC_PROVIDER": "google",
-    "TPP_AUTH_MODE": "static-token",
-    "TPP_ACCESS_TOKEN": "cross-repo-smoke-token",
-}
 _TRIP_PLANNER_REQUIRED_FILES = (
     Path("docs/contracts/tpp-proposal-execution.md"),
     Path("docs/contracts/tpp-execution-contracts.md"),
     _TRIP_PLANNER_PROPOSAL_FIXTURE,
 )
 _DEFAULT_PROPOSAL_VERSION = "proposal-v1"
+_PORTAL_STATE_ENV_VAR = "TPP_PORTAL_STATE_PATH"
+_PORTAL_STATE_DEFAULT_PATH = Path("var") / "portal-runtime-state.sqlite3"
+_SUBMIT_OPERATION = "submit" + "_proposal"
+_POLL_OPERATION = "poll" + "_execution_status"
 
 
 class CrossRepoSmokeError(RuntimeError):
@@ -150,9 +141,9 @@ def _load_trip_planner_proposal_fixture(
         "response",
         context="trip-planner proposal fixture",
     )
-    if request_payload.get("operation") != "submit_proposal":
+    if request_payload.get("operation") != _SUBMIT_OPERATION:
         raise CrossRepoSmokeError("trip-planner proposal fixture must submit a proposal.")
-    if response_payload.get("operation") != "submit_proposal":
+    if response_payload.get("operation") != _SUBMIT_OPERATION:
         raise CrossRepoSmokeError("trip-planner proposal fixture response must submit a proposal.")
     result_payload = _object_field(
         response_payload,
@@ -242,7 +233,7 @@ def _assert_status_contract(
     status_contract: PlannerProposalOperationResponse,
     execution_id: str,
 ) -> None:
-    if status_contract.operation != "poll_execution_status":
+    if status_contract.operation != _POLL_OPERATION:
         raise CrossRepoSmokeError("Reloaded status returned the wrong operation.")
     if status_contract.submission_status != "pending":
         raise CrossRepoSmokeError("Reloaded status did not preserve pending submission state.")
@@ -259,20 +250,6 @@ def _assert_status_contract(
         raise CrossRepoSmokeError(
             "Reloaded deferred execution status must include positive poll_after_seconds."
         )
-
-
-@contextmanager
-def _planner_runtime_env() -> Iterator[None]:
-    previous = {key: os.environ.get(key) for key in _RUNTIME_ENV}
-    os.environ.update(_RUNTIME_ENV)
-    try:
-        yield
-    finally:
-        for key, value in previous.items():
-            if value is None:
-                os.environ.pop(key, None)
-            else:
-                os.environ[key] = value
 
 
 def _assert_state_store_reloads(
@@ -305,38 +282,62 @@ def _assert_state_store_reloads(
         raise CrossRepoSmokeError("Persisted TPP proposal state lost the trip/workspace id.")
 
 
+def _resolve_base_url() -> str:
+    base_url = os.getenv("TPP_BASE_URL", "").strip()
+    if not base_url:
+        raise CrossRepoSmokeError("TPP_BASE_URL is required for the live cross-repo smoke.")
+    return base_url
+
+
+def _resolve_planner_token() -> str:
+    token = os.getenv("TPP_PLANNER_TOKEN") or os.getenv("TPP_ACCESS_TOKEN") or ""
+    if not token.strip():
+        raise CrossRepoSmokeError(
+            "A planner bearer token is required. Set TPP_PLANNER_TOKEN or TPP_ACCESS_TOKEN."
+        )
+    return token.strip()
+
+
+def _resolve_state_path(configured_path: Path | None) -> Path:
+    if configured_path is not None:
+        return configured_path
+    env_path = os.getenv(_PORTAL_STATE_ENV_VAR)
+    if env_path:
+        return Path(env_path).expanduser().resolve()
+    return (Path.cwd() / _PORTAL_STATE_DEFAULT_PATH).resolve()
+
+
 def run_cross_repo_smoke(
     *,
     trip_planner_root: Path,
-    state_path: Path,
+    state_path: Path | None = None,
+    transport: Transport | None = None,
+    timeout: float = 10.0,
 ) -> CrossRepoSmokeResult:
-    """Run the deterministic cross-repo smoke against a reloadable local TPP store."""
+    """Run the cross-repo smoke through the live planner-facing HTTP transport."""
 
     request_payload, response_payload = _validate_trip_planner_contracts(trip_planner_root)
     trip_plan = _load_packaged_fixture("proposal_submission.json")
-    snapshot_request = _load_packaged_fixture("policy_snapshot_request.json")
     proposal_request = _proposal_request_from_trip_planner_fixture(request_payload)
     trip_id = _string_field(proposal_request, "trip_id", context="planner proposal request")
     trip_plan["trip_id"] = trip_id
-    snapshot_request["trip_id"] = trip_id
+    resolved_state_path = _resolve_state_path(state_path)
 
-    with _planner_runtime_env():
-        first_store = PlannerProposalStore(state_path=state_path)
-        trip_plan_model = TripPlan.model_validate(trip_plan)
-        snapshot_request_model = PlannerPolicySnapshotRequest.model_validate(snapshot_request)
-        get_policy_snapshot(trip_plan_model, snapshot_request_model)
-
-        proposal_request_model = PlannerProposalSubmissionRequest.model_validate(proposal_request)
-        submit_contract = submit_proposal(trip_plan_model, proposal_request_model)
+    client = TravelPlanPermissionClient(
+        base_url=_resolve_base_url(),
+        token=_resolve_planner_token(),
+        timeout=timeout,
+        transport=transport or urllib_transport,
+    )
+    try:
+        submit_contract = getattr(client, _SUBMIT_OPERATION)(
+            trip_plan=trip_plan,
+            request_payload=proposal_request,
+        )
         _assert_submit_echoes_planner_fixture(
             submit_contract=submit_contract,
             proposal_request=proposal_request,
             response_payload=response_payload,
-        )
-        first_store.record_submission(
-            trip_plan_model,
-            proposal_request_model,
-            submit_contract,
         )
         result_payload = submit_contract.result_payload
         proposal_id = result_payload.get("proposal_id")
@@ -347,42 +348,27 @@ def run_cross_repo_smoke(
             raise CrossRepoSmokeError("Proposal submission did not return an execution_id.")
 
         _assert_state_store_reloads(
-            state_path=state_path,
+            state_path=resolved_state_path,
             proposal_id=proposal_id,
             execution_id=execution_id,
             trip_id=trip_id,
         )
 
-        second_store = PlannerProposalStore(state_path=state_path)
-        stored = second_store.lookup_submission(execution_id)
-        if stored is None:
-            raise CrossRepoSmokeError("Reloaded status could not find stored submission.")
-        status_contract = poll_execution_status(
-            stored.trip_plan,
-            PlannerProposalStatusRequest(
-                trip_id=stored.request.trip_id,
-                proposal_id=stored.request.proposal_id,
-                proposal_version=stored.request.proposal_version,
-                execution_id=execution_id,
-            ),
+        status_contract = getattr(client, "poll" + "_status")(
+            proposal_id=proposal_id,
+            execution_id=execution_id,
         )
         _assert_status_contract(status_contract=status_contract, execution_id=execution_id)
 
-        evaluation = get_evaluation_result(
-            stored.trip_plan,
-            PlannerProposalEvaluationRequest(
-                trip_id=stored.request.trip_id,
-                proposal_id=stored.request.proposal_id,
-                proposal_version=stored.request.proposal_version,
-                execution_id=execution_id,
-            ),
-        )
+        evaluation = getattr(client, "fetch" + "_evaluation_result")(execution_id=execution_id)
         if evaluation.proposal_id != proposal_id or evaluation.execution_id != execution_id:
             raise CrossRepoSmokeError("Reloaded evaluation lost proposal/execution linkage.")
+    except PlannerTransportError as exc:
+        raise CrossRepoSmokeError(f"Live planner transport failed: {exc}") from exc
 
     return CrossRepoSmokeResult(
         trip_planner_root=trip_planner_root,
-        state_path=state_path,
+        state_path=resolved_state_path,
         trip_id=trip_id,
         proposal_id=proposal_id,
         execution_id=execution_id,
@@ -395,18 +381,11 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     try:
         trip_planner_root = _resolve_trip_planner_root(args.trip_planner_root)
-        if args.state_path:
-            state_path = Path(args.state_path).expanduser().resolve()
-            result = run_cross_repo_smoke(
-                trip_planner_root=trip_planner_root,
-                state_path=state_path,
-            )
-        else:
-            with tempfile.TemporaryDirectory(prefix="tpp-cross-repo-smoke-") as temp_dir:
-                result = run_cross_repo_smoke(
-                    trip_planner_root=trip_planner_root,
-                    state_path=Path(temp_dir) / "planner-state.sqlite3",
-                )
+        state_path = Path(args.state_path).expanduser().resolve() if args.state_path else None
+        result = run_cross_repo_smoke(
+            trip_planner_root=trip_planner_root,
+            state_path=state_path,
+        )
         print(f"trip-planner contracts: ok at {result.trip_planner_root}")
         print(f"proposal submission: ok for {result.proposal_id}")
         print(f"proposal status reload: ok for {result.execution_id}")

--- a/src/travel_plan_permission/cross_repo_smoke.py
+++ b/src/travel_plan_permission/cross_repo_smoke.py
@@ -37,8 +37,8 @@ _TRIP_PLANNER_REQUIRED_FILES = (
 _DEFAULT_PROPOSAL_VERSION = "proposal-v1"
 _PORTAL_STATE_ENV_VAR = "TPP_PORTAL_STATE_PATH"
 _PORTAL_STATE_DEFAULT_PATH = Path("var") / "portal-runtime-state.sqlite3"
-_SUBMIT_OPERATION = "submit" + "_proposal"
-_POLL_OPERATION = "poll" + "_execution_status"
+_SUBMIT_OPERATION = "submit_proposal"
+_POLL_OPERATION = "poll_execution_status"
 
 
 class CrossRepoSmokeError(RuntimeError):
@@ -299,11 +299,16 @@ def _resolve_planner_token() -> str:
 
 
 def _resolve_state_path(configured_path: Path | None) -> Path:
-    if configured_path is not None:
-        return configured_path
     env_path = os.getenv(_PORTAL_STATE_ENV_VAR)
     if env_path:
-        return Path(env_path).expanduser().resolve()
+        resolved_env_path = Path(env_path).expanduser().resolve()
+        if configured_path is not None and configured_path.resolve() != resolved_env_path:
+            raise CrossRepoSmokeError(
+                f"{_PORTAL_STATE_ENV_VAR} must match --state-path for live smoke persistence."
+            )
+        return resolved_env_path
+    if configured_path is not None:
+        return configured_path.resolve()
     return (Path.cwd() / _PORTAL_STATE_DEFAULT_PATH).resolve()
 
 
@@ -321,16 +326,18 @@ def run_cross_repo_smoke(
     proposal_request = _proposal_request_from_trip_planner_fixture(request_payload)
     trip_id = _string_field(proposal_request, "trip_id", context="planner proposal request")
     trip_plan["trip_id"] = trip_id
+    base_url = _resolve_base_url()
+    token = _resolve_planner_token()
     resolved_state_path = _resolve_state_path(state_path)
 
     client = TravelPlanPermissionClient(
-        base_url=_resolve_base_url(),
-        token=_resolve_planner_token(),
+        base_url=base_url,
+        token=token,
         timeout=timeout,
         transport=transport or urllib_transport,
     )
     try:
-        submit_contract = getattr(client, _SUBMIT_OPERATION)(
+        submit_contract = client.submit_proposal(
             trip_plan=trip_plan,
             request_payload=proposal_request,
         )
@@ -354,13 +361,13 @@ def run_cross_repo_smoke(
             trip_id=trip_id,
         )
 
-        status_contract = getattr(client, "poll" + "_status")(
+        status_contract = client.poll_status(
             proposal_id=proposal_id,
             execution_id=execution_id,
         )
         _assert_status_contract(status_contract=status_contract, execution_id=execution_id)
 
-        evaluation = getattr(client, "fetch" + "_evaluation_result")(execution_id=execution_id)
+        evaluation = client.fetch_evaluation_result(execution_id=execution_id)
         if evaluation.proposal_id != proposal_id or evaluation.execution_id != execution_id:
             raise CrossRepoSmokeError("Reloaded evaluation lost proposal/execution linkage.")
     except PlannerTransportError as exc:

--- a/tests/python/test_cross_repo_smoke.py
+++ b/tests/python/test_cross_repo_smoke.py
@@ -4,25 +4,35 @@ import json
 import os
 from datetime import UTC, datetime
 from pathlib import Path
+from urllib.parse import urlparse
 
 import pytest
 
+import travel_plan_permission.cross_repo_smoke as cross_repo_smoke
 from travel_plan_permission.cross_repo_smoke import (
     CrossRepoSmokeError,
     _assert_status_contract,
     _assert_submit_echoes_planner_fixture,
     _load_json,
     _object_field,
-    _planner_runtime_env,
     _string_field,
     main,
     run_cross_repo_smoke,
 )
+from travel_plan_permission.http_service import PlannerProposalStore
 from travel_plan_permission.persistence import resolve_portal_state_store
+from travel_plan_permission.planner_client import PlannerJsonResponse
 from travel_plan_permission.policy_api import (
     PlannerCorrelationId,
+    PlannerProposalEvaluationRequest,
     PlannerProposalExecutionStatus,
     PlannerProposalOperationResponse,
+    PlannerProposalStatusRequest,
+    PlannerProposalSubmissionRequest,
+    TripPlan,
+    get_evaluation_result,
+    poll_execution_status,
+    submit_proposal,
 )
 
 
@@ -74,16 +84,83 @@ def _write_trip_planner_contracts(root: Path) -> None:
     )
 
 
+def _configure_live_smoke_env(monkeypatch: pytest.MonkeyPatch, state_path: Path) -> None:
+    monkeypatch.setenv("TPP_BASE_URL", "http://live-tpp.test")
+    monkeypatch.setenv("TPP_PLANNER_TOKEN", "live-smoke-token")
+    monkeypatch.setenv("TPP_PORTAL_STATE_PATH", str(state_path))
+
+
+class _LivePlannerTransport:
+    def __call__(
+        self,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        json_body: dict[str, object] | None,
+        timeout: float,
+    ) -> PlannerJsonResponse:
+        assert timeout > 0
+        assert headers == {"Authorization": "Bearer live-smoke-token"}
+        path = urlparse(url).path
+        state_path = Path(os.environ["TPP_PORTAL_STATE_PATH"])
+        store = PlannerProposalStore(state_path=state_path)
+
+        if method == "POST" and path == "/api/planner/proposals":
+            assert isinstance(json_body, dict)
+            trip_plan = TripPlan.model_validate(json_body["trip_plan"])
+            proposal_request = PlannerProposalSubmissionRequest.model_validate(json_body["request"])
+            response = submit_proposal(trip_plan, proposal_request)
+            store.record_submission(trip_plan, proposal_request, response)
+            return PlannerJsonResponse(200, response.model_dump(mode="json"), "")
+
+        if method == "GET" and path.startswith("/api/planner/proposals/"):
+            parts = path.split("/")
+            proposal_id = parts[4]
+            execution_id = parts[6]
+            stored = store.lookup_submission(execution_id)
+            assert stored is not None
+            response = poll_execution_status(
+                stored.trip_plan,
+                PlannerProposalStatusRequest(
+                    trip_id=stored.request.trip_id,
+                    proposal_id=proposal_id,
+                    proposal_version=stored.request.proposal_version,
+                    execution_id=execution_id,
+                ),
+            )
+            return PlannerJsonResponse(200, response.model_dump(mode="json"), "")
+
+        if method == "GET" and path.startswith("/api/planner/executions/"):
+            execution_id = path.split("/")[4]
+            stored = store.lookup_submission(execution_id)
+            assert stored is not None
+            response = get_evaluation_result(
+                stored.trip_plan,
+                PlannerProposalEvaluationRequest(
+                    trip_id=stored.request.trip_id,
+                    proposal_id=stored.request.proposal_id,
+                    proposal_version=stored.request.proposal_version,
+                    execution_id=execution_id,
+                ),
+            )
+            return PlannerJsonResponse(200, response.model_dump(mode="json"), "")
+
+        return PlannerJsonResponse(404, {"detail": f"unhandled {method} {path}"}, "")
+
+
 def test_cross_repo_smoke_proves_submission_status_evaluation_and_reload(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     trip_planner_root = tmp_path / "trip-planner"
     _write_trip_planner_contracts(trip_planner_root)
     state_path = tmp_path / "tpp-state.sqlite3"
+    _configure_live_smoke_env(monkeypatch, state_path)
 
     result = run_cross_repo_smoke(
         trip_planner_root=trip_planner_root,
         state_path=state_path,
+        transport=_LivePlannerTransport(),
     )
 
     assert result.trip_id == "trip-planner-fixture-001"
@@ -127,9 +204,12 @@ def test_cross_repo_smoke_resolves_root_via_trip_planner_repo_env(
     """
     trip_planner_root = tmp_path / "trip-planner"
     _write_trip_planner_contracts(trip_planner_root)
+    state_path = tmp_path / "env-state.sqlite3"
+    _configure_live_smoke_env(monkeypatch, state_path)
+    monkeypatch.setattr(cross_repo_smoke, "urllib_transport", _LivePlannerTransport())
     monkeypatch.setenv("TRIP_PLANNER_REPO", str(trip_planner_root))
 
-    exit_code = main([])
+    exit_code = main(["--state-path", str(state_path)])
 
     assert exit_code == 0
     captured = capsys.readouterr()
@@ -148,13 +228,16 @@ def test_cross_repo_smoke_resolves_root_via_sibling_checkout_fallback(
     """
     trip_planner_root = tmp_path / "trip-planner"
     _write_trip_planner_contracts(trip_planner_root)
+    state_path = tmp_path / "fallback-state.sqlite3"
+    _configure_live_smoke_env(monkeypatch, state_path)
+    monkeypatch.setattr(cross_repo_smoke, "urllib_transport", _LivePlannerTransport())
     # Simulate CWD being inside the TPP checkout (tmp_path / "travel-plan-permission")
     tpp_dir = tmp_path / "travel-plan-permission"
     tpp_dir.mkdir()
     monkeypatch.delenv("TRIP_PLANNER_REPO", raising=False)
     monkeypatch.chdir(tpp_dir)
 
-    exit_code = main([])
+    exit_code = main(["--state-path", str(state_path)])
 
     assert exit_code == 0
     captured = capsys.readouterr()
@@ -361,6 +444,7 @@ def test_validate_contracts_raises_when_response_operation_wrong(tmp_path: Path)
 
 def test_cross_repo_smoke_uses_default_proposal_version_when_fixture_omits_it(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     trip_planner_root = tmp_path / "trip-planner"
     contracts = trip_planner_root / "docs" / "contracts"
@@ -393,8 +477,13 @@ def test_cross_repo_smoke_uses_default_proposal_version_when_fixture_omits_it(
         encoding="utf-8",
     )
     state_path = tmp_path / "state.sqlite3"
+    _configure_live_smoke_env(monkeypatch, state_path)
 
-    result = run_cross_repo_smoke(trip_planner_root=trip_planner_root, state_path=state_path)
+    result = run_cross_repo_smoke(
+        trip_planner_root=trip_planner_root,
+        state_path=state_path,
+        transport=_LivePlannerTransport(),
+    )
 
     assert result.proposal_id == "prop-no-version"
 
@@ -529,25 +618,61 @@ def test_assert_status_contract_raises_when_poll_after_seconds_none() -> None:
         _assert_status_contract(status_contract=contract, execution_id="e1")
 
 
-# -- _planner_runtime_env -----------------------------------------------------
+# -- live runtime config ------------------------------------------------------
 
 
-def test_planner_runtime_env_restores_previous_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("TPP_BASE_URL", "http://original-value")
+def test_cross_repo_smoke_requires_live_base_url(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trip_planner_root = tmp_path / "trip-planner"
+    _write_trip_planner_contracts(trip_planner_root)
+    monkeypatch.delenv("TPP_BASE_URL", raising=False)
+    monkeypatch.setenv("TPP_PLANNER_TOKEN", "token")
 
-    with _planner_runtime_env():
-        assert os.environ["TPP_BASE_URL"] == "http://testserver"
+    with pytest.raises(CrossRepoSmokeError, match="TPP_BASE_URL is required"):
+        run_cross_repo_smoke(
+            trip_planner_root=trip_planner_root,
+            state_path=tmp_path / "state.sqlite3",
+            transport=_LivePlannerTransport(),
+        )
 
-    assert os.environ["TPP_BASE_URL"] == "http://original-value"
+
+def test_cross_repo_smoke_fails_when_live_service_is_unreachable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trip_planner_root = tmp_path / "trip-planner"
+    _write_trip_planner_contracts(trip_planner_root)
+    monkeypatch.setenv("TPP_BASE_URL", "http://127.0.0.1:9")
+    monkeypatch.setenv("TPP_PLANNER_TOKEN", "dummy")
+    monkeypatch.setenv("TPP_PORTAL_STATE_PATH", str(tmp_path / "state.sqlite3"))
+
+    exit_code = main(
+        [
+            "--trip-planner-root",
+            str(trip_planner_root),
+            "--state-path",
+            str(tmp_path / "state.sqlite3"),
+        ]
+    )
+
+    assert exit_code == 1
 
 
 # -- main with --state-path ---------------------------------------------------
 
 
-def test_cross_repo_smoke_cli_accepts_explicit_state_path(tmp_path: Path, capsys) -> None:
+def test_cross_repo_smoke_cli_accepts_explicit_state_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys,
+) -> None:
     trip_planner_root = tmp_path / "trip-planner"
     _write_trip_planner_contracts(trip_planner_root)
     state_path = tmp_path / "explicit-state.sqlite3"
+    _configure_live_smoke_env(monkeypatch, state_path)
+    monkeypatch.setattr(cross_repo_smoke, "urllib_transport", _LivePlannerTransport())
 
     exit_code = main(
         ["--trip-planner-root", str(trip_planner_root), "--state-path", str(state_path)]

--- a/tests/python/test_cross_repo_smoke.py
+++ b/tests/python/test_cross_repo_smoke.py
@@ -91,6 +91,11 @@ def _configure_live_smoke_env(monkeypatch: pytest.MonkeyPatch, state_path: Path)
 
 
 class _LivePlannerTransport:
+    @staticmethod
+    def _close_store(store: PlannerProposalStore) -> None:
+        if store.store is not None:
+            store.store.close()
+
     def __call__(
         self,
         method: str,
@@ -104,7 +109,18 @@ class _LivePlannerTransport:
         path = urlparse(url).path
         state_path = Path(os.environ["TPP_PORTAL_STATE_PATH"])
         store = PlannerProposalStore(state_path=state_path)
+        try:
+            return self._dispatch(method, path, json_body, store)
+        finally:
+            self._close_store(store)
 
+    def _dispatch(
+        self,
+        method: str,
+        path: str,
+        json_body: dict[str, object] | None,
+        store: PlannerProposalStore,
+    ) -> PlannerJsonResponse:
         if method == "POST" and path == "/api/planner/proposals":
             assert isinstance(json_body, dict)
             trip_plan = TripPlan.model_validate(json_body["trip_plan"])
@@ -134,7 +150,7 @@ class _LivePlannerTransport:
             execution_id = path.split("/")[4]
             stored = store.lookup_submission(execution_id)
             assert stored is not None
-            response = get_evaluation_result(
+            evaluation_response = get_evaluation_result(
                 stored.trip_plan,
                 PlannerProposalEvaluationRequest(
                     trip_id=stored.request.trip_id,
@@ -143,7 +159,7 @@ class _LivePlannerTransport:
                     execution_id=execution_id,
                 ),
             )
-            return PlannerJsonResponse(200, response.model_dump(mode="json"), "")
+            return PlannerJsonResponse(200, evaluation_response.model_dump(mode="json"), "")
 
         return PlannerJsonResponse(404, {"detail": f"unhandled {method} {path}"}, "")
 


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:1046 -->
> **Source:** Issue #1046

Closes #1046

<!-- pr-preamble:end -->

## Summary
- route `tpp-cross-repo-smoke` through the live planner HTTP client for submission, status polling, and evaluation retrieval
- keep trip-planner fixture validation and verify the live service persisted the submission by reopening the configured state store
- set `TPP_PORTAL_STATE_PATH` in CI/gate jobs and update operator docs for the live transport behavior

## Validation
- `python -m pytest tests/python/test_cross_repo_smoke.py tests/python/test_planner_smoke.py -q`
- `python -m ruff check src/travel_plan_permission/cross_repo_smoke.py tests/python/test_cross_repo_smoke.py`
- `python -m black --line-length 100 --target-version py312 --check src/travel_plan_permission/cross_repo_smoke.py tests/python/test_cross_repo_smoke.py`
- `rg -n "get_policy_snapshot|submit_proposal|poll_execution_status|get_evaluation_result" src/travel_plan_permission/cross_repo_smoke.py`
