### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/workflows/agents-issue-format-guard.yml
+++ b/.github/workflows/agents-issue-format-guard.yml
@@ -87,7 +87,7 @@ jobs:
           if gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
               --jq '.labels[].name' | grep -qx 'agents:formatted'; then
             if gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "agents:formatted"; then
-              echo "Invalid issue body — cleared agents:formatted before rerouting."
+              echo "Invalid issue body — cleared stale agents:formatted."
             else
               echo "::warning::could not remove stale agents:formatted"
             fi


### PR DESCRIPTION
## Sync Summary

### Files Updated
- agents-issue-format-guard.yml: Issue format guard - validates issues on open/edit/reopen, hold/exemption-label changes, and manual dispatch against AGENT_ISSUE_FORMAT, while durable/wontfix and bot issues remain exempt. Pause and needs-human labels hold dispatch. Any invalid non-exempt issue change on those triggers clears stale agents:formatted state, and hold removal revalidates on resume. Non-conforming unheld work gets agents:format so the optimizer repairs it. Requires .github/scripts/issue_format.py.

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `45784e9ab8c0f9363cf6266479ea6b3f1d015a94`
**Template hash:** `0305e620721d`
**Consumer-sync plan ID:** `sha256:0305e620721d9d8b04b441de71898c1360042d1438eea81d9b5e5e64660843dc`
**Sync phase:** `canary`
**Sync branch:** `sync/workflows-0305e620721d`
**Consumer repo:** `stranske/Travel-Plan-Permission`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Travel-Plan-Permission","source_repository":"stranske/Workflows","source_sha":"45784e9ab8c0f9363cf6266479ea6b3f1d015a94","template_hash":"0305e620721d","plan_id":"sha256:0305e620721d9d8b04b441de71898c1360042d1438eea81d9b5e5e64660843dc","sync_phase":"canary","sync_branch":"sync/workflows-0305e620721d","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"31189107268","run_attempt":"1","changes_count":1} -->
<!-- sync-pr-delivery-record:v1 {"schema":"sync-pr-delivery-record/v1","durable_issue_url":"https://github.com/stranske/Workflows/issues/1836","plan_id":"sha256:0305e620721d9d8b04b441de71898c1360042d1438eea81d9b5e5e64660843dc","generation":"0305e620721d","repository":"stranske/Travel-Plan-Permission","desired_tree_hash":"5253556258dfb2653f702c214e502b741dceab80","source_commit":"45784e9ab8c0f9363cf6266479ea6b3f1d015a94","lease_expires_at":"2026-08-10T14:45:26Z","predecessor_prs":[],"successor_prs":[]} -->