### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/scripts/issue_format.py
+++ b/.github/scripts/issue_format.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Validate a GitHub issue body against the fleet's AGENT_ISSUE_FORMAT contract.
+
+Synced to every consumer repo by `maint-68-sync-consumer-repos.yml`. This is the
+single definition of "agent-processable" for the whole fleet — do not fork it
+per repo.
+
+Why it exists: every automated lane reaches an issue through a LABEL. An issue
+filed with no label and no Tasks/Acceptance block is invisible to the entire
+pipeline — nothing validates it, nothing optimises it, nothing claims it. Local
+automation that files *findings* rather than *work orders* therefore produces
+issues no agent can ever pick up: good evidence, permanently unactionable.
+(Observed in Fine-Art-Archive #406-409: four well-evidenced audit findings, zero
+labels, no Tasks section between them.)
+
+Used at both ends:
+  * `agents-issue-format-guard.yml` validates every issue on open/edit and, on
+    failure, applies `agents:format` — the label the existing Agents Issue
+    Optimizer already listens for — so a bad issue is ROUTED to the machinery
+    that repairs it rather than merely flagged;
+  * any local script that files issues can pre-flight with
+    `python .github/scripts/issue_format.py <body-file>` and refuse to file junk
+    (non-zero exit means unfit).
+
+Rules mirror docs/AGENT_ISSUE_FORMAT.md rather than inventing a parallel
+standard: Tasks and Acceptance Criteria are REQUIRED; Why / Scope /
+Implementation Notes / Non-Goals are reported as recommended; and at least one
+acceptance criterion must name a real test, runnable command, or observable
+verification gate.
+
+Recommended sections are advisory: their absence is reported to help authors
+improve an issue, but does not change the exit code or route an otherwise valid
+work order through the optimizer. Keeping that distinction prevents the guard
+from flagging well-formed work orders solely for an optional heading.
+
+`_headings()` skips fenced code blocks, and that is load-bearing rather than
+cosmetic. Without it a body whose ONLY "Tasks" and "Acceptance Criteria" lines
+sit inside a ```bash fence validates as conforming — a false negative that lets
+an unactionable issue through the guard. Well-written issues quote commands and
+expected output in fences constantly, so this is the common case, not an edge
+one. Any change to heading detection must keep a fenced-heading case in the
+upstream Workflows test `tests/scripts/test_issue_format.py`.
+
+Pure stdlib on purpose — it must run on a bare runner with no install step.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass, field
+
+REQUIRED: dict[str, tuple[str, ...]] = {
+    "Tasks": ("tasks", "task list", "implementation"),
+    "Acceptance Criteria": ("acceptance criteria", "acceptance", "definition of done"),
+}
+RECOMMENDED: dict[str, tuple[str, ...]] = {
+    "Why": ("why", "goals", "summary", "motivation", "finding"),
+    "Scope": ("scope", "background", "context", "overview"),
+    "Implementation Notes": ("implementation notes",),
+    "Non-Goals": ("non-goals", "out of scope", "constraints"),
+}
+GATE = re.compile(
+    r"(tests?/[\w./-]+\.py(::[\w:\[\]-]+)?"
+    r"|\btest_[\w]+"
+    r"|\bpytest\b|\bnpm test\b|\bmake test\b"
+    r"|\bgh workflow run\b|\bgh run\b"
+    r"|\bcurl\b|\bHTTP [1-5]\d\d\b"
+    r"|\b(?:API|endpoint|request|response)\s+(?:returns?|responds with)\s+[1-5]\d\d(?:\s+status)?\b"
+    r"|\bsmoke\b|\bverif\w*)",
+    re.I,
+)
+BANNED_ADJECTIVES = ("clean", "nice", "good", "fast", "better", "intuitive", "polished")
+
+
+def _headings(body: str) -> list[tuple[str, int, int]]:
+    """Return markdown headings outside fenced code blocks with line indexes."""
+    out: list[tuple[str, int, int]] = []
+    fence: tuple[str, int] | None = None
+    for i, line in enumerate(body.splitlines()):
+        fence_match = re.match(r"\s{0,3}(`{3,}|~{3,})", line)
+        if fence_match:
+            marker = fence_match.group(1)
+            if fence is None:
+                fence = (marker[0], len(marker))
+            elif (
+                marker[0] == fence[0]
+                and len(marker) >= fence[1]
+                and re.fullmatch(
+                    rf"\s{{0,3}}(?:`{{{fence[1]},}}|~{{{fence[1]},}})\s*",
+                    line,
+                )
+            ):
+                fence = None
+            continue
+        if fence is not None:
+            continue
+        heading = re.match(r"\s{0,3}(#{1,6})\s+(.+?)\s*#*\s*$", line)
+        if heading:
+            out.append((heading.group(2).strip().strip(":").lower(), i, len(heading.group(1))))
+    return out
+
+
+def _find(body: str, aliases: tuple[str, ...]) -> int | None:
+    for text, idx, _ in _headings(body):
+        if any(text == alias or text.startswith(f"{alias} (") for alias in aliases):
+            return idx
+    return None
+
+
+def _section_text(body: str, start: int) -> str:
+    lines = body.splitlines()
+    start_level = next(level for _, idx, level in _headings(body) if idx == start)
+    following = [idx for _, idx, level in _headings(body) if idx > start and level <= start_level]
+    end = following[0] if following else len(lines)
+    return "\n".join(lines[start + 1 : end])
+
+
+@dataclass
+class Report:
+    ok: bool = True
+    missing_required: list[str] = field(default_factory=list)
+    missing_recommended: list[str] = field(default_factory=list)
+    problems: list[str] = field(default_factory=list)
+
+    def as_markdown(self) -> str:
+        if self.ok and not self.missing_recommended:
+            return "Issue body conforms to `docs/AGENT_ISSUE_FORMAT.md`."
+        if self.ok:
+            out = ["Issue body is agent-processable with advisories.", ""]
+        else:
+            out = [
+                "This issue is **not yet agent-processable**. See `docs/AGENT_ISSUE_FORMAT.md`.",
+                "",
+            ]
+        if self.missing_required:
+            out.append(
+                "**Missing required sections:** "
+                + ", ".join(f"`{section}`" for section in self.missing_required)
+            )
+        out.extend(f"- {problem}" for problem in self.problems)
+        if self.missing_recommended:
+            out.extend(
+                [
+                    "",
+                    "_Recommended but absent:_ "
+                    + ", ".join(f"`{section}`" for section in self.missing_recommended),
+                ]
+            )
+        return "\n".join(out)
+
+
+def validate(body: str) -> Report:
+    """Check an issue body; every structural format problem is non-conforming."""
+    report = Report()
+    body = body or ""
+    for name, aliases in REQUIRED.items():
+        if _find(body, aliases) is None:
+            report.missing_required.append(name)
+    for name, aliases in RECOMMENDED.items():
+        if _find(body, aliases) is None:
+            report.missing_recommended.append(name)
+
+    tasks_at = _find(body, REQUIRED["Tasks"])
+    if tasks_at is not None and not re.search(
+        r"^\s*[-*]\s*\[[ xX]\]", _section_text(body, tasks_at), re.M
+    ):
+        report.problems.append(
+            "`Tasks` has no checkbox items (`- [ ] …`); agents track progress by them."
+        )
+
+    acceptance_at = _find(body, REQUIRED["Acceptance Criteria"])
+    if acceptance_at is not None:
+        acceptance = _section_text(body, acceptance_at)
+        if not GATE.search(acceptance):
+            report.problems.append(
+                "`Acceptance Criteria` names no test, runnable command or observable "
+                "verification gate — Definition of Ready / Quality Bar §2 requires one."
+            )
+        hits = [word for word in BANNED_ADJECTIVES if re.search(rf"\b{word}\b", acceptance, re.I)]
+        if hits:
+            report.problems.append(
+                "`Acceptance Criteria` uses subjective wording ("
+                + ", ".join(sorted(hits))
+                + "); replace with a measurable check."
+            )
+    report.ok = not report.missing_required and not report.problems
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if argv:
+        with open(argv[0], encoding="utf-8") as issue_file:
+            body = issue_file.read()
+    else:
+        body = sys.stdin.read()
+    report = validate(body)
+    print(report.as_markdown())
+    return 0 if report.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/agents-auto-label.yml
+++ b/.github/workflows/agents-auto-label.yml
@@ -50,11 +50,12 @@ jobs:
             github.event.workflow_run.repository.default_branch }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
