### PR TITLE
chore: sync workflow templates

### DIFF
--- a/scripts/api_client.py
+++ b/scripts/api_client.py
@@ -1,17 +1,32 @@
 from __future__ import annotations
 
+import importlib
 import time
-from collections.abc import Callable
-from typing import Any
+from collections.abc import Callable, Mapping
+from typing import Any, Protocol, cast
 from urllib.parse import urlencode
-
-import requests  # type: ignore[import-untyped]
 
 GITHUB_API = "https://api.github.com"
 DEFAULT_TIMEOUT = 30
 DEFAULT_RETRY_ATTEMPTS = 3
 DEFAULT_RETRY_BACKOFF = 1.0
 RETRY_STATUS_CODES = {429, 500, 502, 503, 504}
+
+
+class _Response(Protocol):
+    status_code: int
+    text: str
+
+    def json(self) -> Any: ...
+
+
+class _RequestsModule(Protocol):
+    RequestException: type[Exception]
+
+    def request(self, method: str, url: str, **kwargs: Any) -> _Response: ...
+
+
+requests = cast(_RequestsModule, importlib.import_module("requests"))
 
 
 def _should_retry(status_code: int, detail: Any) -> bool:
@@ -65,7 +80,7 @@ def _request_response(
     *,
     max_attempts: int = DEFAULT_RETRY_ATTEMPTS,
     backoff: float = DEFAULT_RETRY_BACKOFF,
-) -> requests.Response:
+) -> _Response:
     attempts = max(1, max_attempts)
     for attempt in range(1, attempts + 1):
         try:
@@ -238,6 +253,7 @@ def fetch_oauth_scopes(
     except RuntimeError:
         return None
     headers = getattr(response, "headers", None)
-    if not headers:
+    if not isinstance(headers, Mapping):
         return None
-    return headers.get("X-OAuth-Scopes")
+    scopes = headers.get("X-OAuth-Scopes")
+    return str(scopes) if scopes is not None else None

--- a/scripts/sync_test_dependencies.py
+++ b/scripts/sync_test_dependencies.py
@@ -33,7 +33,7 @@ except ImportError as exc:  # pragma: no cover - exercised via CLI messaging.
 else:
     TOMLKIT_ERROR = None
 
-PytestIniConfig = tuple[Path, tuple[str, ...]]
+type PytestIniConfig = tuple[Path, tuple[str, ...]]
 PYPROJECT_FILE = Path("pyproject.toml")
 PYTEST_TOML_FILES = (
     Path("pytest.toml"),


### PR DESCRIPTION
## Sync Summary

### Files Updated
- sync_test_dependencies.py: Syncs test dependency pins - required by reusable CI workflow
- api_client.py: Shared GitHub API client used by synced Python automation scripts

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- dependabot.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `551f804fa083ed5003866b4a391ded2379d05835`
**Template hash:** `04a16c14d080`
**Sync branch:** `sync/workflows-04a16c14d080`
**Consumer repo:** `stranske/Travel-Plan-Permission`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Travel-Plan-Permission","source_repository":"stranske/Workflows","source_sha":"551f804fa083ed5003866b4a391ded2379d05835","template_hash":"04a16c14d080","sync_branch":"sync/workflows-04a16c14d080","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"27257723298","run_attempt":"1","changes_count":2} -->