### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/workflows/agents-80-pr-event-hub.yml
+++ b/.github/workflows/agents-80-pr-event-hub.yml
@@ -326,7 +326,7 @@ jobs:
 
       - name: Set up Python
         if: steps.check-merged.outputs.merged == 'true'
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/agents-auto-label.yml
+++ b/.github/workflows/agents-auto-label.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Set up Python
         if: steps.eligibility.outputs.should-run == 'true'
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.14"
 

--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -216,7 +216,7 @@ jobs:
       - name: Set up Python
         id: setup-python
         if: steps.check_enabled.outputs.enabled == 'true'
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.14'
 

--- a/.github/workflows/agents-capability-check.yml
+++ b/.github/workflows/agents-capability-check.yml
@@ -34,7 +34,7 @@ jobs:
           github_token: ${{ github.token }}
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.14"
 

--- a/.github/workflows/agents-decompose.yml
+++ b/.github/workflows/agents-decompose.yml
@@ -29,7 +29,7 @@ jobs:
           github_token: ${{ github.token }}
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.14"
 

--- a/.github/workflows/agents-dedup.yml
+++ b/.github/workflows/agents-dedup.yml
@@ -38,7 +38,7 @@ jobs:
           github_token: ${{ github.token }}
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.14"
 

--- a/.github/workflows/agents-issue-optimizer.yml
+++ b/.github/workflows/agents-issue-optimizer.yml
@@ -139,7 +139,7 @@ jobs:
 
       - name: Set up Python
         if: steps.check.outputs.should_run == 'true'
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.14'
 

--- a/.github/workflows/agents-verify-to-new-pr.yml
+++ b/.github/workflows/agents-verify-to-new-pr.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Set up Python
         if: steps.check-merged.outputs.merged == 'true'
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/agents-weekly-metrics.yml
+++ b/.github/workflows/agents-weekly-metrics.yml
@@ -58,7 +58,7 @@ jobs:
 
 
       - name: Setup Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.14"
 

--- a/.github/workflows/backplane-conformance.yml
+++ b/.github/workflows/backplane-conformance.yml
@@ -26,7 +26,7 @@ jobs:
       manifest: artifacts/reference/manifest.json
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.14'
       - run: pip install -e .


### PR DESCRIPTION
## Sync Summary

### Files Updated
- agents-80-pr-event-hub.yml: PR event hub - consolidates PR meta, bot comments, and verify-to-issue handlers
- agents-issue-optimizer.yml: Issue optimizer - LangChain-based issue formatting and optimization (Phase 1)
- agents-verify-to-new-pr.yml: Verify to new PR - creates follow-up issue and immediately dispatches auto-pilot to prepare a replacement PR (bridge inlined)
- agents-auto-label.yml: Auto-label - suggests/applies labels based on semantic matching (Phase 5A)
- agents-capability-check.yml: Capability check - pre-flight agent feasibility gate (Phase 3A)
- agents-decompose.yml: Task decomposition - breaks large issues into sub-tasks (Phase 3B)
- agents-dedup.yml: Duplicate detection - flags similar open issues (Phase 3C)
- agents-auto-pilot.yml: Auto-pilot - end-to-end automation orchestrator (format → optimize → agent → verify)
- agents-weekly-metrics.yml: Weekly metrics - aggregates auto-pilot, keepalive, autofix and verifier metrics into summary reports
- backplane-conformance.yml: Backplane conformance caller stub - calls reusable-backplane-conformance.yml@main to validate a repo's emitted run-contract/v1 envelope (producer) or ingested object (consumer). No-op for non-participants (opt-in). Template lives under templates/consumer-repo/.github/workflows/.

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `ba477586bf8091c24ca6180b1b25bad5f59c571e`
**Template hash:** `23c2155b07e7`
**Sync branch:** `sync/workflows-23c2155b07e7`
**Consumer repo:** `stranske/Travel-Plan-Permission`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Travel-Plan-Permission","source_repository":"stranske/Workflows","source_sha":"ba477586bf8091c24ca6180b1b25bad5f59c571e","template_hash":"23c2155b07e7","sync_branch":"sync/workflows-23c2155b07e7","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"28088900646","run_attempt":"1","changes_count":10} -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Python setup step across several GitHub workflows to use a newer pinned version.
  * No workflow behavior, inputs, or outputs were changed.
  * This helps keep automation runs aligned with the latest supported setup action version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->