### PR TITLE
chore: sync workflow templates

### DIFF
--- a/scripts/langchain/task_validator.py
+++ b/scripts/langchain/task_validator.py
@@ -14,10 +14,11 @@ from __future__ import annotations
 import argparse
 import json
 import re
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
-from typing import Any
+from typing import Any, TypedDict
 
 try:
     from scripts.langchain.trace_utils import TraceInfo, invoke_with_trace
@@ -152,6 +153,29 @@ class TaskFate:
         return payload
 
 
+class TriageCleanItem(TypedDict):
+    """Clean task record with the original input position."""
+
+    task: str
+    index: int
+
+
+class TriageFlaggedItem(TypedDict):
+    """Flagged task record with heuristic warnings and original position."""
+
+    task: str
+    warnings: list[str]
+    index: int
+
+
+class TriageResult(TypedDict):
+    """Structured result returned by ``triage_tasks``."""
+
+    clean: list[str]
+    clean_items: list[TriageCleanItem]
+    flagged: list[TriageFlaggedItem]
+
+
 @dataclass
 class ValidationResult:
     """Complete result of task validation."""
@@ -234,7 +258,7 @@ WARNING_SIGNALS: dict[str, Any] = {
 # ---------------------------------------------------------------------------
 
 
-def triage_tasks(tasks: list[str]) -> dict[str, list[Any]]:
+def triage_tasks(tasks: list[str]) -> TriageResult:
     """
     Separate tasks into clean vs flagged for review.
 
@@ -242,11 +266,13 @@ def triage_tasks(tasks: list[str]) -> dict[str, list[Any]]:
         tasks: List of task strings to triage
 
     Returns:
-        Dictionary with "clean" (list[str]) and "flagged" (list[dict]) keys
+        Dictionary with "clean" (list[str]), "clean_items" (list[dict] with
+        task/index pairs), and "flagged" (list[dict] with task, warnings, and
+        index) keys
     """
     clean: list[str] = []
-    clean_items: list[dict[str, Any]] = []
-    flagged: list[dict[str, Any]] = []
+    clean_items: list[TriageCleanItem] = []
+    flagged: list[TriageFlaggedItem] = []
 
     for index, task in enumerate(tasks):
         if not task or not task.strip():
@@ -302,7 +328,10 @@ def _load_refinement_prompt() -> str:
 REFINEMENT_PATTERN = re.compile(r"^\s*[-*]?\s*(KEEP|IMPROVE|DROP)\s*:\s*(.+)$", re.IGNORECASE)
 
 
-def _parse_refinement_response(response: str, flagged: list[dict[str, Any]]) -> list[TaskFate]:
+def _parse_refinement_response(
+    response: str,
+    flagged: Sequence[Mapping[str, Any]],
+) -> list[TaskFate]:
     """
     Parse LLM refinement response into TaskFate objects.
 
@@ -385,13 +414,13 @@ def _parse_refinement_response(response: str, flagged: list[dict[str, Any]]) -> 
 
 
 def refine_flagged_tasks(
-    flagged: list[dict[str, Any]], context: str = ""
+    flagged: Sequence[Mapping[str, Any]], context: str = ""
 ) -> tuple[list[str], list[TaskFate], str | None, TraceInfo]:
     """
     Send flagged tasks to LLM for refinement decision.
 
     Args:
-        flagged: List of {"task": str, "warnings": list[str]} dicts
+        flagged: Sequence of mappings with "task", optional "warnings", and optional "index" keys.
         context: Optional issue context for LLM
 
     Returns:
@@ -520,7 +549,7 @@ def merge_with_audit(
     refined: list[str],
     fates: list[TaskFate],
     original_count: int,
-    clean_items: list[dict[str, Any]] | None = None,
+    clean_items: Sequence[Mapping[str, Any]] | None = None,
 ) -> tuple[list[str], str]:
     """
     Merge clean and refined tasks, returning audit summary.

--- a/scripts/langchain/trace_utils.py
+++ b/scripts/langchain/trace_utils.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import dis
 import inspect
+import linecache
 import logging
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 LOGGER = logging.getLogger(__name__)
+
+ConfigSupport = Literal["explicit", "variadic", "unknown", "none"]
 
 
 @dataclass(frozen=True)
@@ -28,6 +32,13 @@ class TraceInfo:
         if self.trace_url:
             payload["langsmith_trace_url"] = self.trace_url
         return payload
+
+
+@dataclass(frozen=True)
+class _TracebackFrame:
+    code: Any
+    lineno: int
+    lasti: int
 
 
 def build_trace_config(
@@ -69,24 +80,97 @@ def extract_trace_info(response: Any) -> TraceInfo:
         return TraceInfo()
 
 
-def _invoke_accepts_config(invoke: Any) -> bool:
+def _invoke_config_support(invoke: Any) -> ConfigSupport:
     try:
         signature = inspect.signature(invoke)
     except (TypeError, ValueError):
-        return True
+        return "unknown"
 
+    accepts_variadic_kwargs = False
     for param in signature.parameters.values():
-        if param.name == "config" or param.kind == inspect.Parameter.VAR_KEYWORD:
-            return True
+        if param.name == "config":
+            return "explicit"
+        if param.kind == inspect.Parameter.VAR_KEYWORD:
+            accepts_variadic_kwargs = True
+    return "variadic" if accepts_variadic_kwargs else "none"
+
+
+def _is_unsupported_config_error(exc: TypeError, *, allow_delegated: bool = False) -> bool:
+    message = str(exc).lower()
+    no_keyword_support = (
+        "takes no keyword argument" in message
+        or "takes no keyword arguments" in message
+        or "does not take keyword argument" in message
+        or "does not take keyword arguments" in message
+        or "doesn't take keyword argument" in message
+        or "doesn't take keyword arguments" in message
+    )
+    unsupported_config_message = no_keyword_support or (
+        "config" in message
+        and (
+            "unexpected keyword argument" in message
+            or "got an unexpected keyword" in message
+            or "positional-only" in message
+        )
+    )
+    if not unsupported_config_message:
+        return False
+    if _is_direct_call_type_error(exc):
+        return True
+    return allow_delegated and "config" in message and _is_delegated_call_type_error(exc)
+
+
+def _traceback_frames(exc: TypeError) -> list[_TracebackFrame]:
+    frames: list[_TracebackFrame] = []
+    tb = exc.__traceback__
+    while tb is not None:
+        frames.append(
+            _TracebackFrame(
+                code=tb.tb_frame.f_code,
+                lineno=tb.tb_lineno,
+                lasti=tb.tb_lasti,
+            )
+        )
+        tb = tb.tb_next
+    return frames
+
+
+def _is_call_instruction(frame: _TracebackFrame) -> bool:
+    for instruction in dis.get_instructions(frame.code):
+        if instruction.offset == frame.lasti:
+            return instruction.opname.startswith("CALL")
     return False
 
 
-def _is_unsupported_config_error(exc: TypeError) -> bool:
-    message = str(exc)
-    return "config" in message and (
-        "unexpected keyword argument" in message
-        or "got an unexpected keyword" in message
-        or "positional-only" in message
+def _is_forwarding_invoke_call(frame: _TracebackFrame) -> bool:
+    if not _is_call_instruction(frame):
+        return False
+
+    source = " ".join(
+        linecache.getline(frame.code.co_filename, lineno).strip()
+        for lineno in range(frame.lineno, frame.lineno + 6)
+    )
+    return "invoke(" in source or "__call__(" in source
+
+
+def _is_direct_call_type_error(exc: TypeError) -> bool:
+    """Return true when Python rejected the call before entering invoke()."""
+
+    frames = _traceback_frames(exc)
+    # TypeErrors raised by the runnable include an inner traceback frame.
+    # Direct argument-binding failures from builtins/C shims stop at this call site.
+    return len(frames) == 1 and frames[0].code is invoke_with_trace.__code__
+
+
+def _is_delegated_call_type_error(exc: TypeError) -> bool:
+    """Return true for ``invoke(**kwargs)`` wrappers rejected below the wrapper."""
+
+    frames = _traceback_frames(exc)
+    return (
+        len(frames) > 1
+        and frames[0].code is invoke_with_trace.__code__
+        and all(frame.code.co_name in {"invoke", "__call__"} for frame in frames[1:])
+        and _is_forwarding_invoke_call(frames[-1])
     )
 
 
@@ -111,11 +195,15 @@ def invoke_with_trace(
         issue_number=issue_number,
     )
     invoke = runnable.invoke
-    if _invoke_accepts_config(invoke):
+    config_support = _invoke_config_support(invoke)
+    if config_support != "none":
         try:
             response = invoke(payload, config=config)
         except TypeError as exc:
-            if not _is_unsupported_config_error(exc):
+            if not _is_unsupported_config_error(
+                exc,
+                allow_delegated=config_support == "variadic",
+            ):
                 raise
             response = invoke(payload)
     else:


### PR DESCRIPTION
## Sync Summary

### Files Updated
- trace_utils.py: Shared LangSmith trace metadata helpers for LangChain workflows
- task_validator.py: Task validator - refines generated issue tasks for actionability

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- dependabot.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `9ade7910186c1d7a39e42c7836b5d080ad0cefaa`
**Template hash:** `fea657f689c9`
**Sync branch:** `sync/workflows-fea657f689c9`
**Consumer repo:** `stranske/Travel-Plan-Permission`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Travel-Plan-Permission","source_repository":"stranske/Workflows","source_sha":"9ade7910186c1d7a39e42c7836b5d080ad0cefaa","template_hash":"fea657f689c9","sync_branch":"sync/workflows-fea657f689c9","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"25935619862","run_attempt":"1","changes_count":2} -->