### PR TITLE
Resolve planner proposal status contract

### DIFF
--- a/docs/contracts/planner-integration.md
+++ b/docs/contracts/planner-integration.md
@@ -158,13 +158,20 @@ shape. At submission time:
 
 ### 3. Read proposal status
 
-TPP returns the same canonical `TripPlan` shape for status readback, enriched
-with:
+TPP returns a `PlannerProposalOperationResponse` for status readback. The
+top-level envelope remains the polling contract for queue state, execution
+state, `result_endpoint`, `proposal_id`, and `execution_id` linkage. The
+canonical planner-facing status details live in the typed `proposal_status`
+field, which includes:
 
 - the latest `status`,
 - immutable `approval_history`,
 - any current `validation_results`,
 - any `exception_requests` captured during review.
+
+Callers should use `submission_status` and `execution_status` to decide whether
+to keep polling, then read `proposal_status` for approval, validation, and
+exception state that belongs to the trip proposal itself.
 
 ### 4. Consume policy evaluation results
 

--- a/src/travel_plan_permission/policy_api.py
+++ b/src/travel_plan_permission/policy_api.py
@@ -30,7 +30,6 @@ from .models import (
     ExpenseReport,
     TripPlan,
     TripStatus,
-    ValidationResult,
 )
 from .policy import PolicyContext, PolicyEngine, PolicyResult, Severity
 from .policy_versioning import PolicyVersion
@@ -41,6 +40,7 @@ from .security import (
     PLANNER_EXECUTION_STATUS_ENDPOINT,
     PLANNER_POLICY_SNAPSHOT_ENDPOINT,
 )
+from .validation import ValidationResult
 
 PolicyIssueSeverity = Literal["info", "warning", "error"]
 PolicyCheckStatus = Literal["pass", "fail"]

--- a/src/travel_plan_permission/policy_api.py
+++ b/src/travel_plan_permission/policy_api.py
@@ -23,12 +23,14 @@ from pydantic import BaseModel, Field
 from .canonical import CanonicalTripPlan
 from .mapping import TemplateMapping, load_template_mapping
 from .models import (
+    ApprovalEvent,
     ExceptionRequest,
     ExpenseCategory,
     ExpenseItem,
     ExpenseReport,
     TripPlan,
     TripStatus,
+    ValidationResult,
 )
 from .policy import PolicyContext, PolicyEngine, PolicyResult, Severity
 from .policy_versioning import PolicyVersion
@@ -92,6 +94,7 @@ __all__ = [
     "PlannerRetryMetadata",
     "PlannerErrorRecord",
     "PlannerProposalExecutionStatus",
+    "PlannerProposalStatusPayload",
     "PlannerProposalSubmissionRequest",
     "PlannerProposalStatusRequest",
     "PlannerProposalEvaluationRequest",
@@ -297,6 +300,28 @@ class PlannerProposalExecutionStatus(BaseModel):
     )
 
 
+class PlannerProposalStatusPayload(BaseModel):
+    """Canonical trip proposal status details carried by a poll response."""
+
+    trip_id: str = Field(..., description="Trip identifier linked to the proposal")
+    proposal_id: str = Field(..., description="Stable planner proposal identifier")
+    proposal_version: str = Field(..., description="Planner proposal version identifier")
+    execution_id: str = Field(..., description="Execution identifier returned on submit")
+    status: TripStatus = Field(..., description="Current canonical trip proposal status")
+    approval_history: tuple[ApprovalEvent, ...] = Field(
+        default_factory=tuple,
+        description="Immutable approval and override history for this proposal",
+    )
+    validation_results: list[ValidationResult] = Field(
+        default_factory=list,
+        description="Latest validation results attached to the proposal",
+    )
+    exception_requests: list[ExceptionRequest] = Field(
+        default_factory=list,
+        description="Current exception requests linked to the proposal",
+    )
+
+
 class PlannerProposalSubmissionRequest(BaseModel):
     """Planner-facing submission request contract for proposal execution."""
 
