### PR TITLE
Persist TripState smoke records by execution

### DIFF
--- a/src/travel_plan_permission/persistence/store.py
+++ b/src/travel_plan_permission/persistence/store.py
@@ -11,6 +11,7 @@ from typing import Protocol, runtime_checkable
 RECORD_NAMESPACES: tuple[str, ...] = (
     "plans_by_trip_id",
     "proposals_by_execution_id",
+    "trip_states_by_execution_id",
     "portal_drafts_by_id",
     "expense_drafts_by_id",
     "manager_reviews",

--- a/tests/python/test_portal_state_store.py
+++ b/tests/python/test_portal_state_store.py
@@ -91,6 +91,71 @@ class TestSQLitePortalStateStore:
         store_b.close()
         loaded.close()
 
+    def test_trip_state_records_round_trip_by_execution_id(self, tmp_path: Path) -> None:
+        path = tmp_path / "trip-states.sqlite3"
+        store = SQLitePortalStateStore(path)
+        store.initialize()
+        trip_state = {
+            "plan_json": {
+                "trip_id": "trip-001",
+                "traveler_name": "Sam Parker",
+                "destination": "Chicago, IL",
+                "departure_date": "2026-03-10",
+                "return_date": "2026-03-12",
+                "purpose": "Client meeting",
+                "estimated_cost": "840.00",
+            },
+            "planner_turn": {"source": "trip_planner", "execution_id": "exec-001"},
+            "policy_result": {"policy_version": "test", "status": "fail", "issues": []},
+            "checkpoint_metadata": {
+                "state_model": "TripState",
+                "trip_id": "trip-001",
+                "policy_status": "fail",
+            },
+            "follow_up_action": {
+                "source": "policy_check",
+                "execution_id": "exec-001",
+                "trip_id": "trip-001",
+                "policy_status": "fail",
+            },
+        }
+        store.save_snapshot({"trip_states_by_execution_id": {"exec-001": trip_state}})
+
+        reopened = SQLitePortalStateStore(path)
+        reopened.initialize()
+        loaded = reopened.load_snapshot()
+        assert loaded is not None
+        assert loaded["trip_states_by_execution_id"]["exec-001"] == trip_state
+        store.close()
+        reopened.close()
+
+    def test_trip_state_namespace_reconciles_absent_records(self, tmp_path: Path) -> None:
+        path = tmp_path / "trip-state-reconcile.sqlite3"
+        store_a = SQLitePortalStateStore(path)
+        store_a.initialize()
+        store_a.save_snapshot(
+            {
+                "trip_states_by_execution_id": {
+                    "exec-a": {
+                        "plan_json": {"trip_id": "trip-a"},
+                        "planner_turn": {"source": "trip_planner"},
+                    }
+                }
+            }
+        )
+
+        store_b = SQLitePortalStateStore(path)
+        store_b.initialize()
+        store_b.save_snapshot({"trip_states_by_execution_id": {}})
+
+        loaded = SQLitePortalStateStore(path)
+        loaded.initialize()
+        snapshot = loaded.load_snapshot()
+        assert snapshot is None or snapshot["trip_states_by_execution_id"] == {}
+        store_a.close()
+        store_b.close()
+        loaded.close()
+
     def test_empty_record_namespace_removes_all_records(self, tmp_path: Path) -> None:
         path = tmp_path / "expense-concurrent.sqlite3"
         store_a = SQLitePortalStateStore(path)

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,0 +1,11 @@
+## 2026-06-11T10:06:04Z - opener (codex): issue #1186 -> PR pending
+
+- Repo: `stranske/Travel-Plan-Permission`
+- Issue: `#1186` - Cross-repo smoke: persist and assert TripState follow-up state after live HTTP evaluation
+- Branch: `codex/issue-1186-tripstate-http-smoke`
+- Worktree: `/Users/teacher/.codex/automations/pd-workloop-resume/worktrees/travel-1186-tripstate-smoke`
+- Change: registered `trip_states_by_execution_id` as a per-record SQL snapshot namespace so TripState smoke persistence survives SQLite/Postgres reloads with the same keyed-record behavior as proposal state.
+- Tests:
+  - `PYTHONPATH=src python -m pytest tests/python/test_cross_repo_smoke.py::test_cross_repo_smoke_proves_submission_status_evaluation_and_reload tests/python/test_cross_repo_smoke.py::test_cross_repo_smoke_persists_trip_state_after_evaluation tests/python/test_portal_state_store.py::TestSQLitePortalStateStore::test_trip_state_records_round_trip_by_execution_id tests/python/test_portal_state_store.py::TestSQLitePortalStateStore::test_trip_state_namespace_reconciles_absent_records -v` passed.
+  - `git diff --check` passed.
+- Next action: commit, push, open ready-for-review PR with `agent:codex`, `agents:keepalive`, `autofix`, `repo-review-approved`, and `priority:high`.

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,11 +1,14 @@
-## 2026-06-11T10:06:04Z - opener (codex): issue #1186 -> PR pending
+## 2026-06-11T10:07:47Z - opener (codex): issue #1186 -> PR #1187
 
 - Repo: `stranske/Travel-Plan-Permission`
 - Issue: `#1186` - Cross-repo smoke: persist and assert TripState follow-up state after live HTTP evaluation
+- PR: `#1187` - Persist TripState smoke records by execution
 - Branch: `codex/issue-1186-tripstate-http-smoke`
 - Worktree: `/Users/teacher/.codex/automations/pd-workloop-resume/worktrees/travel-1186-tripstate-smoke`
 - Change: registered `trip_states_by_execution_id` as a per-record SQL snapshot namespace so TripState smoke persistence survives SQLite/Postgres reloads with the same keyed-record behavior as proposal state.
 - Tests:
   - `PYTHONPATH=src python -m pytest tests/python/test_cross_repo_smoke.py::test_cross_repo_smoke_proves_submission_status_evaluation_and_reload tests/python/test_cross_repo_smoke.py::test_cross_repo_smoke_persists_trip_state_after_evaluation tests/python/test_portal_state_store.py::TestSQLitePortalStateStore::test_trip_state_records_round_trip_by_execution_id tests/python/test_portal_state_store.py::TestSQLitePortalStateStore::test_trip_state_namespace_reconciles_absent_records -v` passed.
   - `git diff --check` passed.
-- Next action: commit, push, open ready-for-review PR with `agent:codex`, `agents:keepalive`, `autofix`, `repo-review-approved`, and `priority:high`.
+- Routing: PR is non-draft with `agent:codex`, `agents:keepalive`, `autofix`, `repo-review-approved`, and `priority:high`.
+- Cap-health immediately after PR creation reported `needs-dispatch-evidence` because the first Gate/Gate Followups runs were cancelled; this state update is being pushed as a newer branch head before rerunning repair/cap-health.
+- Next action: wait for keepalive/Gate evidence on the latest head.


### PR DESCRIPTION
Closes #1186

## Summary
- registers `trip_states_by_execution_id` as a per-record SQL snapshot namespace
- adds SQLite round-trip and reconciliation coverage for persisted TripState records
- preserves the existing live HTTP smoke assertions that TripState planner runtime fields survive reload

## Validation
- `PYTHONPATH=src python -m pytest tests/python/test_cross_repo_smoke.py::test_cross_repo_smoke_proves_submission_status_evaluation_and_reload tests/python/test_cross_repo_smoke.py::test_cross_repo_smoke_persists_trip_state_after_evaluation tests/python/test_portal_state_store.py::TestSQLitePortalStateStore::test_trip_state_records_round_trip_by_execution_id tests/python/test_portal_state_store.py::TestSQLitePortalStateStore::test_trip_state_namespace_reconciles_absent_records -v`
- `git diff --check HEAD~1..HEAD`
