### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/workflows/agents-guard.yml
+++ b/.github/workflows/agents-guard.yml
@@ -111,7 +111,7 @@ jobs:
           github.event_name == 'pull_request_target' &&
           steps.eligibility.outputs.should-run == 'true' &&
           steps.api_client_base.outputs.available != 'true'
-        uses: "stranske/Workflows/.github/actions/setup-api-client@d68de1904bcdbe16bfe2462b73aa18f41f8a0a47" # v1
+        uses: "stranske/Workflows/.github/actions/setup-api-client@c2537cc959f2ce05926c4639d25b90678abc97bc" # v1
         with:
           secrets: ${{ toJSON(secrets) }}
           github_token: ${{ github.token }}
@@ -180,7 +180,7 @@ jobs:
           steps.eligibility.outputs.should-run == 'true' &&
           github.event_name == 'pull_request' &&
           steps.api_client_head.outputs.available != 'true'
-        uses: "stranske/Workflows/.github/actions/setup-api-client@d68de1904bcdbe16bfe2462b73aa18f41f8a0a47" # v1
+        uses: "stranske/Workflows/.github/actions/setup-api-client@c2537cc959f2ce05926c4639d25b90678abc97bc" # v1
         with:
           secrets: ${{ toJSON(secrets) }}
           github_token: ${{ github.token }}

--- a/scripts/check_agents_md_freshness.py
+++ b/scripts/check_agents_md_freshness.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import shlex
 import shutil
 import sys
 from dataclasses import dataclass
@@ -47,7 +48,9 @@ def managed_section(text: str) -> str | None:
 
 
 def _clean_ref(value: str) -> str:
-    value = value.strip().strip("\"'")
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        value = value[1:-1]
     value = re.sub(r"[:#]L?\d+(?:-L?\d+)?$", "", value)
     return value
 
@@ -59,17 +62,38 @@ def _looks_like_path(value: str) -> bool:
     return "/" in value or path.suffix.lower() in PATH_SUFFIXES
 
 
+def _resolve_repo_path(repo_root: Path, ref: str) -> Path | None:
+    root = repo_root.resolve()
+    raw_path = Path(ref)
+    candidate = raw_path if raw_path.is_absolute() else root / raw_path
+    candidate = candidate.resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        return None
+    return candidate
+
+
 def _path_exists(repo_root: Path, ref: str) -> bool:
-    return (repo_root / ref).exists()
+    candidate = _resolve_repo_path(repo_root, ref)
+    return candidate.exists() if candidate else False
+
+
+def _command_parts(ref: str) -> list[str]:
+    try:
+        return shlex.split(ref)
+    except ValueError:
+        return ref.split()
 
 
 def _command_exists(repo_root: Path, ref: str) -> bool:
-    parts = ref.split()
+    parts = _command_parts(ref)
     if not parts:
         return True
     command = parts[0]
     if command.startswith(("./", "../")) or "/" in command:
-        return (repo_root / command).exists()
+        candidate = _resolve_repo_path(repo_root, command)
+        return candidate.exists() if candidate else False
     return shutil.which(command) is not None
 
 
@@ -77,7 +101,7 @@ def _check_command_ref(repo_root: Path, ref: str) -> list[Finding]:
     findings: list[Finding] = []
     if not _command_exists(repo_root, ref):
         findings.append(Finding("command", ref, f"referenced command not found: {ref}"))
-    for arg in ref.split()[1:]:
+    for arg in _command_parts(ref)[1:]:
         arg = _clean_ref(arg)
         if "=" in arg:
             _, arg = arg.split("=", 1)
@@ -140,7 +164,12 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     repo_root = args.repo_root.resolve()
-    agents_md = args.agents_md.resolve() if args.agents_md else None
+    if args.agents_md:
+        agents_md = (
+            args.agents_md if args.agents_md.is_absolute() else repo_root / args.agents_md
+        ).resolve()
+    else:
+        agents_md = None
     findings = check_agents_md(repo_root, agents_md)
 
     if args.as_json:

--- a/scripts/orchestrator_skill.py
+++ b/scripts/orchestrator_skill.py
@@ -80,7 +80,8 @@ def _require_nonempty_string(value: Any, field_name: str) -> str:
 
 
 def _validate_repo(repo: str) -> str:
-    if "/" not in repo or repo.startswith("/") or repo.endswith("/"):
+    parts = repo.split("/")
+    if len(parts) != 2 or not all(parts):
         raise OrchestratorSkillConfigError("repo must use owner/name format")
     return repo
 

--- a/scripts/reference_packs.py
+++ b/scripts/reference_packs.py
@@ -83,7 +83,8 @@ def _require_nonempty_string(value: Any, field_name: str) -> str:
 
 
 def _validate_repo(repo: str) -> str:
-    if "/" not in repo or repo.startswith("/") or repo.endswith("/"):
+    parts = repo.split("/")
+    if len(parts) != 2 or not all(parts):
         raise ReferencePackConfigError("repo must use owner/name format")
     return repo
 

--- a/scripts/runner_lib/core.py
+++ b/scripts/runner_lib/core.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import base64
 import binascii
+import contextlib
 import dataclasses
 import datetime as dt
 import hashlib
@@ -81,6 +82,34 @@ def _validate_provider(provider: str) -> str:
     if normalized not in PROVIDERS:
         raise ValueError(f"unsupported provider: {provider}")
     return normalized
+
+
+def _resolve_child_path(root: Path, path: str | Path, *, description: str) -> Path:
+    root_resolved = root.resolve()
+    raw_path = Path(path)
+    candidate = raw_path if raw_path.is_absolute() else root_resolved / raw_path
+    candidate = candidate.resolve()
+    try:
+        candidate.relative_to(root_resolved)
+    except ValueError as exc:
+        raise ValueError(f"{description} must stay within {root_resolved}") from exc
+    return candidate
+
+
+def _resolve_reference_checkout_path(workspace_path: Path, checkout_path: str | Path) -> Path:
+    reference_root = (workspace_path / ".reference").resolve()
+    candidate = _resolve_child_path(
+        workspace_path,
+        checkout_path,
+        description="reference checkout path",
+    )
+    try:
+        candidate.relative_to(reference_root)
+    except ValueError as exc:
+        raise ValueError("reference checkout path must stay within .reference") from exc
+    if candidate == reference_root:
+        raise ValueError("reference checkout path must identify a child of .reference")
+    return candidate
 
 
 def _runner_key(pr_number: int, head_sha: str, provider: str) -> str:
@@ -314,7 +343,7 @@ def _materialize_single_checkout_plan(
         )
         _run_git(["git", "-C", str(clone_dir), "sparse-checkout", "reapply"], env=git_env)
 
-        destination_root = workspace_path / checkout_path
+        destination_root = _resolve_reference_checkout_path(workspace_path, checkout_path)
         if destination_root.exists():
             shutil.rmtree(destination_root)
         destination_root.mkdir(parents=True, exist_ok=True)
