### PR TITLE
chore: refresh consumer CI config (llm_slots bump + drop double-CI trigger)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ name: CI
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/config/llm_slots.json
+++ b/config/llm_slots.json
@@ -3,12 +3,12 @@
     {
       "name": "slot1",
       "provider": "openai",
-      "model": "gpt-5.2"
+      "model": "gpt-5.4"
     },
     {
       "name": "slot2",
       "provider": "anthropic",
-      "model": "claude-sonnet-4-5-20250929"
+      "model": "claude-sonnet-4-6"
     },
     {
       "name": "slot3",


### PR DESCRIPTION
Fleet-hygiene fixes from the Workflows audit §4. Fixes applied: llm_slots(→gpt-5.4/sonnet-4-6) rm-pull_request-trigger. llm_slots was frozen at 2-gen-old models (create_only sync); the prohibited `pull_request:` trigger double-ran CI (the reusable Gate already covers PRs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow trigger and default model ID changes only; no auth, data, or application logic changes.
> 
> **Overview**
> **CI** no longer runs on `pull_request` to `main` in `.github/workflows/ci.yml`; it still runs on `push` to `main` and `workflow_dispatch`, avoiding a second full CI run when the reusable Workflows gate already covers PRs.
> 
> **Default LLM routing** in `config/llm_slots.json` updates slot1 from `gpt-5.2` to `gpt-5.4` and slot2 from `claude-sonnet-4-5-20250929` to `claude-sonnet-4-6` (slot3 unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac2130f2f01cdd3e9ff1dc04aa5b785783a15de3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->