+          path: eligibility-source
 
       # Escape hatch: set mode: warning if false-negative skips appear post-merge.
       - name: Check event eligibility
         id: eligibility
-        uses: ./.github/actions/agent-event-eligibility
+        uses: ./eligibility-source/.github/actions/agent-event-eligibility
         with:
           expected-actions: opened,reopened,edited
           custom-predicate: >-

--- a/.github/workflows/agents-issue-format-guard.yml
+++ b/.github/workflows/agents-issue-format-guard.yml
@@ -1,0 +1,160 @@
+name: Agents Issue Format Guard
+
+on:
+  issues:
+    types: [opened, edited, reopened, labeled, unlabeled]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue to (re)check"
+        required: true
+        type: string
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+
+concurrency:
+  group: issue-format-guard-${{ github.event.issue.number || inputs.issue_number }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    if: >-
+      github.event_name != 'issues' ||
+      github.event.action == 'opened' || github.event.action == 'edited' ||
+      github.event.action == 'reopened' ||
+      ((github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
+      (github.event.label.name == 'agents:auto-pilot-pause' ||
+      github.event.label.name == 'needs-human' ||
+      github.event.label.name == 'tracker:durable' || github.event.label.name == 'wontfix'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Resolve issue
+        id: issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
+        run: |
+          set -euo pipefail
+          gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --json number,body,labels,state,author > issue.json
+          jq -r '.body // ""' issue.json > body.md
+          exempt=false
+          held=false
+          if jq -e '[.labels[].name] | any(. == "tracker:durable" or . == "wontfix")' issue.json >/dev/null; then exempt=true; fi
+          if jq -e '[.labels[].name] | any(. == "agents:auto-pilot-pause" or . == "needs-human")' issue.json >/dev/null; then held=true; fi
+          if jq -er '.author.login // ""' issue.json | grep -qiE '(\[bot\]|^renovate$|^dependabot$)'; then exempt=true; fi
+          if grep -qiE 'do not dispatch|not a (repo|cloud) coding task' body.md; then exempt=true; fi
+          {
+            echo "number=$NUMBER"
+            echo "exempt=$exempt"
+            echo "held=$held"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Validate against AGENT_ISSUE_FORMAT
+        id: validate
+        if: steps.issue.outputs.exempt != 'true'
+        run: |
+          set +e
+          if [[ ! -f .github/scripts/issue_format.py ]]; then
+            echo "validator absent — skipping while this repo is mid-sync"
+            echo "rc=skip" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          python3 .github/scripts/issue_format.py body.md > report.md
+          rc=$?
+          set -e
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          cat report.md || true
+          if [[ "$rc" -ne 0 && "$rc" -ne 1 ]]; then
+            exit "$rc"
+          fi
+
+      - name: Invalidate stale format completion after an invalid issue change
+        if: >-
+          steps.issue.outputs.exempt != 'true' && steps.validate.outputs.rc == '1'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NUMBER: ${{ steps.issue.outputs.number }}
+        run: |
+          set -euo pipefail
+          if gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
+              --jq '.labels[].name' | grep -qx 'agents:formatted'; then
+            if gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "agents:formatted"; then
+              echo "Invalid issue body — cleared agents:formatted before rerouting."
+            else
+              echo "::warning::could not remove stale agents:formatted"
+            fi
+          fi
+
+      - name: Route non-conforming issue to the optimizer
+        if: steps.issue.outputs.exempt != 'true' && steps.issue.outputs.held != 'true' && steps.validate.outputs.rc == '1'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NUMBER: ${{ steps.issue.outputs.number }}
+        run: |
+          set -euo pipefail
+          if gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
+              --jq '[.labels[].name] | any(. == "agents:auto-pilot-pause" or . == "needs-human")' | grep -qx true; then
+            echo "Issue is now held — skipping optimizer dispatch."
+            exit 0
+          fi
+          fingerprint="$(sha256sum body.md | cut -c1-12)"
+          if ! gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json comments \
+              --jq '.comments[].body' | grep -qF "format-guard:$fingerprint"; then
+            {
+              cat report.md
+              echo
+              echo "Dispatching the Agents Issue Optimizer format phase."
+              echo
+              echo "<!-- format-guard:$fingerprint -->"
+            } | gh issue comment "$NUMBER" --repo "$GITHUB_REPOSITORY" --body-file -
+          fi
+          if gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
+              --jq '.labels[].name' | grep -qx 'agents:formatted'; then
+            gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "agents:formatted" \
+              || echo "::warning::could not remove agents:formatted"
+          fi
+          gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" --add-label "agents:format" \
+            || echo "::warning::could not apply agents:format (label missing in this repo?)"
+          # GITHUB_TOKEN label edits do not start issues:labeled workflows; dispatch is explicit.
+          gh workflow run agents-issue-optimizer.yml --repo "$GITHUB_REPOSITORY" \
+            -f issue_number="$NUMBER" -f phase=format
+
+      - name: Restore format completion after an unheld revalidation
+        if: >-
+          steps.issue.outputs.exempt != 'true' && steps.validate.outputs.rc == '0' &&
+          github.event.action == 'unlabeled' &&
+          (github.event.label.name == 'agents:auto-pilot-pause' || github.event.label.name == 'needs-human')
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NUMBER: ${{ steps.issue.outputs.number }}
+        run: |
+          set -euo pipefail
+          if gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
+              --jq '[.labels[].name] | any(. == "agents:auto-pilot-pause" or . == "needs-human")' | grep -qx true; then
+            echo "Issue remains held — leaving agents:formatted cleared."
+            exit 0
+          fi
+          gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" --add-label "agents:formatted" \
+            || echo "::warning::could not apply agents:formatted (label missing in this repo?)"
+          echo "Unheld issue revalidated — restored agents:formatted."
+
+      - name: Clear the stale format trigger
+        if: steps.issue.outputs.exempt != 'true' && steps.issue.outputs.held != 'true' && steps.validate.outputs.rc == '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NUMBER: ${{ steps.issue.outputs.number }}
+        run: |
+          set -euo pipefail
+          if gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
+              --jq '.labels[].name' | grep -qx 'agents:format'; then
+            gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "agents:format"
+            echo "Conforms now — cleared agents:format."
+          fi


### PR DESCRIPTION
## Sync Summary

### Files Updated
- agents-issue-format-guard.yml: Issue format guard - validates issues on open/edit/reopen, hold/exemption-label changes, and manual dispatch against AGENT_ISSUE_FORMAT, while durable/wontfix and bot issues remain exempt. Pause and needs-human labels hold dispatch. Any invalid non-exempt issue change on those triggers clears stale agents:formatted state, and hold removal revalidates on resume. Non-conforming unheld work gets agents:format so the optimizer repairs it. Requires .github/scripts/issue_format.py.
- agents-auto-label.yml: Auto-label - suggests/applies labels based on semantic matching (Phase 5A)
- issue_format.py: Pure-stdlib validator for AGENT_ISSUE_FORMAT compliance. Single fleet definition of agent-processable; used by agents-issue-format-guard.yml and callable directly by local filers to pre-flight before gh issue create (non-zero exit = unfit). Do not fork per repo.

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `1e9ad1e59df0e939966de0b97a0769d62899587c`
**Template hash:** `d8ad9cb0a4e8`
**Consumer-sync plan ID:** `sha256:d8ad9cb0a4e803f6de8830403aad87be700b94eae98c54bbf3a2b91f6de84a57`
**Sync phase:** `canary`
**Sync branch:** `sync/workflows-d8ad9cb0a4e8`
**Consumer repo:** `stranske/Travel-Plan-Permission`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Travel-Plan-Permission","source_repository":"stranske/Workflows","source_sha":"1e9ad1e59df0e939966de0b97a0769d62899587c","template_hash":"d8ad9cb0a4e8","plan_id":"sha256:d8ad9cb0a4e803f6de8830403aad87be700b94eae98c54bbf3a2b91f6de84a57","sync_phase":"canary","sync_branch":"sync/workflows-d8ad9cb0a4e8","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"31175127441","run_attempt":"1","changes_count":3} -->
<!-- sync-pr-delivery-record:v1 {"schema":"sync-pr-delivery-record/v1","durable_issue_url":"https://github.com/stranske/Workflows/issues/1836","plan_id":"sha256:d8ad9cb0a4e803f6de8830403aad87be700b94eae98c54bbf3a2b91f6de84a57","generation":"d8ad9cb0a4e8","repository":"stranske/Travel-Plan-Permission","desired_tree_hash":"c45ead65c7047df66caface95cee7725c9f0c75d","source_commit":"1e9ad1e59df0e939966de0b97a0769d62899587c","lease_expires_at":"2026-08-10T11:43:01Z","predecessor_prs":[],"successor_prs":[]} -->