### PR TITLE
Reconcile persisted portal state records

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,10 @@ shared staging deployments, set `TPP_PORTAL_DATABASE_URL` (e.g.
 the optional `postgres` extra to pull in the `psycopg` driver. Pre-existing
 local state at `var/portal-runtime-state.json` (the deprecated single-file
 backend) is imported once on first start when the sibling SQLite file is
-created. Pass a `.json`-suffixed path or set `TPP_PORTAL_BACKEND=json` to
-keep using the deprecated JSON file during migration. For restart
+created. SQL snapshot saves reconcile keyed record namespaces, so drafts,
+reviews, submissions, plans, and exception records evicted from memory do not
+reappear after restart. Pass a `.json`-suffixed path or set
+`TPP_PORTAL_BACKEND=json` to keep using the deprecated JSON file during migration. For restart
 verification, create a draft, copy the `/portal/review/{draft_id}` URL,
 restart the service, and reopen the same page to confirm the review state,
 submission result, and follow-on review link still render intentionally

--- a/docs/local-testing-plan.md
+++ b/docs/local-testing-plan.md
@@ -114,8 +114,9 @@ restart-oriented local check whenever you touch portal workflow state:
 
 For multi-instance staging, also exercise the same flow against a Postgres
 URL: two service instances pointing at the same database should each see the
-other instance's drafts after a refresh, since per-record upserts at the SQL
-layer prevent lost writes between processes.
+latest committed snapshot after a refresh. Keyed record namespaces reconcile
+on save, so records evicted from one instance's serialized state should not
+reappear after restart.
 
 Treat any restart-sensitive data loss as a regression to file rather than as
 an ambiguous flake.

--- a/src/travel_plan_permission/persistence/postgres_store.py
+++ b/src/travel_plan_permission/persistence/postgres_store.py
@@ -1,7 +1,7 @@
 """Postgres-backed portal state store, gated on TPP_PORTAL_DATABASE_URL.
 
 The driver (``psycopg``) is loaded lazily so the import cost only applies
-when a Postgres URL is configured. The schema and per-record-upsert
+when a Postgres URL is configured. The schema and per-namespace reconcile
 semantics mirror :class:`SQLitePortalStateStore`; the SQL strings differ only
 where Postgres syntax requires (e.g. ``ON CONFLICT`` parameter ordering).
 """
@@ -107,6 +107,19 @@ class PostgresPortalStateStore:
         with conn.transaction(), conn.cursor() as cur:
             for namespace, value in snapshot.items():
                 if namespace in RECORD_NAMESPACES and isinstance(value, dict):
+                    record_keys = [str(record_key) for record_key in value]
+                    if record_keys:
+                        cur.execute(
+                            "DELETE FROM tpp.portal_records "
+                            "WHERE namespace = %s "
+                            "AND NOT (record_key = ANY(%s))",
+                            (namespace, record_keys),
+                        )
+                    else:
+                        cur.execute(
+                            "DELETE FROM tpp.portal_records WHERE namespace = %s",
+                            (namespace,),
+                        )
                     for record_key, payload in value.items():
                         cur.execute(
                             "INSERT INTO tpp.portal_records "

--- a/src/travel_plan_permission/persistence/sqlite_store.py
+++ b/src/travel_plan_permission/persistence/sqlite_store.py
@@ -9,12 +9,11 @@ not set. The store uses three tables:
 * ``portal_singletons`` — single-row payload for namespaces that don't fit
   the keyed model (e.g. ``review_ids_by_draft_id``).
 
-``save_snapshot`` upserts mapped records inside a single transaction. It does
-not delete records that are absent from the snapshot; the in-memory
-``PlannerProposalStore`` may LRU-evict records on its side, and a follow-up
-will add an explicit per-record delete API. Until then, two concurrent
-processes can write different ids to the same backing store and both records
-survive (per-record CAS at the SQL row level).
+``save_snapshot`` reconciles each mapped namespace inside a single
+transaction: rows whose keys are absent from the latest serialized snapshot are
+deleted before current records are upserted. This keeps SQL-backed restart
+state aligned with in-memory LRU eviction for portal drafts, expense drafts,
+manager reviews, submissions, plans, and exception requests.
 """
 
 from __future__ import annotations
@@ -114,6 +113,20 @@ class SQLitePortalStateStore:
         with _transaction(conn):
             for namespace, value in snapshot.items():
                 if namespace in RECORD_NAMESPACES and isinstance(value, dict):
+                    record_keys = [str(record_key) for record_key in value]
+                    if record_keys:
+                        placeholders = ", ".join("?" for _ in record_keys)
+                        conn.execute(
+                            "DELETE FROM portal_records "
+                            "WHERE namespace = ? "
+                            f"AND record_key NOT IN ({placeholders})",
+                            (namespace, *record_keys),
+                        )
+                    else:
+                        conn.execute(
+                            "DELETE FROM portal_records WHERE namespace = ?",
+                            (namespace,),
+                        )
                     for record_key, payload in value.items():
                         conn.execute(
                             "INSERT INTO portal_records "

--- a/src/travel_plan_permission/persistence/store.py
+++ b/src/travel_plan_permission/persistence/store.py
@@ -42,10 +42,10 @@ class PortalStateStore(Protocol):
     def save_snapshot(self, snapshot: dict[str, object]) -> None:
         """Persist a serialized snapshot.
 
-        Implementations should perform per-record upserts (within a single
-        transaction) for the namespaces declared in :data:`RECORD_NAMESPACES`
-        so two processes writing different ids do not clobber each other's
-        rows. Singleton mappings (e.g. ``review_ids_by_draft_id``) may be
+        Implementations should reconcile each namespace declared in
+        :data:`RECORD_NAMESPACES` within a single transaction: delete rows whose
+        keys are absent from the incoming namespace, then upsert the current
+        records. Singleton mappings (e.g. ``review_ids_by_draft_id``) may be
         stored as a single blob.
         """
 

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -1930,8 +1930,9 @@ def test_portal_exception_decision_returns_404_for_missing_request(monkeypatch) 
     assert response.json()["detail"] == "Exception request not found."
 
 
-def test_save_portal_draft_evicts_exception_state_with_oldest_draft() -> None:
-    store = PlannerProposalStore()
+def test_save_portal_draft_evicts_exception_state_with_oldest_draft(tmp_path) -> None:
+    state_path = tmp_path / "portal-runtime-state.sqlite3"
+    store = PlannerProposalStore(state_path=state_path)
     old_draft = store.save_portal_draft({"traveler_name": "First"})
     store.create_exception_request(
         old_draft.draft_id,
@@ -1948,6 +1949,10 @@ def test_save_portal_draft_evicts_exception_state_with_oldest_draft() -> None:
 
     assert old_draft.draft_id not in store.portal_drafts_by_id
     assert old_draft.draft_id not in store.exception_requests_by_draft_id
+
+    reopened = PlannerProposalStore(state_path=state_path)
+    assert old_draft.draft_id not in reopened.portal_drafts_by_id
+    assert old_draft.draft_id not in reopened.exception_requests_by_draft_id
 
 
 def test_manager_review_store_returns_copies() -> None:

--- a/tests/python/test_portal_state_store.py
+++ b/tests/python/test_portal_state_store.py
@@ -72,10 +72,7 @@ class TestSQLitePortalStateStore:
         finally:
             store.close()
 
-    def test_per_record_upsert_preserves_other_records(self, tmp_path: Path) -> None:
-        # Two store instances writing different draft ids should both survive,
-        # since save_snapshot upserts per-record rather than overwriting the
-        # full namespace.
+    def test_save_snapshot_reconciles_absent_records(self, tmp_path: Path) -> None:
         path = tmp_path / "concurrent.sqlite3"
         store_a = SQLitePortalStateStore(path)
         store_a.initialize()
@@ -89,12 +86,12 @@ class TestSQLitePortalStateStore:
         loaded.initialize()
         snapshot = loaded.load_snapshot()
         assert snapshot is not None
-        assert set(snapshot["portal_drafts_by_id"].keys()) == {"alpha", "beta"}
+        assert set(snapshot["portal_drafts_by_id"].keys()) == {"beta"}
         store_a.close()
         store_b.close()
         loaded.close()
 
-    def test_expense_drafts_use_per_record_upserts(self, tmp_path: Path) -> None:
+    def test_empty_record_namespace_removes_all_records(self, tmp_path: Path) -> None:
         path = tmp_path / "expense-concurrent.sqlite3"
         store_a = SQLitePortalStateStore(path)
         store_a.initialize()
@@ -102,18 +99,17 @@ class TestSQLitePortalStateStore:
 
         store_b = SQLitePortalStateStore(path)
         store_b.initialize()
-        store_b.save_snapshot({"expense_drafts_by_id": {"exp-b": _draft_payload({"who": "b"})}})
+        store_b.save_snapshot({"expense_drafts_by_id": {}})
 
         loaded = SQLitePortalStateStore(path)
         loaded.initialize()
         snapshot = loaded.load_snapshot()
-        assert snapshot is not None
-        assert set(snapshot["expense_drafts_by_id"].keys()) == {"exp-a", "exp-b"}
+        assert snapshot is None or snapshot["expense_drafts_by_id"] == {}
         store_a.close()
         store_b.close()
         loaded.close()
 
-    def test_threaded_writers_dont_lose_records(self, tmp_path: Path) -> None:
+    def test_reconcile_is_transactional_for_threaded_writers(self, tmp_path: Path) -> None:
         path = tmp_path / "threads.sqlite3"
         bootstrap = SQLitePortalStateStore(path)
         bootstrap.initialize()
@@ -145,7 +141,23 @@ class TestSQLitePortalStateStore:
         snapshot = store.load_snapshot()
         store.close()
         assert snapshot is not None
-        assert set(snapshot["portal_drafts_by_id"].keys()) == set(ids)
+        assert len(snapshot["portal_drafts_by_id"]) == 1
+        assert next(iter(snapshot["portal_drafts_by_id"])) in set(ids)
+
+    def test_lru_evicted_portal_drafts_stay_evicted_after_restart(
+        self, tmp_path: Path
+    ) -> None:
+        state_path = tmp_path / "portal-runtime-state.sqlite3"
+        first_store = PlannerProposalStore(state_path=state_path)
+
+        for index in range(65):
+            first_store.save_portal_draft({"traveler_name": f"Traveler {index}"})
+
+        expected_keys = set(first_store.portal_drafts_by_id)
+
+        reopened = PlannerProposalStore(state_path=state_path)
+        assert set(reopened.portal_drafts_by_id) == expected_keys
+        assert len(reopened.portal_drafts_by_id) == 64
 
 
 class TestJsonPortalStateStore:
@@ -539,6 +551,35 @@ class TestPostgresPortalStateStore:
             }
         )
         assert mock_cur.execute.call_count >= 2
+        store.close()
+
+    def test_save_snapshot_deletes_stale_postgres_records(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_pg, mock_conn, mock_cur = self._make_mock_psycopg()
+        monkeypatch.setitem(sys.modules, "psycopg", mock_pg)
+
+        from travel_plan_permission.persistence.postgres_store import PostgresPortalStateStore
+
+        store = PostgresPortalStateStore("postgresql://test/db")
+        store.save_snapshot(
+            {
+                "portal_drafts_by_id": {
+                    "d1": {"answers": {}},
+                    "d2": {"answers": {}},
+                },
+                "exception_requests_by_draft_id": {},
+            }
+        )
+
+        delete_calls = [
+            call
+            for call in mock_cur.execute.call_args_list
+            if call.args and str(call.args[0]).startswith("DELETE FROM tpp.portal_records")
+        ]
+        assert len(delete_calls) == 2
+        assert delete_calls[0].args[1] == ("portal_drafts_by_id", ["d1", "d2"])
+        assert delete_calls[1].args[1] == ("exception_requests_by_draft_id",)
         store.close()
 
     def test_close_when_never_connected(self) -> None:


### PR DESCRIPTION
## Summary
- reconcile SQLite/Postgres record namespaces so LRU-evicted rows are deleted on snapshot save
- add restart coverage for evicted portal drafts and exception state plus mocked Postgres stale-row deletes
- update persistence docs to describe namespace reconciliation behavior

Closes #1048

## Tests
- python -m ruff check src/travel_plan_permission/persistence/sqlite_store.py src/travel_plan_permission/persistence/postgres_store.py src/travel_plan_permission/persistence/store.py tests/python/test_portal_state_store.py tests/python/test_http_service.py
- python -m pytest tests/python/test_portal_state_store.py tests/python/test_http_service.py::test_save_portal_draft_evicts_exception_state_with_oldest_draft -q