@@ -373,6 +398,10 @@ class PlannerProposalOperationResponse(BaseModel):
     )
     result_payload: dict[str, object] = Field(
         default_factory=dict, description="Structured linkage payload for the planner"
+    )
+    proposal_status: PlannerProposalStatusPayload | None = Field(
+        default=None,
+        description="Canonical status readback details when polling a stored proposal",
     )
     error: PlannerErrorRecord | None = Field(
         default=None, description="Structured error detail when the operation failed"
@@ -941,6 +970,25 @@ def _proposal_result_payload(
     }
 
 
+def _proposal_status_payload(
+    *,
+    plan: TripPlan,
+    proposal_id: str,
+    proposal_version: str,
+    execution_id: str,
+) -> PlannerProposalStatusPayload:
+    return PlannerProposalStatusPayload(
+        trip_id=plan.trip_id,
+        proposal_id=proposal_id,
+        proposal_version=proposal_version,
+        execution_id=execution_id,
+        status=plan.status,
+        approval_history=plan.approval_history,
+        validation_results=plan.validation_results,
+        exception_requests=plan.exception_requests,
+    )
+
+
 def _proposal_response_for_plan(
     *,
     operation: PlannerOperationType,
@@ -968,6 +1016,16 @@ def _proposal_response_for_plan(
     )
     if organization_id is not None:
         base_payload["organization_id"] = organization_id
+    status_payload = (
+        _proposal_status_payload(
+            plan=plan,
+            proposal_id=proposal_id,
+            proposal_version=proposal_version,
+            execution_id=execution_id,
+        )
+        if operation == "poll_execution_status"
+        else None
+    )
 
     if not service_available:
         return PlannerProposalOperationResponse(
@@ -995,6 +1053,7 @@ def _proposal_response_for_plan(
             ),
             received_at=event_time,
             status_endpoint=status_endpoint,
+            proposal_status=status_payload,
         )
 
     if plan.status == TripStatus.REJECTED:
@@ -1021,6 +1080,7 @@ def _proposal_response_for_plan(
             ),
             received_at=event_time,
             status_endpoint=status_endpoint,
+            proposal_status=status_payload,
         )
 
     if plan.status in {TripStatus.APPROVED, TripStatus.COMPLETED}:
@@ -1040,6 +1100,7 @@ def _proposal_response_for_plan(
             result_payload=base_payload | {"queue_state": "completed"},
             received_at=event_time,
             status_endpoint=status_endpoint,
+            proposal_status=status_payload,
         )
 
     pending_state: PlannerExecutionState = "running" if transport_pattern == "async" else "deferred"
@@ -1071,6 +1132,7 @@ def _proposal_response_for_plan(
         ),
         received_at=event_time,
         status_endpoint=status_endpoint,
+        proposal_status=status_payload,
     )
 
 

