### PR TITLE
Codex bootstrap for #1071

### DIFF
--- a/agents/codex-1071.md
+++ b/agents/codex-1071.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #1071 -->

--- a/agents/codex-1071.md
+++ b/agents/codex-1071.md
@@ -1,1 +1,0 @@
-<!-- bootstrap for codex on issue #1071 -->

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -7,6 +7,25 @@ Draft → Employee Submit → Manager Review → Board Secretary Review → Appr
 
 Branches: Request Changes, Reject. No delegation/escalation in Stage 1–2.
 
+### Portal surface split
+
+TPP exposes three distinct surfaces so reviewers can complete approvals in
+business terms without needing runtime internals:
+
+- **Reviewer surface** (`/portal/manager/reviews` and
+  `/portal/manager/reviews/{review_id}`): focuses on request status, policy
+  rationale, exception decisions, follow-up actions, and approval/audit history.
+- **Administrator surface** (`/portal/admin`): keeps role simulation, auth
+  posture, exception queue administration, and runtime control details in an
+  explicit admin navigation target.
+- **Developer/integration surface** (policy API endpoints, contract fixtures,
+  smoke commands, and runbooks): covers payload contracts, auth wiring, and
+  diagnostics used by `trip-planner` integration and local/CI verification.
+
+Reviewer pages should avoid transport/payload internals (draft IDs, planner
+seam details, and policy-engine implementation labels) unless the user has
+explicitly navigated to admin or diagnostics views.
+
 ### Workflow portal contract
 
 The Stage 2 browser portal now uses three explicit server-rendered endpoints:

--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -266,6 +266,16 @@ class RoleView:
     role: RoleName
     permissions: tuple[Permission, ...]
 
+    @property
+    def can_configure(self) -> bool:
+        """Return whether this simulated role view exposes admin diagnostics."""
+
+        return self.role in {
+            RoleName.FINANCE_ADMIN,
+            RoleName.POLICY_ADMIN,
+            RoleName.SYSTEM_ADMIN,
+        }
+
 
 @dataclass(frozen=True)
 class ExpensePortalReviewState:
@@ -2099,7 +2109,7 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
     def portal_admin_dashboard(
         request: Request,
         authorization: str | None = Header(default=None),
-        actor_role: str | None = Query(default=RoleName.TRAVELER.value),
+        actor_role: str | None = Query(default=RoleName.FINANCE_ADMIN.value),
     ) -> HTMLResponse:
         auth_context = _authorize_request(
             authorization,

--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -2107,6 +2107,11 @@ def create_app(store: PlannerProposalStore | None = None) -> FastAPI:
             route=_route_identifier(request),
         )
         role_view = _resolve_role_view(actor_role)
