### PR TITLE
test: prove TripState smoke persistence guard (#1191)

### DIFF
--- a/tests/python/test_cross_repo_smoke.py
+++ b/tests/python/test_cross_repo_smoke.py
@@ -241,6 +241,32 @@ def test_cross_repo_smoke_persists_trip_state_after_evaluation(
     assert trip_state["policy_result"]["policy_version"]
 
 
+def test_cross_repo_smoke_fails_when_trip_state_persistence_is_skipped(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trip_planner_root = tmp_path / "trip-planner"
+    _write_trip_planner_contracts(trip_planner_root)
+    state_path = tmp_path / "missing-trip-state.sqlite3"
+    _configure_live_smoke_env(monkeypatch, state_path)
+
+    def _skip_trip_state_persistence(**_: object) -> None:
+        return None
+
+    monkeypatch.setattr(
+        cross_repo_smoke,
+        "_persist_trip_state",
+        _skip_trip_state_persistence,
+    )
+
+    with pytest.raises(CrossRepoSmokeError, match="TripState state does not contain execution_id"):
+        run_cross_repo_smoke(
+            trip_planner_root=trip_planner_root,
+            state_path=state_path,
+            transport=_LivePlannerTransport(),
+        )
+
+
 def test_run_cross_repo_smoke_uses_live_client_instead_of_direct_policy_calls() -> None:
     source = textwrap.dedent(inspect.getsource(cross_repo_smoke.run_cross_repo_smoke))
     tree = ast.parse(source)

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,3 +1,16 @@
+## 2026-06-13T14:03:00Z - opener (codex): issue #1191 -> PR pending
+
+- Repo: `stranske/Travel-Plan-Permission`
+- Issue: `#1191` - Cross-repo smoke: persist and assert TripState follow-up state after live HTTP evaluation
+- Branch: `codex/issue-1191-tripstate-followup-state`
+- Worktree: `/Users/teacher/.codex/automations/pd-workloop-resume/worktrees/tpp-1191-tripstate`
+- Context: `origin/main` already contains the core TripState smoke persistence from #1186/#1187 (`TripState` construction, `trip_states_by_execution_id`, reload assertions, docs evidence). This lane adds the remaining durable deliberate-break proof requested by #1191 rather than duplicating the implementation.
+- Change: added `test_cross_repo_smoke_fails_when_trip_state_persistence_is_skipped`, which monkeypatches `_persist_trip_state` to no-op and asserts `run_cross_repo_smoke` fails on the TripState reload check.
+- Tests:
+  - `python -m pytest tests/python/test_cross_repo_smoke.py::test_cross_repo_smoke_proves_submission_status_evaluation_and_reload tests/python/test_cross_repo_smoke.py::test_cross_repo_smoke_persists_trip_state_after_evaluation tests/python/test_cross_repo_smoke.py::test_cross_repo_smoke_fails_when_trip_state_persistence_is_skipped -q` passed.
+  - `python -m pytest tests/python/test_cross_repo_smoke.py tests/python/test_orchestration_smoke.py -q` passed.
+- Next action: commit, push, open ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`; then hand off to keepalive.
+
 ## 2026-06-11T10:07:47Z - opener (codex): issue #1186 -> PR #1187
 
 - Repo: `stranske/Travel-Plan-Permission`

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,7 +1,8 @@
-## 2026-06-13T14:03:00Z - opener (codex): issue #1191 -> PR pending
+## 2026-06-13T14:03:00Z - opener (codex): issue #1191 -> PR #1192
 
 - Repo: `stranske/Travel-Plan-Permission`
 - Issue: `#1191` - Cross-repo smoke: persist and assert TripState follow-up state after live HTTP evaluation
+- PR: `#1192` - test: prove TripState smoke persistence guard (#1191)
 - Branch: `codex/issue-1191-tripstate-followup-state`
 - Worktree: `/Users/teacher/.codex/automations/pd-workloop-resume/worktrees/tpp-1191-tripstate`
 - Context: `origin/main` already contains the core TripState smoke persistence from #1186/#1187 (`TripState` construction, `trip_states_by_execution_id`, reload assertions, docs evidence). This lane adds the remaining durable deliberate-break proof requested by #1191 rather than duplicating the implementation.
@@ -9,7 +10,8 @@
 - Tests:
   - `python -m pytest tests/python/test_cross_repo_smoke.py::test_cross_repo_smoke_proves_submission_status_evaluation_and_reload tests/python/test_cross_repo_smoke.py::test_cross_repo_smoke_persists_trip_state_after_evaluation tests/python/test_cross_repo_smoke.py::test_cross_repo_smoke_fails_when_trip_state_persistence_is_skipped -q` passed.
   - `python -m pytest tests/python/test_cross_repo_smoke.py tests/python/test_orchestration_smoke.py -q` passed.
-- Next action: commit, push, open ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`; then hand off to keepalive.
+- Routing: PR is non-draft with `agent:codex`, `agents:keepalive`, and `autofix`.
+- Next action: wait for keepalive/Gate evidence on PR #1192.
 
 ## 2026-06-11T10:07:47Z - opener (codex): issue #1186 -> PR #1187
 


### PR DESCRIPTION
Closes #1191

## Summary
- Adds a focused deliberate-break regression test for the TripState persistence smoke path.
- Monkeypatches `_persist_trip_state` to no-op and asserts the smoke fails on the TripState reload check, proving the existing persistence assertion is durable.
- Records the lane state in `workloop-state.md`.

## Validation
- `python -m pytest tests/python/test_cross_repo_smoke.py::test_cross_repo_smoke_proves_submission_status_evaluation_and_reload tests/python/test_cross_repo_smoke.py::test_cross_repo_smoke_persists_trip_state_after_evaluation tests/python/test_cross_repo_smoke.py::test_cross_repo_smoke_fails_when_trip_state_persistence_is_skipped -q`
- `python -m pytest tests/python/test_cross_repo_smoke.py tests/python/test_orchestration_smoke.py -q`
- `git diff --check`