### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/scripts/issue_format.py
+++ b/.github/scripts/issue_format.py
@@ -103,7 +103,10 @@ def _headings(body: str) -> list[tuple[str, int, int]]:
 
 def _find(body: str, aliases: tuple[str, ...]) -> int | None:
     for text, idx, _ in _headings(body):
-        if any(text == alias or text.startswith(f"{alias} (") for alias in aliases):
+        if any(
+            text == alias or text.startswith((f"{alias} (", f"{alias} -", f"{alias} /"))
+            for alias in aliases
+        ):
             return idx
     return None
 

--- a/.github/workflows/agents-issue-format-guard.yml
+++ b/.github/workflows/agents-issue-format-guard.yml
@@ -61,20 +61,31 @@ jobs:
         id: validate
         if: steps.issue.outputs.exempt != 'true'
         run: |
-          set +e
+          set -euo pipefail
+          report_file="$(mktemp)"
+          error_file="$(mktemp)"
+          trap 'rm -f "$report_file" "$error_file"' EXIT
           if [[ ! -f .github/scripts/issue_format.py ]]; then
             echo "validator absent — skipping while this repo is mid-sync"
             echo "rc=skip" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          python3 .github/scripts/issue_format.py body.md > report.md
+          set +e
+          python3 .github/scripts/issue_format.py body.md > "$report_file" 2> "$error_file"
           rc=$?
           set -e
           echo "rc=$rc" >> "$GITHUB_OUTPUT"
-          cat report.md || true
+          cat "$report_file" || true
+          if [[ "$rc" -eq 1 && -s "$error_file" ]]; then
+            echo "::error::issue-format validator failed unexpectedly"
+            cat "$error_file" >&2
+            exit 1
+          fi
           if [[ "$rc" -ne 0 && "$rc" -ne 1 ]]; then
+            cat "$error_file" >&2
             exit "$rc"
           fi
+          cp "$report_file" report.md
 
       - name: Invalidate stale format completion after an invalid issue change
         if: >-


### PR DESCRIPTION
## Sync Summary

### Files Updated
- agents-issue-format-guard.yml: Issue format guard - validates issues on open/edit/reopen, hold/exemption-label changes, and manual dispatch against AGENT_ISSUE_FORMAT, while durable/wontfix and bot issues remain exempt. Pause and needs-human labels hold dispatch. Any invalid non-exempt issue change on those triggers clears stale agents:formatted state, and hold removal revalidates on resume. Non-conforming unheld work gets agents:format so the optimizer repairs it. Requires .github/scripts/issue_format.py.
- issue_format.py: Pure-stdlib validator for AGENT_ISSUE_FORMAT compliance. Single fleet definition of agent-processable; used by agents-issue-format-guard.yml and callable directly by local filers to pre-flight before gh issue create (non-zero exit = unfit). Do not fork per repo.

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `fce14d49cbd3dd6e68598edda4eacc01fbfa95c4`
**Template hash:** `64c3d2444537`
**Consumer-sync plan ID:** `sha256:64c3d2444537a7a41a91ff17f67c7456c608467a9ed0ebab3355215c4423c5a5`
**Sync phase:** `canary`
**Sync branch:** `sync/workflows-64c3d2444537`
**Consumer repo:** `stranske/Travel-Plan-Permission`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Travel-Plan-Permission","source_repository":"stranske/Workflows","source_sha":"fce14d49cbd3dd6e68598edda4eacc01fbfa95c4","template_hash":"64c3d2444537","plan_id":"sha256:64c3d2444537a7a41a91ff17f67c7456c608467a9ed0ebab3355215c4423c5a5","sync_phase":"canary","sync_branch":"sync/workflows-64c3d2444537","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"31231943379","run_attempt":"1","changes_count":2} -->
<!-- sync-pr-delivery-record:v1 {"schema":"sync-pr-delivery-record/v1","durable_issue_url":"https://github.com/stranske/Workflows/issues/1836","plan_id":"sha256:64c3d2444537a7a41a91ff17f67c7456c608467a9ed0ebab3355215c4423c5a5","generation":"64c3d2444537","repository":"stranske/Travel-Plan-Permission","desired_tree_hash":"61556386443623caf93f3a44efb8a03c9516c028","source_commit":"fce14d49cbd3dd6e68598edda4eacc01fbfa95c4","lease_expires_at":"2026-08-11T01:09:28Z","predecessor_prs":[],"successor_prs":[]} -->