+        if not role_view.can_configure:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Admin diagnostics require an administrator role view.",
+            )
         return _TEMPLATES.TemplateResponse(
             request=request,
             name="portal_admin.html",

--- a/src/travel_plan_permission/http_service.py
+++ b/src/travel_plan_permission/http_service.py
@@ -1561,6 +1561,7 @@ def _manager_review_queue_context(
         "role_view": role_view,
         "actor_permissions": tuple(sorted(auth_context.permissions, key=lambda item: item.value)),
         "role_can_approve": auth_context.can(Permission.APPROVE),
+        "role_can_configure": auth_context.can(Permission.CONFIGURE),
     }
 
 
@@ -1580,6 +1581,7 @@ def _manager_review_detail_context(
         "role_view": role_view,
         "actor_permissions": tuple(sorted(auth_context.permissions, key=lambda item: item.value)),
         "role_can_approve": auth_context.can(Permission.APPROVE),
+        "role_can_configure": auth_context.can(Permission.CONFIGURE),
         "exceptions": exceptions or [],
         "audit_events": audit_events or [],
         "error_message": error_message,

--- a/src/travel_plan_permission/templates/manager_review_detail.html
+++ b/src/travel_plan_permission/templates/manager_review_detail.html
@@ -139,7 +139,7 @@
                 <li>
                   {{ item.type.value }} · {{ item.status.value }}
                   {% if item.approval_level %} · {{ item.approval_level.value }}{% endif %}
-                  {% if item.approval %} · {{ item.approval.approver_id }}{% endif %}
+                  {% if item.approval %} by {{ item.approval.approver_id }}{% endif %}
                 </li>
               {% else %}
                 <li>No exception requests attached to this draft.</li>
@@ -168,7 +168,7 @@
             <h3>Audit trail</h3>
             <ul>
               {% for event in audit_events %}
-                <li>{{ event.timestamp.isoformat() }}: {{ event.outcome }} recorded by {{ event.actor }}</li>
+                <li>{{ event.timestamp.isoformat() }}: {{ event.event_type.value }} · {{ event.outcome }} by {{ event.actor }}</li>
               {% else %}
                 <li>No audit events recorded for this review yet.</li>
               {% endfor %}

--- a/src/travel_plan_permission/templates/manager_review_detail.html
+++ b/src/travel_plan_permission/templates/manager_review_detail.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Manager Review Detail</title>
+    <title>Reviewer Approval Detail</title>
     <style>
       :root {
         --ink: #122432;
@@ -68,11 +68,10 @@
     <main>
       <div class="topbar">
         <div>
-          <h1>Manager review detail</h1>
-          <p style="margin-top: 10px;">Decision state, policy posture, and immutable approval history for one submitted request.</p>
+          <h1>Reviewer approval detail</h1>
+          <p style="margin-top: 10px;">Use this page to understand policy rationale, decide on approval, and record required follow-up.</p>
         </div>
         <div class="actions">
-          <a class="link" href="/portal/admin?actor_role={{ role_view.role.value }}">Admin console</a>
           <a class="link" href="/portal/manager/reviews?actor_role={{ role_view.role.value }}">Review queue</a>
           <a class="link" href="/portal/review/{{ review.draft_id }}">Open draft review</a>
         </div>
@@ -84,10 +83,9 @@
           <h2 style="margin-top: 14px;">{{ review.trip_plan.traveler_name }} to {{ review.trip_plan.destination }}</h2>
           <p style="margin-top: 10px;">{{ review.trip_plan.purpose }}</p>
           <div class="meta">
-            <span>Trip {{ review.trip_plan.trip_id }}</span>
+            <span>Approval state: {{ review.status }}</span>
             <span>Submitted {{ review.submitted_at.isoformat() }}</span>
             <span>Updated {{ review.updated_at.isoformat() }}</span>
-            <span>Viewer {{ role_view.role.value }}</span>
           </div>
 
           <div class="grid" style="margin-top: 18px;">
@@ -103,10 +101,10 @@
               </ul>
             </div>
             <div class="card">
-              <h3>Decision-ready notes</h3>
+              <h3>Policy rationale for reviewers</h3>
               <ul>
                 {% for issue in review.policy_result.issues %}
-                  <li>{{ issue.code }}: {{ issue.message }}</li>
+                  <li>{{ issue.message }}</li>
                 {% else %}
                   <li>No current blocking policy issues.</li>
                 {% endfor %}
@@ -135,7 +133,7 @@
           </div>
 
           <div class="callout" style="margin-top: 18px;">
-            <h3>Exception workflow</h3>
+            <h3>Exception requests</h3>
             <ul>
               {% for item in exceptions %}
                 <li>
@@ -150,10 +148,27 @@
           </div>
 
           <div class="callout" style="margin-top: 18px;">
-            <h3>Runtime audit trail</h3>
+            <h3>Required follow-up</h3>
+            <ul>
+              {% if review.status.value in ["pending", "changes_requested"] %}
+                <li>Record a manager decision and include rationale for the traveler.</li>
+              {% endif %}
+              {% for item in exceptions %}
+                {% if item.status.value == "pending" %}
+                  <li>Resolve the pending {{ item.type.value }} exception request before final approval.</li>
+                {% endif %}
+              {% endfor %}
+              {% if review.status.value == "approved" %}
+                <li>Request is approved. Confirm downstream handoff is complete.</li>
+              {% endif %}
+            </ul>
+          </div>
+
+          <div class="callout" style="margin-top: 18px;">
+            <h3>Audit trail</h3>
             <ul>
               {% for event in audit_events %}
-                <li>{{ event.timestamp.isoformat() }}: {{ event.event_type.value }} · {{ event.outcome }} by {{ event.actor }}{% if event.metadata %} — {{ event.metadata }}{% endif %}</li>
+                <li>{{ event.timestamp.isoformat() }}: {{ event.outcome }} recorded by {{ event.actor }}</li>
               {% else %}
                 <li>No audit events recorded for this review yet.</li>
               {% endfor %}
@@ -164,18 +179,6 @@
         <aside class="stack">
           <section class="panel">
             <h2>Record manager decision</h2>
-            <p style="margin-top: 10px;">
-              Role view simulation: <strong>{{ role_view.role.value }}</strong>, showing
-              {% for permission in role_view.permissions %}<code>{{ permission.value }}</code>{% if not loop.last %}, {% endif %}{% endfor %}.
-            </p>
-            <p style="margin-top: 10px;">
-              Authenticated token permissions:
-              {% for permission in actor_permissions %}
-                <code>{{ permission.value }}</code>{% if not loop.last %}, {% endif %}
-              {% else %}
-                <code>none</code>
-              {% endfor %}.
-            </p>
             {% if error_message %}
               <div class="callout" style="margin-top: 16px;">
                 <h3>Decision error</h3>

--- a/src/travel_plan_permission/templates/manager_review_detail.html
+++ b/src/travel_plan_permission/templates/manager_review_detail.html
@@ -116,21 +116,27 @@
             <h3>Approval history</h3>
             <ul>
               {% for event in review.trip_plan.approval_history %}
-                <li>{{ event.timestamp.isoformat() }}: {{ event.outcome.value }} by {{ event.approver_id }}{% if event.justification %} — {{ event.justification }}{% endif %}</li>
+                <li>
+                  {{ event.timestamp.isoformat() }}: {{ event.outcome.value }}
+                  {% if role_can_configure %} by {{ event.approver_id }}{% endif %}
+                  {% if event.justification %} — {{ event.justification }}{% endif %}
+                </li>
               {% else %}
                 <li>No manager decision recorded yet.</li>
               {% endfor %}
             </ul>
           </div>
 
-          <div class="callout" style="margin-top: 18px;">
-            <h3>Workflow event log</h3>
-            <ul>
-              {% for event in review.history %}
-                <li>{{ event.timestamp.isoformat() }}: {{ event.event_type }} by {{ event.actor_id }}{% if event.rationale %} — {{ event.rationale }}{% endif %}</li>
-              {% endfor %}
-            </ul>
-          </div>
+          {% if role_can_configure %}
+            <div class="callout" style="margin-top: 18px;">
+              <h3>Workflow event log</h3>
+              <ul>
+                {% for event in review.history %}
+                  <li>{{ event.timestamp.isoformat() }}: {{ event.event_type }} by {{ event.actor_id }}{% if event.rationale %} — {{ event.rationale }}{% endif %}</li>
+                {% endfor %}
+              </ul>
+            </div>
+          {% endif %}
 
           <div class="callout" style="margin-top: 18px;">
             <h3>Exception requests</h3>

--- a/src/travel_plan_permission/templates/manager_review_detail.html
+++ b/src/travel_plan_permission/templates/manager_review_detail.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Reviewer Approval Detail</title>
+    <title>Reviewer Approval Detail | Manager review detail</title>
     <style>
       :root {
         --ink: #122432;

--- a/src/travel_plan_permission/templates/manager_review_queue.html
+++ b/src/travel_plan_permission/templates/manager_review_queue.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Reviewer Approval Queue</title>
+    <title>Reviewer Approval Queue | Manager review queue</title>
     <style>
       :root {
         --ink: #102230;

--- a/src/travel_plan_permission/templates/manager_review_queue.html
+++ b/src/travel_plan_permission/templates/manager_review_queue.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Manager Review Queue</title>
+    <title>Reviewer Approval Queue</title>
     <style>
       :root {
         --ink: #102230;
@@ -51,15 +51,10 @@
       <section class="panel">
         <div class="topbar">
           <div>
-            <h1>Manager review queue</h1>
-            <p style="margin-top: 10px;">Submitted browser requests stay here with policy posture and decision history until a manager acts.</p>
-            <p style="margin-top: 10px;">
-              Role view simulation: <strong>{{ role_view.role.value }}</strong>, showing
-              {% for permission in role_view.permissions %}<code>{{ permission.value }}</code>{% if not loop.last %}, {% endif %}{% endfor %}.
-            </p>
+            <h1>Reviewer approval queue</h1>
+            <p style="margin-top: 10px;">Submitted travel requests stay here until a reviewer records the next approval decision.</p>
           </div>
           <div class="row">
-            <a class="link" href="/portal/admin?actor_role={{ role_view.role.value }}">Admin console</a>
             <a class="link" href="/portal">Portal home</a>
           </div>
         </div>
@@ -76,10 +71,9 @@
                   <span class="badge">{{ review.status }}</span>
                 </div>
                 <div class="meta">
-                  <span>Trip {{ review.trip_plan.trip_id }}</span>
-                  <span>Draft {{ review.draft_id }}</span>
-                  <span>Policy {{ review.policy_snapshot.policy_status }}</span>
-                  <span>{{ review.policy_snapshot.approval_triggers | length }} approval trigger(s)</span>
+                  <span>Approval state: {{ review.status }}</span>
+                  <span>Policy posture: {{ review.policy_snapshot.policy_status }}</span>
+                  <span>{{ review.policy_snapshot.approval_triggers | length }} policy reason(s) to review</span>
                 </div>
                 <div style="margin-top: 16px;">
                   <a class="link" href="/portal/manager/reviews/{{ review.review_id }}">Open review details</a>

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -1752,6 +1752,23 @@ def test_portal_admin_console_surfaces_permissions_runtime_and_audit_history(
     assert "artifact_downloaded" in console.text
 
 
+def test_portal_admin_console_requires_admin_role_view(monkeypatch) -> None:
+    _set_bootstrap_runtime_env(monkeypatch)
+    store = PlannerProposalStore()
+    client = TestClient(create_app(store))
+
+    forbidden = client.get(
+        "/portal/admin?actor_role=traveler",
+        headers=_bootstrap_auth_header(
+            subject="viewer-only",
+            permissions=(Permission.VIEW,),
+        ),
+    )
+
+    assert forbidden.status_code == 403
+    assert forbidden.json()["detail"] == "Admin diagnostics require an administrator role view."
+
+
 def test_manager_review_detail_uses_authenticated_permissions_for_actions(
     monkeypatch,
 ) -> None:

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -1575,7 +1575,7 @@ def test_submission_creates_manager_review_queue_entry(monkeypatch) -> None:
     assert "pending_manager_review" in queue.text
     assert detail.status_code == 200
     assert "Current policy posture" in detail.text
-    assert "Workflow event log" in detail.text
+    assert "Required follow-up" in detail.text
 
 
 def test_manager_review_decision_updates_status_and_history(monkeypatch) -> None:
@@ -1786,9 +1786,6 @@ def test_manager_review_detail_uses_authenticated_permissions_for_actions(
     )
 
     assert detail.status_code == 200
-    assert "Role view simulation: <strong>traveler</strong>" in detail.text
-    assert "Authenticated token permissions:" in detail.text
-    assert "<code>approve</code>" in detail.text
     assert "Save manager decision" in detail.text
 
 

--- a/tests/python/test_http_service.py
+++ b/tests/python/test_http_service.py
@@ -1694,14 +1694,7 @@ def test_manager_review_detail_hides_decision_form_for_read_only_role(
     store = PlannerProposalStore()
     client = TestClient(create_app(store))
 
-    draft_id, _location = _create_portal_draft(client)
-    client.post(
-        f"/portal/review/{draft_id}/submit",
-        headers=AUTH_HEADER,
-        follow_redirects=True,
-    )
-    review = store.lookup_manager_review_for_draft(draft_id)
-    assert review is not None
+    review = _seed_manager_review(store, status=http_service.ReviewStatus.PENDING_MANAGER_REVIEW)
 
     detail = client.get(
         f"/portal/manager/reviews/{review.review_id}?actor_role=traveler",
@@ -1711,6 +1704,7 @@ def test_manager_review_detail_hides_decision_form_for_read_only_role(
     assert detail.status_code == 200
     assert "Read-only role" in detail.text
     assert "Save manager decision" not in detail.text
+    assert "Workflow event log" not in detail.text
 
 
 def test_portal_admin_console_surfaces_permissions_runtime_and_audit_history(
@@ -1787,6 +1781,27 @@ def test_manager_review_detail_uses_authenticated_permissions_for_actions(
 
     assert detail.status_code == 200
     assert "Save manager decision" in detail.text
+
+
+def test_manager_review_detail_shows_debug_event_log_for_configure_permission(
+    monkeypatch,
+) -> None:
+    _set_bootstrap_runtime_env(monkeypatch)
+    store = PlannerProposalStore()
+    client = TestClient(create_app(store))
+
+    review = _seed_manager_review(store, status=http_service.ReviewStatus.PENDING_MANAGER_REVIEW)
+
+    detail = client.get(
+        f"/portal/manager/reviews/{review.review_id}",
+        headers=_bootstrap_auth_header(
+            subject="admin-debugger",
+            permissions=(Permission.VIEW, Permission.CONFIGURE),
+        ),
+    )
+
+    assert detail.status_code == 200
+    assert "Workflow event log" in detail.text
 
 
 def test_exception_decision_updates_review_detail_and_audit_log(monkeypatch) -> None:

--- a/tests/python/test_planner_client.py
+++ b/tests/python/test_planner_client.py
@@ -66,7 +66,11 @@ def _operation_payload(
             "proposal_id": "proposal-123",
             "proposal_version": "proposal-v1",
             "execution_id": "exec-949",
-            "status": "rejected" if submission_status == "failed" else "approved" if terminal else "submitted",
+            "status": (
+                "rejected"
+                if submission_status == "failed"
+                else "approved" if terminal else "submitted"
+            ),
             "approval_history": [],
             "validation_results": [],
             "exception_requests": [],

--- a/tests/python/test_portal_state_store.py
+++ b/tests/python/test_portal_state_store.py
@@ -144,9 +144,7 @@ class TestSQLitePortalStateStore:
         assert len(snapshot["portal_drafts_by_id"]) == 1
         assert next(iter(snapshot["portal_drafts_by_id"])) in set(ids)
 
-    def test_lru_evicted_portal_drafts_stay_evicted_after_restart(
-        self, tmp_path: Path
-    ) -> None:
+    def test_lru_evicted_portal_drafts_stay_evicted_after_restart(self, tmp_path: Path) -> None:
         state_path = tmp_path / "portal-runtime-state.sqlite3"
         first_store = PlannerProposalStore(state_path=state_path)
 


### PR DESCRIPTION
### Keepalive: OFF
<!-- meta:issue:1071 -->

### Source Issue #1071: [Agent] Align TPP Portal With Product/Admin/Debug Surfaces

Base: main
Head: codex/issue-1071

Source: https://github.com/stranske/Travel-Plan-Permission/issues/1071

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The combined product depends on TPP being understandable as a business approval service, not just as an integration target. The TPP portal should preserve administrator and developer detail, but normal manager/reviewer screens should emphasize request status, exception needs, policy rationale, and next actions in business language.

#### Tasks
- [x] Document the product/admin/debug surface split in TPP design docs.
- [x] Audit portal templates for reviewer-facing copy that exposes implementation details.
- [x] Update reviewer queue and detail views to prioritize approval state, exception rationale, required follow-up, and audit trail.
- [x] Keep admin policy configuration and integration diagnostics behind appropriate navigation or debug views.
- [x] Add tests or snapshot checks for reviewer-facing wording and visibility of debug details.
- [x] Update cross-repo planner integration docs if any user-facing policy labels need to be shared with `trip-planner`.

#### Acceptance Criteria
- [x] TPP docs explain which surfaces are for reviewers, administrators, and developers.
- [x] Reviewer portal pages do not require knowledge of planner transport, payload IDs, or policy-engine internals to complete a review.
- [x] Admin/debug information remains accessible through explicit admin or diagnostic surfaces.
- [x] Existing planner integration contract tests continue to pass.
- [x] Any shared labels or state meanings are documented in both TPP and `trip-planner` integration docs.
<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



Target repo: `Travel-Plan-Permission`

## Why

The combined product depends on TPP being understandable as a business approval service, not just as an integration target. The TPP portal should preserve administrator and developer detail, but normal manager/reviewer screens should emphasize request status, exception needs, policy rationale, and next actions in business language.

## Scope

Update TPP design and portal surfaces to distinguish product/reviewer views, administrator configuration views, and debug/integration views. Keep API contracts stable for `trip-planner`.

## Non-Goals

- Rewriting TPP policy engine logic.
- Changing cross-repo API schemas unless a compatibility plan is documented.
- Moving TPP functionality into `trip-planner`.
- Removing admin or debug visibility.

## Tasks

- [ ] Document the product/admin/debug surface split in TPP design docs.
- [ ] Audit portal templates for reviewer-facing copy that exposes implementation details.
- [ ] Update reviewer queue and detail views to prioritize approval state, exception rationale, required follow-up, and audit trail.
- [ ] Keep admin policy configuration and integration diagnostics behind appropriate navigation or debug views.
- [x] Add tests or snapshot checks for reviewer-facing wording and visibility of debug details.
- [x] Update cross-repo planner integration docs if any user-facing policy labels need to be shared with `trip-planner`.

## Acceptance Criteria

- [ ] TPP docs explain which surfaces are for reviewers, administrators, and developers.
- [ ] Reviewer portal pages do not require knowledge of planner transport, payload IDs, or policy-engine internals to complete a review.
- [ ] Admin/debug information remains accessible through explicit admin or diagnostic surfaces.
- [x] Existing planner integration contract tests continue to pass.
- [x] Any shared labels or state meanings are documented in both TPP and `trip-planner` integration docs.

## Implementation Notes

Likely files in `Travel-Plan-Permission`:

- `docs/approval-workflow.md`
- `docs/policy-api.md`
- `docs/contracts/planner-integration.md`
- `src/travel_plan_permission/templates/manager_review_queue.html`
- `src/travel_plan_permission/templates/manager_review_detail.html`
- `src/travel_plan_permission/templates/review_summary.html`
- `src/travel_plan_permission/templates/portal_admin.html`
- `src/travel_plan_permission/http_service.py`
- `tests/python/`

Treat this as a companion issue to Issue 9. `trip-planner` should decide when TPP matters for a trip; TPP should make the policy review itself legible once a business request reaches it.



</details>

—
PR created automatically to engage Codex.

Closes #1071