### PR TITLE
Follow-up: prove live cross-repo smoke client path

### DIFF
--- a/tests/python/test_cross_repo_smoke.py
+++ b/tests/python/test_cross_repo_smoke.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import ast
+import inspect
 import json
 import os
+import textwrap
 from datetime import UTC, datetime
 from pathlib import Path
 from urllib.parse import urlparse
@@ -193,6 +196,37 @@ def test_cross_repo_smoke_proves_submission_status_evaluation_and_reload(
     stored = persisted["proposals_by_execution_id"][result.execution_id]
     assert stored["request"]["proposal_version"] == "planner-proposal-v2"
     assert stored["request"]["payload"] == {"proposal_ref": "planner-proposal-123"}
+
+
+def test_run_cross_repo_smoke_uses_live_client_instead_of_direct_policy_calls() -> None:
+    source = textwrap.dedent(inspect.getsource(cross_repo_smoke.run_cross_repo_smoke))
+    tree = ast.parse(source)
+    direct_calls = {
+        node.func.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    method_calls = {
+        node.func.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+    }
+
+    assert "TravelPlanPermissionClient" in direct_calls
+    assert {
+        "submit_proposal",
+        "poll_status",
+        "fetch_evaluation_result",
+    }.issubset(method_calls)
+    assert (
+        not {
+            "get_policy_snapshot",
+            "submit_proposal",
+            "poll_execution_status",
+            "get_evaluation_result",
+        }
+        & direct_calls
+    )
 
 
 def test_cross_repo_smoke_cli_reports_missing_trip_planner_checkout(

--- a/tests/python/test_cross_repo_smoke.py
+++ b/tests/python/test_cross_repo_smoke.py
@@ -201,32 +201,52 @@ def test_cross_repo_smoke_proves_submission_status_evaluation_and_reload(
 def test_run_cross_repo_smoke_uses_live_client_instead_of_direct_policy_calls() -> None:
     source = textwrap.dedent(inspect.getsource(cross_repo_smoke.run_cross_repo_smoke))
     tree = ast.parse(source)
-    direct_calls = {
-        node.func.id
-        for node in ast.walk(tree)
-        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
-    }
-    method_calls = {
-        node.func.attr
-        for node in ast.walk(tree)
-        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
-    }
+    client_variables = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        if not isinstance(node.value, ast.Call):
+            continue
+        if not isinstance(node.value.func, ast.Name):
+            continue
+        if node.value.func.id != "TravelPlanPermissionClient":
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                client_variables.add(target.id)
 
-    assert "TravelPlanPermissionClient" in direct_calls
+    client_method_calls = set()
+    forbidden_direct_calls = set()
+    forbidden_non_client_method_calls = set()
+    forbidden_policy_calls = {
+        "get_policy_snapshot",
+        "submit_proposal",
+        "poll_execution_status",
+        "get_evaluation_result",
+    }
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if isinstance(node.func, ast.Name):
+            if node.func.id in forbidden_policy_calls:
+                forbidden_direct_calls.add(node.func.id)
+            continue
+        if not isinstance(node.func, ast.Attribute):
+            continue
+        if isinstance(node.func.value, ast.Name) and node.func.value.id in client_variables:
+            client_method_calls.add(node.func.attr)
+            continue
+        if node.func.attr in forbidden_policy_calls:
+            forbidden_non_client_method_calls.add(node.func.attr)
+
+    assert client_variables == {"client"}
     assert {
         "submit_proposal",
         "poll_status",
         "fetch_evaluation_result",
-    }.issubset(method_calls)
-    assert (
-        not {
-            "get_policy_snapshot",
-            "submit_proposal",
-            "poll_execution_status",
-            "get_evaluation_result",
-        }
-        & direct_calls
-    )
+    }.issubset(client_method_calls)
+    assert not forbidden_direct_calls
+    assert not forbidden_non_client_method_calls
 
 
 def test_cross_repo_smoke_cli_reports_missing_trip_planner_checkout(


### PR DESCRIPTION
Follow-up for source PR #1066 and issue #1046.

## Why

The post-merge provider comparison for #1066 reported Anthropic CONCERNS because the verifier prompt had a truncated diff and could not directly confirm that `tpp-cross-repo-smoke` uses the live `TravelPlanPermissionClient` path instead of direct in-process policy API calls.

## Scope

Add a focused regression test that inspects `run_cross_repo_smoke` and proves the main execution path constructs `TravelPlanPermissionClient`, calls `submit_proposal`, `poll_status`, and `fetch_evaluation_result` as client methods, and does not directly call `get_policy_snapshot`, `submit_proposal`, `poll_execution_status`, or `get_evaluation_result` as in-process policy functions.

## Validation

- `python -m pytest tests/python/test_cross_repo_smoke.py -q`
- `python -m ruff check tests/python/test_cross_repo_smoke.py`
- `python -m black --line-length 100 --target-version py312 --check tests/python/test_cross_repo_smoke.py`

Refs #1046.