### PR TITLE
deps: sync dev tool versions

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -5,7 +5,7 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.5.1
-RUFF_VERSION=0.16.0
+RUFF_VERSION=0.16.1
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
 MYPY_VERSION=2.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dev = [
     "pytest==9.1.1",
     "pytest-cov==7.1.0",
     "cryptography",
-    "ruff==0.16.0",
+    "ruff==0.16.1",
     "black==26.5.1",
     "mypy==2.3.0",
     "types-PyYAML>=6.0.12",

--- a/requirements.lock
+++ b/requirements.lock
@@ -205,7 +205,7 @@ requests==2.34.2
     #   requests-toolbelt
 requests-toolbelt==1.0.0
     # via langsmith
-ruff==0.16.0
+ruff==0.16.1
     # via travel-plan-permission (pyproject.toml)
 six==1.17.0
     # via python-dateutil


### PR DESCRIPTION
## Dev Tool Version Sync

This PR updates dev tool versions in `pyproject.toml` and related generated dependency files to match the central version pins from [stranske/Workflows](https://github.com/stranske/Workflows).

### Changes
```
Found 2 version updates:
  - ruff: ==0.16.0 -> ==0.16.1
  - requirements.lock:ruff: 0.16.0 -> ==0.16.1

Run with --apply to update dependency files
```

### Why
Consistent dev tool versions across repos ensures:
- CI behaviors match between repos
- No surprises from version drift
- Easier debugging when tools behave the same everywhere

---
**Source:** `.github/workflows/autofix-versions.env`