--- a/tests/fixtures/planner_integration/proposal_status.json
+++ b/tests/fixtures/planner_integration/proposal_status.json
@@ -1,57 +1,50 @@
 {
-  "trip_id": "TRIP-PLANNER-2001",
-  "traveler_name": "Jordan Lee",
-  "traveler_role": "Program Manager",
-  "department": "Operations",
-  "destination": "Chicago, IL 60601",
-  "origin_city": "Austin, TX",
-  "destination_city": "Chicago, IL",
-  "departure_date": "2026-05-20",
-  "return_date": "2026-05-22",
-  "purpose": "Planner integration rehearsal",
-  "transportation_mode": "air",
-  "expected_costs": {
-    "airfare": 420.5,
-    "lodging": 610.0,
-    "meals": 160.0
+  "operation": "poll_execution_status",
+  "submission_status": "succeeded",
+  "request_id": "req-6c7111b78d37",
+  "correlation_id": {
+    "value": "corr-4de8cc0e31f6",
+    "issued_by": "trip-planner"
   },
-  "funding_source": "OPS-INT",
-  "estimated_cost": 1190.5,
-  "status": "approved",
-  "expense_breakdown": {
-    "airfare": 420.5,
-    "lodging": 610.0,
-    "meals": 160.0
+  "transport_pattern": "deferred",
+  "execution_status": {
+    "state": "succeeded",
+    "terminal": true,
+    "summary": "Proposal execution completed successfully.",
+    "external_status": "200 OK",
+    "poll_after_seconds": null,
+    "updated_at": "2026-04-11T06:10:00Z"
   },
-  "selected_fare": 420.5,
-  "lowest_fare": 399.0,
-  "cabin_class": "economy",
-  "flight_duration_hours": 2.8,
-  "fare_evidence_attached": true,
-  "driving_cost": 280.0,
-  "flight_cost": 420.5,
-  "comparable_hotels": [
-    590.0,
-    610.0
-  ],
-  "overnight_stay": true,
-  "meals_provided": false,
-  "meal_per_diem_requested": true,
-  "selected_providers": {
-    "airfare": "Blue Skies Airlines",
-    "lodging": "Loop Business Hotel"
+  "result_payload": {
+    "trip_id": "TRIP-PLANNER-2001",
+    "proposal_id": "proposal-2001",
+    "proposal_version": "proposal-v1",
+    "execution_id": "exec-10c6fb4730f2",
+    "queue_state": "completed",
+    "result_endpoint": "GET /api/planner/executions/exec-10c6fb4730f2/evaluation-result"
   },
-  "validation_results": [],
-  "approval_history": [
-    {
-      "approver_id": "manager-001",
-      "level": "manager",
-      "outcome": "approved",
-      "timestamp": "2026-04-11T06:10:00Z",
-      "justification": null,
-      "previous_status": "submitted",
-      "new_status": "approved"
-    }
-  ],
-  "exception_requests": []
+  "proposal_status": {
+    "trip_id": "TRIP-PLANNER-2001",
+    "proposal_id": "proposal-2001",
+    "proposal_version": "proposal-v1",
+    "execution_id": "exec-10c6fb4730f2",
+    "status": "approved",
+    "validation_results": [],
+    "approval_history": [
+      {
+        "approver_id": "manager-001",
+        "level": "manager",
+        "outcome": "approved",
+        "timestamp": "2026-04-11T06:10:00Z",
+        "justification": null,
+        "previous_status": "submitted",
+        "new_status": "approved"
+      }
+    ],
+    "exception_requests": []
+  },
+  "error": null,
+  "retry": null,
+  "received_at": "2026-04-11T06:10:00Z",
+  "status_endpoint": "GET /api/planner/proposals/proposal-2001/executions/exec-10c6fb4730f2"
 }

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -2342,6 +2342,18 @@ def test_submission_status_lookup_survives_restart(monkeypatch, tmp_path) -> Non
     state_path = tmp_path / "portal-runtime-state.sqlite3"
     first_client = TestClient(create_app(PlannerProposalStore(state_path=state_path)))
     trip_plan = _load_fixture("proposal_submission.json")
+    trip_plan["status"] = "approved"
+    trip_plan["approval_history"] = [
+        {
+            "approver_id": "manager-001",
+            "level": "manager",
+            "outcome": "approved",
+            "timestamp": "2026-04-11T06:10:00Z",
+            "justification": None,
+            "previous_status": "submitted",
+            "new_status": "approved",
+        }
+    ]
     request_payload = {
         "trip_id": trip_plan["trip_id"],
         "proposal_id": "proposal-123",
@@ -2369,6 +2381,13 @@ def test_submission_status_lookup_survives_restart(monkeypatch, tmp_path) -> Non
     )
 
     assert status_response.status_code == 200
+    status_payload = status_response.json()
+    assert status_payload["operation"] == "poll_execution_status"
+    assert status_payload["submission_status"] == "succeeded"
+    assert status_payload["proposal_status"]["status"] == "approved"
+    assert status_payload["proposal_status"]["approval_history"][0]["new_status"] == "approved"
+    assert status_payload["proposal_status"]["validation_results"] == []
+    assert status_payload["proposal_status"]["exception_requests"] == []
     assert evaluation_response.status_code == 200
 
 

--- a/tests/python/test_planner_client.py
+++ b/tests/python/test_planner_client.py
@@ -61,6 +61,16 @@ def _operation_payload(
             "execution_id": "exec-949",
             "raw_response": {"provider_status": execution_state},
         },
+        "proposal_status": {
+            "trip_id": "TRIP-949",
+            "proposal_id": "proposal-123",
+            "proposal_version": "proposal-v1",
+            "execution_id": "exec-949",
+            "status": "rejected" if submission_status == "failed" else "approved" if terminal else "submitted",
+            "approval_history": [],
+            "validation_results": [],
+            "exception_requests": [],
+        },
         "error": None,
         "retry": None,
         "received_at": "2026-04-27T00:00:01Z",
@@ -150,6 +160,8 @@ def test_polling_returns_terminal_response_without_dropping_body() -> None:
     assert result.execution_status is not None
     assert result.execution_status.terminal is True
     assert result.result_payload["raw_response"] == {"provider_status": "failed"}
+    assert result.proposal_status is not None
+    assert result.proposal_status.status.value == "rejected"
     assert [call[0] for call in transport.calls] == ["GET", "GET"]
     assert sleep_calls == [1]
 
@@ -219,3 +231,15 @@ def test_fetch_evaluation_result_parses_planner_contract_fixture() -> None:
     assert result.execution_id == "exec-10c6fb4730f2"
     assert result.outcome == "compliant"
     assert result.policy_result.status == "pass"
+
+
+def test_poll_status_parses_planner_status_contract_fixture() -> None:
+    payload = json.loads((FIXTURE_ROOT / "proposal_status.json").read_text(encoding="utf-8"))
+    transport = ScriptedTransport([_json_response(payload)])
+    client = _client(transport)
+
+    result = client.poll_status(proposal_id="proposal-2001", execution_id="exec-10c6fb4730f2")
+
+    assert result.proposal_status is not None
+    assert result.proposal_status.status.value == "approved"
+    assert result.proposal_status.approval_history[0].approver_id == "manager-001"

--- a/tests/python/test_planner_integration_contract.py
+++ b/tests/python/test_planner_integration_contract.py
@@ -8,6 +8,7 @@ from travel_plan_permission.policy_api import (
     PlannerPolicySnapshot,
     PlannerPolicySnapshotRequest,
     PlannerProposalEvaluationResult,
+    PlannerProposalOperationResponse,
 )
 
 FIXTURE_ROOT = Path(__file__).resolve().parents[1] / "fixtures" / "planner_integration"
@@ -65,12 +66,16 @@ def test_proposal_submission_fixture_matches_trip_plan_model() -> None:
     assert submission.selected_providers["airfare"] == "Blue Skies Airlines"
 
 
-def test_proposal_status_fixture_matches_trip_plan_model() -> None:
-    status_payload = TripPlan.model_validate(_load_fixture("proposal_status.json"))
+def test_proposal_status_fixture_matches_operation_response_model() -> None:
+    status_payload = PlannerProposalOperationResponse.model_validate(
+        _load_fixture("proposal_status.json")
+    )
 
-    assert status_payload.status.value == "approved"
-    assert len(status_payload.approval_history) == 1
-    assert status_payload.approval_history[0].new_status.value == "approved"
+    assert status_payload.operation == "poll_execution_status"
+    assert status_payload.proposal_status is not None
+    assert status_payload.proposal_status.status.value == "approved"
+    assert len(status_payload.proposal_status.approval_history) == 1
+    assert status_payload.proposal_status.approval_history[0].new_status.value == "approved"
 
 
 def test_compliant_evaluation_result_fixture_matches_model() -> None:


### PR DESCRIPTION
## Summary
- add a typed proposal_status payload to planner status poll responses
- update the proposal status fixture, client parsing tests, and live restart route coverage
- revise the planner integration contract docs to describe the operation envelope plus canonical status field

Closes #1047

## Tests
- python -m ruff check src/travel_plan_permission/policy_api.py tests/python/test_planner_integration_contract.py tests/python/test_planner_client.py tests/python/test_http_service.py
- python -m pytest tests/python/test_planner_integration_contract.py tests/python/test_http_service.py::test_submission_status_lookup_survives_restart tests/python/test_planner_client.py -q