@@ -356,11 +385,6 @@ def materialize_orchestrator_skill(
         return None
 
     if plan.pack:
-        materialize_reference_packs(
-            workspace_path,
-            reference_pack_name=plan.pack,
-            token=token,
-        )
         reference_packs = _load_reference_packs_module()
         snapshot = reference_packs.load_reference_packs(workspace_path)
         matching = [
@@ -370,7 +394,17 @@ def materialize_orchestrator_skill(
         ]
         if not matching:
             raise ValueError(f"orchestrator skill reference pack not found: {plan.pack}")
-        checkout_path = workspace_path / matching[0].checkout_path
+        checkout_path = _resolve_reference_checkout_path(
+            workspace_path,
+            matching[0].checkout_path,
+        )
+        with contextlib.suppress(FileNotFoundError):
+            shutil.rmtree(checkout_path)
+        materialize_reference_packs(
+            workspace_path,
+            reference_pack_name=plan.pack,
+            token=token,
+        )
     else:
         checkout_path = _materialize_single_checkout_plan(
             workspace_path,
@@ -413,12 +447,23 @@ def assemble_prompt(
         )
 
     if context.get("materialize_orchestrator_skill"):
-        materialize_orchestrator_skill(
+        orchestrator_summary_path = materialize_orchestrator_skill(
             workspace,
             pack_override=context.get("orchestrator_skill_pack") or None,
             enabled_override=context.get("orchestrator_skill_enabled"),
             token=token,
         )
+    else:
+        orchestrator_summary_raw = context.get("orchestrator_skill_summary_path")
+        orchestrator_summary_path = (
+            Path(str(orchestrator_summary_raw)) if orchestrator_summary_raw else None
+        )
+        if orchestrator_summary_path:
+            orchestrator_summary_path = _resolve_child_path(
+                workspace,
+                orchestrator_summary_path,
+                description="orchestrator_skill_summary_path",
+            )
 
     output_file = str(
         context.get("output_file") or _prompt_output_name(provider, context.get("pr_number"))
@@ -448,12 +493,11 @@ def assemble_prompt(
     if reference_summary.is_file():
         parts.extend(["\n\n## Reference Packs\n", _read_text(reference_summary).rstrip()])
 
-    orchestrator_summary = workspace / ".reference" / "ORCHESTRATOR_SKILL.md"
-    if orchestrator_summary.is_file():
+    if orchestrator_summary_path and orchestrator_summary_path.is_file():
         parts.extend(
             [
                 "\n\n## Orchestrator Skill Context\n",
-                _read_text(orchestrator_summary).rstrip(),
+                _read_text(orchestrator_summary_path).rstrip(),
             ]
         )
 
@@ -504,7 +548,14 @@ def _parse_jsonl_output(raw_output: str) -> tuple[list[str], list[str]]:
         event_type = str(event.get("type") or event.get("status") or "").lower()
         text = _extract_text_from_json_event(event)
         if "error" in event_type or event.get("error"):
-            errors.append(text or json.dumps(event, sort_keys=True))
+            error_value = event.get("error")
+            nested_error = (
+                _extract_text_from_json_event(error_value)
+                if isinstance(error_value, dict)
+                else None
+            )
+            direct_error = error_value.strip() if isinstance(error_value, str) else None
+            errors.append(direct_error or nested_error or text or json.dumps(event, sort_keys=True))
         elif text:
             messages.append(text)
     if not parsed_any:
@@ -522,7 +573,7 @@ def parse_runner_output(provider: str, raw_output: str) -> RunnerResult:
     clipped = raw[:64000] if len(raw) > 64000 else raw
 
     messages, errors = _parse_jsonl_output(clipped) if provider == "codex" else ([], [])
-    final_message = messages[-1] if messages else clipped.strip()
+    final_message = errors[0] if errors else (messages[-1] if messages else clipped.strip())
 
     if not errors and re.search(
         r"(^::error::|\bTraceback\b|\bError:|\bException\b)",
@@ -943,6 +994,7 @@ def _cmd_assemble(args: argparse.Namespace) -> int:
         "materialize_orchestrator_skill": args.materialize_orchestrator_skill,
         "orchestrator_skill_pack": args.orchestrator_skill_pack or None,
         "orchestrator_skill_enabled": _parse_optional_bool(args.orchestrator_skill_enabled),
+        "orchestrator_skill_summary_path": os.environ.get("ORCHESTRATOR_SKILL_SUMMARY_PATH"),
         "github_token": os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN"),
     }
     prompt = assemble_prompt(args.reference_pack_name, context, args.provider)

--- a/tools/langchain_client.py
+++ b/tools/langchain_client.py
@@ -8,13 +8,28 @@ timeouts, retries, and environment overrides.
 from __future__ import annotations
 
 import contextlib
-import json
 import logging
 import os
 from dataclasses import dataclass
-from pathlib import Path
 
+from tools import llm_registry as _llm_registry
 from tools.llm_provider import DEFAULT_MODEL, GITHUB_MODELS_BASE_URL
+from tools.llm_registry import (
+    PROVIDER_ANTHROPIC,
+    PROVIDER_GITHUB,
+    PROVIDER_OPENAI,
+    ModelRegistryEntry,
+    SlotDefinition,
+    apply_slot_env_overrides,
+    default_slots,
+    is_model_blocked,
+    load_model_registry,
+    load_slot_config,
+    normalize_provider,
+    registry_entry_for,
+    resolve_slots,
+    select_model_for_tier,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -22,15 +37,12 @@ ENV_PROVIDER = "LANGCHAIN_PROVIDER"
 ENV_MODEL = "LANGCHAIN_MODEL"
 ENV_TIMEOUT = "LANGCHAIN_TIMEOUT"
 ENV_MAX_RETRIES = "LANGCHAIN_MAX_RETRIES"
-ENV_SLOT_CONFIG = "LANGCHAIN_SLOT_CONFIG"
+ENV_SLOT_CONFIG = _llm_registry.ENV_SLOT_CONFIG
+ENV_MODEL_REGISTRY_CONFIG = _llm_registry.ENV_MODEL_REGISTRY_CONFIG
 ENV_SLOT_PREFIX = "LANGCHAIN_SLOT"
 ENV_ANTHROPIC_KEY = "CLAUDE_API_STRANSKE"
-
-PROVIDER_OPENAI = "openai"
-PROVIDER_ANTHROPIC = "anthropic"
-PROVIDER_GITHUB = "github-models"
-
-DEFAULT_SLOT_CONFIG_PATH = Path(__file__).resolve().parent.parent / "config" / "llm_slots.json"
+DEFAULT_SLOT_CONFIG_PATH = _llm_registry.DEFAULT_SLOT_CONFIG_PATH
+DEFAULT_MODEL_REGISTRY_CONFIG_PATH = _llm_registry.DEFAULT_MODEL_REGISTRY_CONFIG_PATH
 
 
 def _env_int(name: str, default: int) -> int:
@@ -59,24 +71,8 @@ class ClientInfo:
         return f"{self.provider}/{self.model}"
 
 
-@dataclass(frozen=True)
-class SlotDefinition:
-    name: str
-    provider: str
-    model: str
-
-
 def _normalize_provider(value: str | None) -> str | None:
-    if not value:
-        return None
-    normalized = value.strip().lower()
-    if normalized in {"github", "github_models", "github-models"}:
-        return PROVIDER_GITHUB
-    if normalized in {"anthropic", "claude"}:
-        return PROVIDER_ANTHROPIC
-    if normalized in {"openai"}:
-        return PROVIDER_OPENAI
-    return None
+    return normalize_provider(value)
 
 
 def _resolve_provider(provider: str | None, *, force_openai: bool) -> tuple[str | None, bool]:
@@ -93,57 +89,53 @@ def _resolve_model(model: str | None) -> str:
     return model or env_model or DEFAULT_MODEL
 
 
+def _load_model_registry() -> list[ModelRegistryEntry]:
+    return load_model_registry()
+
+
+def _registry_entry_for(
+    provider: str, model: str, registry: list[ModelRegistryEntry] | None = None
+) -> ModelRegistryEntry | None:
+    return registry_entry_for(provider, model, registry=registry)
+
+
+def _is_model_blocked(
+    provider: str, model: str, registry: list[ModelRegistryEntry] | None = None
+) -> bool:
+    return is_model_blocked(provider, model, registry=registry)
+
+
+def _select_model_for_tier(
+    *,
+    provider: str,
+    tier: str,
+    registry: list[ModelRegistryEntry] | None = None,
+) -> str | None:
+    return select_model_for_tier(provider=provider, tier=tier, registry=registry)
+
+
 def _default_slots() -> list[SlotDefinition]:
-    return [
-        SlotDefinition(name="slot1", provider=PROVIDER_OPENAI, model="gpt-5.4"),
-        SlotDefinition(name="slot2", provider=PROVIDER_ANTHROPIC, model="claude-sonnet-4-6"),
-        SlotDefinition(name="slot3", provider=PROVIDER_GITHUB, model=DEFAULT_MODEL),
-    ]
+    return default_slots(github_default_model=DEFAULT_MODEL)
 
 
 def _load_slot_config() -> list[SlotDefinition]:
-    config_path = os.environ.get(ENV_SLOT_CONFIG)
-    path = Path(config_path) if config_path else DEFAULT_SLOT_CONFIG_PATH
-    if not path.is_file():
-        return _default_slots()
-    try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return _default_slots()
-
-    slots: list[SlotDefinition] = []
-    for idx, entry in enumerate(payload.get("slots", []), start=1):
-        provider = _normalize_provider(str(entry.get("provider", "")))
-        model = str(entry.get("model", "")).strip()
-        if not provider or not model:
-            continue
-        name = str(entry.get("name") or f"slot{idx}").strip() or f"slot{idx}"
-        slots.append(SlotDefinition(name=name, provider=provider, model=model))
-
-    return slots or _default_slots()
+    return load_slot_config(github_default_model=DEFAULT_MODEL)
 
 
 def _apply_slot_env_overrides(slots: list[SlotDefinition]) -> list[SlotDefinition]:
-    updated: list[SlotDefinition] = []
-    for idx, slot in enumerate(slots, start=1):
-        provider_key = f"{ENV_SLOT_PREFIX}{idx}_PROVIDER"
-        model_key = f"{ENV_SLOT_PREFIX}{idx}_MODEL"
-        provider_override = _normalize_provider(os.environ.get(provider_key))
-        model_override = os.environ.get(model_key)
-        if idx == 1:
-            model_override = model_override or os.environ.get(ENV_MODEL)
-        updated.append(
-            SlotDefinition(
-                name=slot.name,
-                provider=provider_override or slot.provider,
-                model=(model_override or slot.model).strip(),
-            )
-        )
-    return updated
+    return apply_slot_env_overrides(
+        slots,
+        env_model_name=ENV_MODEL,
+        env_slot_prefix=ENV_SLOT_PREFIX,
+    )
 
 
 def _resolve_slots() -> list[SlotDefinition]:
-    return _apply_slot_env_overrides(_load_slot_config())
+    return resolve_slots(
+        github_default_model=DEFAULT_MODEL,
+        env_model_name=ENV_MODEL,
+        env_slot_prefix=ENV_SLOT_PREFIX,
+    )
 
 
 def _is_reasoning_model(model: str) -> bool:
@@ -234,6 +226,9 @@ def build_chat_client(
     selected_provider, provider_explicit = _resolve_provider(provider, force_openai=force_openai)
     if provider_explicit and selected_provider is None:
         return None
+    if selected_provider and _is_model_blocked(selected_provider, selected_model):
+        logger.warning("Refusing blocked LLM model: %s/%s", selected_provider, selected_model)
+        return None
 
     if selected_provider == PROVIDER_GITHUB:
         if not github_token:
@@ -285,7 +280,25 @@ def build_chat_client(
     model_override = model or os.environ.get(ENV_MODEL)
     used_override = False
     for slot in slots:
+        slot_available = any(
+            (
+                slot.provider == PROVIDER_OPENAI and openai_token,
+                slot.provider == PROVIDER_ANTHROPIC and anthropic_token and chat_anthropic_cls,
+                slot.provider == PROVIDER_GITHUB and github_token,
+            )
+        )
+        if not slot_available:
+            continue
         slot_model = model_override if model_override and not used_override else slot.model
+        if _is_model_blocked(slot.provider, slot_model):
+            logger.warning("Skipping blocked LLM model override: %s/%s", slot.provider, slot_model)
+            if model_override and not used_override:
+                used_override = True
+                slot_model = slot.model
+                if _is_model_blocked(slot.provider, slot_model):
+                    continue
+            else:
+                continue
         if slot.provider == PROVIDER_OPENAI and openai_token:
             with contextlib.suppress(Exception):
                 client = _build_openai_client(
@@ -358,6 +371,15 @@ def build_chat_clients(
     selected_provider, provider_explicit = _resolve_provider(provider, force_openai=False)
     if provider_explicit and selected_provider is None:
         return []
+    registry = _load_model_registry()
+    if selected_provider:
+        blocked_models = [candidate for candidate in (first_model, second_model) if candidate]
+        if any(
+            _is_model_blocked(selected_provider, candidate, registry=registry)
+            for candidate in blocked_models
+        ):
+            logger.warning("Refusing blocked LLM model for provider %s", selected_provider)
+            return []
 
     clients: list[ClientInfo] = []
 
@@ -475,6 +497,9 @@ def build_chat_clients(
     for idx, slot in enumerate(candidate_slots):
         slot_model = model_overrides[idx] if idx < len(model_overrides) else None
         slot_model = slot_model or slot.model
+        if _is_model_blocked(slot.provider, slot_model, registry=registry):
+            logger.warning("Skipping blocked LLM model override: %s/%s", slot.provider, slot_model)
+            continue
         if slot.provider == PROVIDER_OPENAI and openai_token:
             with contextlib.suppress(Exception):
                 clients.append(

--- a/tools/llm_registry.py
+++ b/tools/llm_registry.py
@@ -1,0 +1,294 @@
+"""Shared LLM slot and model-registry resolution helpers."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+ENV_MODEL_REGISTRY_CONFIG = "LANGCHAIN_MODEL_REGISTRY_CONFIG"
+ENV_SLOT_CONFIG = "LANGCHAIN_SLOT_CONFIG"
+
+PROVIDER_OPENAI = "openai"
+PROVIDER_ANTHROPIC = "anthropic"
+PROVIDER_GITHUB = "github-models"
+
+DEFAULT_SLOT_CONFIG_PATH = Path(__file__).resolve().parent.parent / "config" / "llm_slots.json"
+DEFAULT_MODEL_REGISTRY_CONFIG_PATH = (
+    Path(__file__).resolve().parent.parent / "config" / "model_registry.json"
+)
+
+
+@dataclass(frozen=True)
+class ModelRegistryEntry:
+    provider: str
+    model: str
+    blocked: bool
+    quality: dict[str, float]
+
+
+@dataclass(frozen=True)
+class SlotDefinition:
+    name: str
+    provider: str
+    model: str
+
+
+def normalize_provider(value: str | None) -> str | None:
+    if not value:
+        return None
+    normalized = value.strip().lower()
+    if normalized in {"github", "github_models", "github-models"}:
+        return PROVIDER_GITHUB
+    if normalized in {"anthropic", "claude"}:
+        return PROVIDER_ANTHROPIC
+    if normalized == PROVIDER_OPENAI:
+        return PROVIDER_OPENAI
+    return None
+
+
+def _slot_entries(payload: dict[str, object], path: Path) -> list[dict[str, object]]:
+    raw_slots = payload.get("slots", [])
+    if not isinstance(raw_slots, list):
+        logger.warning("Invalid slot config format in %s; expected slots list", path)
+        return []
+    slots: list[dict[str, object]] = []
+    for raw_slot in raw_slots:
+        if isinstance(raw_slot, dict):
+            slots.append(raw_slot)
+        else:
+            logger.warning("Ignoring invalid slot entry in %s; expected object", path)
+    return slots
+
+
+def load_model_registry() -> list[ModelRegistryEntry]:
+    config_path = os.environ.get(ENV_MODEL_REGISTRY_CONFIG)
+    path = Path(config_path) if config_path else DEFAULT_MODEL_REGISTRY_CONFIG_PATH
+    if not path.is_file():
+        return []
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        logger.warning("Could not read model registry %s; continuing without registry", path)
+        return []
+    if not isinstance(payload, dict):
+        logger.warning("Invalid model registry format in %s; expected object", path)
+        return []
+
+    raw_models = payload.get("models", [])
+    if not isinstance(raw_models, list):
+        logger.warning("Invalid model registry format in %s; expected models list", path)
+        return []
+
+    entries: list[ModelRegistryEntry] = []
+    for raw_entry in raw_models:
+        if not isinstance(raw_entry, dict):
+            logger.warning("Ignoring invalid model registry entry in %s; expected object", path)
+            continue
+        provider = normalize_provider(str(raw_entry.get("provider", "")))
+        model = str(raw_entry.get("model_id", "")).strip()
+        if not provider or not model:
+            continue
+        quality_payload = raw_entry.get("quality", {})
+        if not isinstance(quality_payload, dict):
+            logger.warning(
+                "Ignoring invalid quality scores for %s/%s in %s; expected object",
+                provider,
+                model,
+                path,
+            )
+            quality_payload = {}
+        quality = {
+            str(tier).upper(): float(score)
+            for tier, score in quality_payload.items()
+            if isinstance(score, int | float)
+        }
+        entries.append(
+            ModelRegistryEntry(
+                provider=provider,
+                model=model,
+                blocked=bool(raw_entry.get("blocked", False)),
+                quality=quality,
+            )
+        )
+    return entries
+
+
+def registry_entry_for(
+    provider: str, model: str, registry: list[ModelRegistryEntry] | None = None
+) -> ModelRegistryEntry | None:
+    entries = registry if registry is not None else load_model_registry()
+    normalized_provider = normalize_provider(provider)
+    normalized_model = model.strip()
+    for entry in entries:
+        if entry.provider == normalized_provider and entry.model == normalized_model:
+            return entry
+    return None
+
+
+def is_model_blocked(
+    provider: str, model: str, registry: list[ModelRegistryEntry] | None = None
+) -> bool:
+    entry = registry_entry_for(provider, model, registry=registry)
+    return bool(entry and entry.blocked)
+
+
+def select_model_for_tier(
+    *,
+    provider: str,
+    tier: str,
+    registry: list[ModelRegistryEntry] | None = None,
+) -> str | None:
+    entries = registry if registry is not None else load_model_registry()
+    normalized_provider = normalize_provider(provider)
+    normalized_tier = tier.strip().upper()
+    candidates = [
+        entry
+        for entry in entries
+        if entry.provider == normalized_provider
+        and not entry.blocked
+        and normalized_tier in entry.quality
+    ]
+    if not candidates:
+        return None
+    selected = max(candidates, key=lambda entry: entry.quality[normalized_tier])
+    return selected.model
+
+
+def configured_model_for_provider(
+    provider: str,
+    *,
+    fallback: str,
+    tier: str = "T3",
+    registry: list[ModelRegistryEntry] | None = None,
+) -> str:
+    normalized_provider = normalize_provider(provider)
+    entries = registry if registry is not None else load_model_registry()
+
+    config_path = os.environ.get(ENV_SLOT_CONFIG)
+    path = Path(config_path) if config_path else DEFAULT_SLOT_CONFIG_PATH
+    if path.is_file():
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            payload = {}
+        if not isinstance(payload, dict):
+            logger.warning("Invalid slot config format in %s; expected object", path)
+            payload = {}
+        for slot in _slot_entries(payload, path):
+            slot_provider = normalize_provider(str(slot.get("provider", "")))
+            if slot_provider != normalized_provider:
+                continue
+            model = str(slot.get("model", "")).strip()
+            slot_tier = str(slot.get("quality_tier") or slot.get("tier") or tier).strip()
+            if not model and slot_tier:
+                model = (
+                    select_model_for_tier(
+                        provider=slot_provider or "",
+                        tier=slot_tier,
+                        registry=entries,
+                    )
+                    or ""
+                )
+            if model and not is_model_blocked(slot_provider or "", model, registry=entries):
+                return model
+
+    selected = select_model_for_tier(provider=provider, tier=tier, registry=entries)
+    if selected:
+        return selected
+    if not is_model_blocked(provider, fallback, registry=entries):
+        return fallback
+    return ""
+
+
+def default_slots(*, github_default_model: str) -> list[SlotDefinition]:
+    return [
+        SlotDefinition(name="slot1", provider=PROVIDER_OPENAI, model="gpt-5.4"),
+        SlotDefinition(name="slot2", provider=PROVIDER_ANTHROPIC, model="claude-sonnet-4-6"),
+        SlotDefinition(name="slot3", provider=PROVIDER_GITHUB, model=github_default_model),
+    ]
+
+
+def load_slot_config(*, github_default_model: str) -> list[SlotDefinition]:
+    config_path = os.environ.get(ENV_SLOT_CONFIG)
+    path = Path(config_path) if config_path else DEFAULT_SLOT_CONFIG_PATH
+    fallback_slots = default_slots(github_default_model=github_default_model)
+    if not path.is_file():
+        return fallback_slots
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return fallback_slots
+    if not isinstance(payload, dict):
+        logger.warning("Invalid slot config format in %s; expected object", path)
+        return fallback_slots
+
+    registry = load_model_registry()
+    slots: list[SlotDefinition] = []
+    for idx, entry in enumerate(_slot_entries(payload, path), start=1):
+        provider = normalize_provider(str(entry.get("provider", "")))
+        model = str(entry.get("model", "")).strip()
+        tier = str(entry.get("quality_tier") or entry.get("tier") or "").strip()
+        if provider and not model and tier:
+            model = select_model_for_tier(provider=provider, tier=tier, registry=registry) or ""
+        if not provider or not model:
+            continue
+        if is_model_blocked(provider, model, registry=registry):
+            logger.warning("Skipping blocked LLM model in slot config: %s/%s", provider, model)
+            continue
+        name = str(entry.get("name") or f"slot{idx}").strip() or f"slot{idx}"
+        slots.append(SlotDefinition(name=name, provider=provider, model=model))
+
+    return slots or fallback_slots
+
+
+def apply_slot_env_overrides(
+    slots: list[SlotDefinition],
+    *,
+    env_model_name: str = "LANGCHAIN_MODEL",
+    env_slot_prefix: str = "LANGCHAIN_SLOT",
+) -> list[SlotDefinition]:
+    registry = load_model_registry()
+    updated: list[SlotDefinition] = []
+    for idx, slot in enumerate(slots, start=1):
+        provider_key = f"{env_slot_prefix}{idx}_PROVIDER"
+        model_key = f"{env_slot_prefix}{idx}_MODEL"
+        provider_override = normalize_provider(os.environ.get(provider_key))
+        model_override = os.environ.get(model_key)
+        if idx == 1:
+            model_override = model_override or os.environ.get(env_model_name)
+        provider = provider_override or slot.provider
+        model = (model_override or slot.model).strip()
+        if is_model_blocked(provider, model, registry=registry):
+            logger.warning("Skipping blocked LLM slot override: %s/%s", provider, model)
+            override_requested = provider_override is not None or model_override is not None
+            if override_requested and not is_model_blocked(
+                slot.provider, slot.model, registry=registry
+            ):
+                updated.append(slot)
+            continue
+        updated.append(
+            SlotDefinition(
+                name=slot.name,
+                provider=provider,
+                model=model,
+            )
+        )
+    return updated
+
+
+def resolve_slots(
+    *,
+    github_default_model: str,
+    env_model_name: str = "LANGCHAIN_MODEL",
+    env_slot_prefix: str = "LANGCHAIN_SLOT",
+) -> list[SlotDefinition]:
+    return apply_slot_env_overrides(
+        load_slot_config(github_default_model=github_default_model),
+        env_model_name=env_model_name,
+        env_slot_prefix=env_slot_prefix,
+    )


### PR DESCRIPTION
## Sync Summary

### Files Updated
- agents-guard.yml: Agents guard - enforces agents workflow protections (Health 45)
- check_agents_md_freshness.py: Warns when the generated Orchestrator AGENTS.md playbook section cites stale repo paths or commands
- reference_packs.py: Validates and resolves reference pack configuration for shared runner prompt assembly
- orchestrator_skill.py: Validates and resolves exported Orchestrator skill context for remote Codex lanes
- runner_lib/ (1 files): Shared runner prompt assembly, output parsing, and dispatch debounce helpers
- langchain_client.py: LangChain client builder - multi-provider client with slot-based fallback and configuration
- llm_registry.py: LLM model registry helper - shared slot/model selection and blocked-model enforcement

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `821168725d0568cade5bb9a18fc58cab97657975`
**Template hash:** `591316374281`
**Sync branch:** `sync/workflows-591316374281`
**Consumer repo:** `stranske/Travel-Plan-Permission`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Travel-Plan-Permission","source_repository":"stranske/Workflows","source_sha":"821168725d0568cade5bb9a18fc58cab97657975","template_hash":"591316374281","sync_branch":"sync/workflows-591316374281","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"27931910051","run_attempt":"1","changes_count":7} -->