### PR TITLE
test(orchestration): assert _LangGraphPolicyGraph in seam test

### DIFF
--- a/tests/python/test_orchestration_smoke.py
+++ b/tests/python/test_orchestration_smoke.py
@@ -208,6 +208,18 @@ def test_policy_graph_langgraph_seam(tmp_path: Path) -> None:
         "message": "Book the conference trip and check policy.",
     }
 
+    # Build the graph explicitly so the seam test can verify the LangGraph
+    # path was actually taken — not a silent fallback to _SimplePolicyGraph.
+    # Without this check, every behavioral seam assertion below would still
+    # pass under fallback (both implementations call the same
+    # _planner_runtime_node inline), so a regression in _build_langgraph()
+    # that returns None would not be caught by this test alone.
+    graph = build_policy_graph(prefer_langgraph=True)
+    assert isinstance(graph, orchestration_graph._LangGraphPolicyGraph), (
+        f"prefer_langgraph=True silently fell back to {type(graph).__name__}; "
+        "this test exists to catch regressions in _build_langgraph()."
+    )
+
     state = run_policy_graph(
         plan,
         canonical_plan=canonical,


### PR DESCRIPTION
## Summary

Follow-up to #1084 / PR #1085 noted in the 2026-05-13 cycle review.

The original `test_policy_graph_langgraph_seam` asserts the seam fields (`checkpoint_metadata`, `follow_up_action`, `planner_turn`) populate correctly under `prefer_langgraph=True` — but every behavioral assertion would still pass under a silent fallback to `_SimplePolicyGraph`, because both implementations call the same `_planner_runtime_node` inline.

This PR adds a build-time `isinstance(graph, _LangGraphPolicyGraph)` check inside the seam test before invoking the graph. If `_build_langgraph()` silently returns `None` (caught exception, missing dependency the `importorskip` didn't catch, etc.), the assertion fails with a clear message naming the actual type that was returned.

The existing `test_policy_graph_prefers_langgraph_when_available` test stays as a focused safety net for the same regression, but the seam test now also stands on its own — deleting either test would still leave the other to catch the regression.

## Test plan

- [x] `pytest tests/python/test_orchestration_smoke.py::test_policy_graph_langgraph_seam -q` passes
- [x] Verified the assertion catches the regression: patching `_build_langgraph` to return `None` makes the assertion fail, where previously every behavioral assertion still passed under `_SimplePolicyGraph` fallback
- [ ] CI green on the standard gate (will populate after CI runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)